### PR TITLE
Hacks to solve #41

### DIFF
--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -10,7 +10,8 @@
 		properties: {
 
 			title: {
-				type: String
+				type: String,
+				reflectToAttribute: true
 			},
 
 			valuePath: {
@@ -32,7 +33,7 @@
 			editable: {
 				type: Boolean
 			},
-	
+
 			/**
 			 * Values to filter this column will be managed outside of omnitable
 			 */
@@ -40,7 +41,7 @@
 				type: Boolean,
 				value: false
 			},
-	
+
 			filter: {
 				type: Object,
 				notify: true

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -11,7 +11,7 @@
 
 			title: {
 				type: String,
-				reflectToAttribute: true
+				notify: true
 			},
 
 			valuePath: {

--- a/cosmoz-omnitable-item.html
+++ b/cosmoz-omnitable-item.html
@@ -1,0 +1,43 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../paper-item/paper-item-shared-styles.html"/>
+
+<dom-module id="cosmoz-omnitable-item">
+	<template>
+		<style include="paper-item-shared-styles"></style>
+		<style>
+		:host {
+			@apply --layout-horizontal;
+			@apply --layout-center;
+			@apply --paper-font-subhead;
+
+			@apply --paper-item;
+			white-space: nowrap;
+		}
+		</style>
+		<span>[[ label ]]</span>
+	</template>
+	<script>
+		Polymer({
+
+			is: 'cosmoz-omnitable-item',
+
+			properties: {
+				label: {
+					type: String,
+					observer: '_labelChanged'
+				}
+			},
+
+			// HACK: ensure paper-dropdown-menu updates current selected item label after translation change
+			// See https://github.com/PolymerElements/paper-dropdown-menu/issues/197
+			_labelChanged: function (newValue) {
+				if (this.classList.contains('iron-selected')) {
+					this.fire('iron-deselect', { item: this});
+					this.fire('iron-select', { item: this});
+				}
+			}
+		});
+
+	</script>
+</dom-module>

--- a/cosmoz-omnitable.html
+++ b/cosmoz-omnitable.html
@@ -228,7 +228,7 @@
 				<div class="footer-controls">
 					<div class="footer-control">
 						<paper-dropdown-menu vertical-align="bottom" horizontal-align="left" id="groupOnSelector" label="[[ _('Group on', t) ]]">
-							<paper-listbox class="dropdown-content menu" slot="dropdown-content" selected="{{ groupOn }}" attr-for-selected="data-group-on">
+							<paper-listbox id="groupOnListbox" class="dropdown-content menu" slot="dropdown-content" selected="{{ groupOn }}" attr-for-selected="data-group-on">
 								<paper-item data-group-on=""><i style="white-space: nowrap">[[ _('No grouping', t) ]]</i></paper-item>
 								<template is="dom-repeat" items="[[ columns ]]" as="column">
 									<paper-item data-group-on$="[[ column.groupOn ]]" hidden$="[[ !column.groupOn ]]">[[ column.title ]]</paper-item>

--- a/cosmoz-omnitable.html
+++ b/cosmoz-omnitable.html
@@ -29,6 +29,7 @@
 <link rel="import" href="cosmoz-omnitable-styles.html">
 
 <link rel="import" href="cosmoz-omnitable-columns.html">
+<link rel="import" href="cosmoz-omnitable-item.html">
 
 
 <!--
@@ -229,9 +230,9 @@
 					<div class="footer-control">
 						<paper-dropdown-menu vertical-align="bottom" horizontal-align="left" id="groupOnSelector" label="[[ _('Group on', t) ]]">
 							<paper-listbox id="groupOnListbox" class="dropdown-content menu" slot="dropdown-content" selected="{{ groupOn }}" attr-for-selected="data-group-on">
-								<paper-item data-group-on=""><i style="white-space: nowrap">[[ _('No grouping', t) ]]</i></paper-item>
+								<cosmoz-omnitable-item id="groupOnItem" data-group-on="" label="[[ _('No grouping', t) ]]" style="font-style: italic"></cosmoz-omnitable-item>
 								<template is="dom-repeat" items="[[ columns ]]" as="column">
-									<paper-item data-group-on$="[[ column.groupOn ]]" hidden$="[[ !column.groupOn ]]">[[ column.title ]]</paper-item>
+									<cosmoz-omnitable-item data-group-on$="[[ column.groupOn ]]" label="[[column.title]]" hidden$="[[ !column.groupOn ]]"></cosmoz-omnitable-item>
 								</template>
 							</paper-listbox>
 						</paper-dropdown-menu>
@@ -239,11 +240,11 @@
 					<div class="footer-control">
 						<paper-dropdown-menu vertical-align="bottom" horizontal-align="right" id="sortOnSelectorMenu" label="[[_('Sort on', t)]]">
 							<paper-listbox class="dropdown-content menu" slot="dropdown-content" id="sortOnSelector" on-iron-items-changed="_updateSelectedSortIndex" selected="{{ _sortOnSelectorSelected }}">
-								<paper-item on-tap="_onSortColumnActivate"><i style="white-space: nowrap;">[[ _('No sorting', t) ]]</i></paper-item>
+								<cosmoz-omnitable-item label="[[ _('No sorting', t) ]]" style="font-style: italic"></cosmoz-omnitable-item>
 								<template is="dom-repeat" id="sortColumns" items="[[ columns ]]" as="column">
-									<paper-item on-tap="_onSortColumnActivate" hidden$="[[ !column.sortOn ]]">
-										<span>[[ column.title ]]</span>&nbsp;<span>[[ _getSortDirection(column, sortOn.*) ]]</span>
-									</paper-item>
+									<cosmoz-omnitable-item on-tap="_onSortColumnActivate" hidden$="[[ !column.sortOn ]]"
+										label="[[ _computeSortOnLabel(column, column.title, sortOn.*) ]]">
+									</cosmoz-omnitable-item>
 								</template>
 							</paper-listbox>
 						</paper-dropdown-menu>


### PR DESCRIPTION
* Use a mutation observer to notify changes of columns properties to dom-repeat elements.
* Added a hack to workaround a paper-dropdown-menu issue when items labels are changing.