### PR TITLE
Alternate fix to #42 for issue #41

### DIFF
--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -10,7 +10,8 @@
 		properties: {
 
 			title: {
-				type: String
+				type: String,
+				notify: true
 			},
 
 			valuePath: {

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -211,11 +211,12 @@
 
 			// TODO: Un-listen from old columns ?
 
-			this.columns = columns;
-
-			this.columns.forEach(function (column) {
+			columns.forEach(function (column) {
 				this.listen(column, 'filter-changed', '_onColumnFilterChanged');
+				this.listen(column, 'title-changed', '_onColumnTitleChanged');
 			}, this);
+
+			this.set('columns', columns);
 
 			this._updateVisibleColumns();
 
@@ -297,6 +298,22 @@
 
 		_onColumnFilterChanged: function (event) {
 			this._debounceFilterItems();
+		},
+
+		_onColumnTitleChanged: function (event, detail) {
+			var column = event.target,
+				columnIndex = this.columns.indexOf(column);
+
+			// re-notify column change to make dom-repeat re-render menu item title
+			this.notifyPath(['columns', columnIndex, 'title']);
+
+			// HACK: ensure paper-dropdown-menu updates current selected item label after translation change
+			// See https://github.com/PolymerElements/paper-dropdown-menu/issues/197
+			if (column === this.groupOnColumn) {
+				this.$.groupOnSelector._selectedItemChanged(this.$.groupOnSelector.selectedItem);
+			} else if (column === this.sortOnColumn) {
+				this.$.sortOnSelectorMenu._selectedItemChanged(this.$.sortOnSelectorMenu.selectedItem);
+			}
 		},
 
 		/**


### PR DESCRIPTION
There doesn't seem to be a clean way to handle this and I'm a bit puzzled how we can't get the subproperty changes to notify dom-repeat through the built-in binding/notification system, so I guess we have to live with a "renotify" solution for now.

But I do think using attributes and a MutationObserver is a bit overkill and not precise enough, although we would get a more generalized re-notify solution (which I'm not sure we need at this point).

Also I think having generic `translationsChanged` observers in combination with regular translation observers will at best cause overhead and in worst case generate race conditions or other weird behavior.

Finally I try to avoid async/debounce/timeout as workarounds - it kind of begs for async issues down the line.

I think I found a more general issue with the translations in neovici/cosmoz-i18next@c0c7681

Let me know what you think but I really think we should focus on merging #38 first.
(This PR is intended to showcase another path and actually has pseudo code for the sort on selectedItem label. :exclamation: )