### PR TITLE
Allow a default column width value which is dependent on the editable property

### DIFF
--- a/cosmoz-omnitable-column-amount.html
+++ b/cosmoz-omnitable-column-amount.html
@@ -111,19 +111,15 @@
 				cellWidth: {
 					type: String,
 					value: '70px'
+				},
+				cellClass: {
+					type: String,
+					value: 'amount-cell align-right'
+				},
+				headerCellClass: {
+					type: String,
+					value: 'amount-header-cell'
 				}
-			},
-
-			_getDefaultFlex: function () {
-				return '1';
-			},
-
-			_getDefaultCellClass: function () {
-				return 'amount-cell align-right';
-			},
-
-			_getDefaultHeaderCellClass: function () {
-				return 'amount-header-cell';
 			},
 
 			_computeFilterText: function (filterNotify) {

--- a/cosmoz-omnitable-column-amount.html
+++ b/cosmoz-omnitable-column-amount.html
@@ -112,6 +112,10 @@
 					type: String,
 					value: '70px'
 				},
+				editCellWidth: {
+					type: String,
+					value: '70px'
+				},
 				cellClass: {
 					type: String,
 					value: 'amount-cell align-right'

--- a/cosmoz-omnitable-column-amount.html
+++ b/cosmoz-omnitable-column-amount.html
@@ -86,11 +86,11 @@
 					value: function () {
 						return [];
 					}
+				},
+				width: {
+					type: String,
+					value: '70px'
 				}
-			},
-
-			_getDefaultWidth: function () {
-				return '70px';
 			},
 
 			_getDefaultFlex: function () {

--- a/cosmoz-omnitable-column-amount.html
+++ b/cosmoz-omnitable-column-amount.html
@@ -108,7 +108,7 @@
 						return [];
 					}
 				},
-				width: {
+				cellWidth: {
 					type: String,
 					value: '70px'
 				}

--- a/cosmoz-omnitable-column-autocomplete.html
+++ b/cosmoz-omnitable-column-autocomplete.html
@@ -58,11 +58,12 @@
 				valueProperty: {
 					type: String,
 					value: ''
-				}
-			},
+				},
 
-			_getDefaultHeaderCellClass: function () {
-				return 'autocomplete-header-cell';
+				headerCellClass: {
+					type: String,
+					value: 'autocomplete-header-cell'
+				}
 			},
 
 			_applySingleFilter: function (filterString, item) {

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -95,13 +95,28 @@
 				value: true,
 				readOnly: true
 			},
-
-			width: {
-				type: String
+			/**
+			 * The with of the cell template.
+			 */
+			cellWidth: {
+				type: String,
+				value: '75px'
 			},
 
-			editableWidth: {
-				type: String
+			/**
+			 * The with of the edit-cell template.
+			 */
+			editCellWidth: {
+				type: String,
+				value: ''
+			},
+
+			/**
+			 * The computed with of the active template.
+			 */
+			width: {
+				type: String,
+				computed: '_computeTemplateWidth(editable, editCellWidth, cellWidth)'
 			},
 
 			flex: {
@@ -167,6 +182,13 @@
 		ready: function () {
 			this._headerTemplatizer = this._createTemplatizer('template.header');
 			this._itemCells = [];
+		},
+
+		_computeTemplateWidth(editable, editCellWidth, cellWidth) {
+			if (editable) {
+				return editCellWidth ? editCellWidth : cellWidth;
+			}
+			return cellWidth;
 		},
 
 		_createTemplatizer: function (templateElementOrSelector) {

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -107,14 +107,7 @@
 			 */
 			editCellWidth: {
 				type: String,
-				value: ''
-			},
-			/**
-			 * The computed width of the active template.
-			 */
-			width: {
-				type: String,
-				computed: '_computeTemplateWidth(editable, editCellWidth, cellWidth)'
+				value: '75px'
 			},
 
 			flex: {
@@ -171,13 +164,6 @@
 		ready: function () {
 			this._headerTemplatizer = this._createTemplatizer('template.header');
 			this._itemCells = [];
-		},
-
-		_computeTemplateWidth(editable, editCellWidth, cellWidth) {
-			if (editable) {
-				return editCellWidth ? editCellWidth : cellWidth;
-			}
-			return cellWidth;
 		},
 
 		_createTemplatizer: function (templateElementOrSelector) {

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -96,23 +96,21 @@
 				readOnly: true
 			},
 			/**
-			 * The with of the cell template.
+			 * The width of the cell template.
 			 */
 			cellWidth: {
 				type: String,
 				value: '75px'
 			},
-
 			/**
-			 * The with of the edit-cell template.
+			 * The width of the edit-cell template.
 			 */
 			editCellWidth: {
 				type: String,
 				value: ''
 			},
-
 			/**
-			 * The computed with of the active template.
+			 * The computed width of the active template.
 			 */
 			width: {
 				type: String,

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -31,7 +31,8 @@
 			 * If true, the column will be editable by using an input element for rendering.
 			 */
 			editable: {
-				type: Boolean
+				type: Boolean,
+				observer: '_editableChanged'
 			},
 
 			/**
@@ -99,7 +100,7 @@
 			width: {
 				type: String,
 				value: function () {
-					return this._getDefaultWidth();
+					return this._getDefaultWidth(this.editable);
 				}
 			},
 
@@ -231,8 +232,17 @@
 			}
 		},
 
+		_editableChanged(editable, oldEditable) {
+			if (this.width !== this._getDefaultWidth(oldEditable)) {
+				// width property has been changed from outside
+				return;
+			}
+			this.width = this._getDefaultWidth(editable);
+		},
+
 		/**
 		 * Override this in column elements if you need a different default width
+		 * @param {Boolean} editable - If column is editable.
 		 * @returns {String} Default width
 		 */
 		_getDefaultWidth: function () {

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -119,23 +119,17 @@
 
 			flex: {
 				type: String,
-				value: function () {
-					return this._getDefaultFlex();
-				}
+				value: '1'
 			},
 
 			cellClass: {
 				type: String,
-				value: function () {
-					return this._getDefaultCellClass();
-				}
+				value: 'default-cell'
 			},
 
 			headerCellClass: {
 				type: String,
-				value: function () {
-					return this._getDefaultHeaderCellClass();
-				}
+				value: 'default-header-cell'
 			},
 
 			styleModule: {
@@ -255,18 +249,6 @@
 		/**
 		 * Override this in column elements if you need a different default width
 		 */
-
-		_getDefaultFlex: function () {
-			return '1';
-		},
-
-		_getDefaultCellClass: function () {
-			return 'default-cell';
-		},
-
-		_getDefaultHeaderCellClass: function () {
-			return 'default-header-cell';
-		},
 
 		_getDefaultStyleModule: function () {
 			return;

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -133,10 +133,7 @@
 			},
 
 			styleModule: {
-				type: String,
-				value: function () {
-					return this._getDefaultStyleModule();
-				}
+				type: String
 			},
 
 			/**
@@ -249,10 +246,6 @@
 		/**
 		 * Override this in column elements if you need a different default width
 		 */
-
-		_getDefaultStyleModule: function () {
-			return;
-		},
 
 		getString: function (item, valuePathArg) {
 			var valuePath = valuePathArg || this.valuePath;

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -31,8 +31,7 @@
 			 * If true, the column will be editable by using an input element for rendering.
 			 */
 			editable: {
-				type: Boolean,
-				observer: '_editableChanged'
+				type: Boolean
 			},
 
 			/**
@@ -98,10 +97,11 @@
 			},
 
 			width: {
-				type: String,
-				value: function () {
-					return this._getDefaultWidth(this.editable);
-				}
+				type: String
+			},
+
+			editableWidth: {
+				type: String
 			},
 
 			flex: {
@@ -232,22 +232,9 @@
 			}
 		},
 
-		_editableChanged(editable, oldEditable) {
-			if (this.width !== this._getDefaultWidth(oldEditable)) {
-				// width property has been changed from outside
-				return;
-			}
-			this.width = this._getDefaultWidth(editable);
-		},
-
 		/**
 		 * Override this in column elements if you need a different default width
-		 * @param {Boolean} editable - If column is editable.
-		 * @returns {String} Default width
 		 */
-		_getDefaultWidth: function () {
-			return '75px';
-		},
 
 		_getDefaultFlex: function () {
 			return '1';

--- a/cosmoz-omnitable-column-boolean.html
+++ b/cosmoz-omnitable-column-boolean.html
@@ -61,7 +61,7 @@
 
 				},
 
-				width: {
+				templatetemplateWidth: {
 					type: String,
 					value: '60px'
 				}

--- a/cosmoz-omnitable-column-boolean.html
+++ b/cosmoz-omnitable-column-boolean.html
@@ -59,6 +59,11 @@
 
 				_textValue: {
 
+				},
+
+				width: {
+					type: String,
+					value: '60px'
 				}
 			},
 
@@ -75,11 +80,6 @@
 			_filterChangedFromInput: false,
 
 			_filterChangedFromAbove: false,
-
-			_getDefaultWidth: function () {
-				return '60px';
-			},
-
 			/**
 			 * No need to grow, as the values in a boolean column should have known fixed width
 			 * @returns {String} Default flex

--- a/cosmoz-omnitable-column-boolean.html
+++ b/cosmoz-omnitable-column-boolean.html
@@ -64,6 +64,15 @@
 				templatetemplateWidth: {
 					type: String,
 					value: '60px'
+				},
+
+				/**
+				 * No need to grow, as the values in a boolean column should have known fixed width
+				 * @returns {String} Default flex
+				 */
+				flex: {
+					type: String,
+					value: '0'
 				}
 			},
 
@@ -80,13 +89,6 @@
 			_filterChangedFromInput: false,
 
 			_filterChangedFromAbove: false,
-			/**
-			 * No need to grow, as the values in a boolean column should have known fixed width
-			 * @returns {String} Default flex
-			 */
-			_getDefaultFlex: function () {
-				return '0';
-			},
 
 			_textFilterChanged: function (textFilter) {
 				if (this._filterChangedFromAbove) {

--- a/cosmoz-omnitable-column-date-behavior.html
+++ b/cosmoz-omnitable-column-date-behavior.html
@@ -96,7 +96,7 @@
 				type: String,
 				computed: '_computeTooltip(title, _filterText)'
 			},
-			width: {
+			cellWidth: {
 				type: String,
 				value: '180px'
 			}

--- a/cosmoz-omnitable-column-date-behavior.html
+++ b/cosmoz-omnitable-column-date-behavior.html
@@ -95,8 +95,11 @@
 			_tooltip: {
 				type: String,
 				computed: '_computeTooltip(title, _filterText)'
+			},
+			width: {
+				type: String,
+				value: '180px'
 			}
-	
 		},
 
 		_getMinMax(firstRaw, secondRaw, max) {
@@ -153,11 +156,6 @@
 			}
 			return mom.format('YYYY-MM-DD');
 		},
-
-		_getDefaultWidth() {
-			return '180px';
-		},
-
 		/**
 		 * No need to grow, as the values in a date column should have known fixed width
 		 * @returns {String} Default flex

--- a/cosmoz-omnitable-column-date-behavior.html
+++ b/cosmoz-omnitable-column-date-behavior.html
@@ -100,7 +100,12 @@
 
 			cellWidth: {
 				type: String,
-				value: '180px'
+				value: '100px'
+			},
+
+			editCellWidth: {
+				type: String,
+				value: '150px'
 			},
 			/**
 			 * No need to grow, as the values in a date column should have known fixed width

--- a/cosmoz-omnitable-column-date-behavior.html
+++ b/cosmoz-omnitable-column-date-behavior.html
@@ -99,6 +99,14 @@
 			cellWidth: {
 				type: String,
 				value: '180px'
+			},
+			/**
+			 * No need to grow, as the values in a date column should have known fixed width
+			 * @returns {String} Default flex
+			 */
+			flex: {
+				type: String,
+				value: '0'
 			}
 		},
 
@@ -155,13 +163,6 @@
 				return;
 			}
 			return mom.format('YYYY-MM-DD');
-		},
-		/**
-		 * No need to grow, as the values in a date column should have known fixed width
-		 * @returns {String} Default flex
-		 */
-		_getDefaultFlex() {
-			return '0';
 		},
 
 		_expandUserFormat(userFormat) {

--- a/cosmoz-omnitable-column-datetime.html
+++ b/cosmoz-omnitable-column-datetime.html
@@ -56,14 +56,14 @@
 					value: 'YYYY-MM-DD HH:mm:ss.SSS'
 				},
 
-				editableWidth: {
+				editCellWidth: {
 					type: String,
-					value: '300px'
+					value: '320px'
 				},
 
 				cellWidth: {
 					type: String,
-					value: '180px'
+					value: '210px'
 				},
 
 				_inputFormat: {

--- a/cosmoz-omnitable-column-datetime.html
+++ b/cosmoz-omnitable-column-datetime.html
@@ -84,6 +84,11 @@
 				}
 				return mom.format('YYYY-MM-DDTHH:mm:ss');
 			},
+
+			_getDefaultWidth(editable) {
+				return editable ? '300px' : '180px';
+			},
+
 		});
 
 	</script>

--- a/cosmoz-omnitable-column-datetime.html
+++ b/cosmoz-omnitable-column-datetime.html
@@ -53,6 +53,16 @@
 				userFormat: {
 					type: String,
 					value: 'YYYY-MM-DD HH:mm:ss.SSS'
+				},
+
+				editableWidth: {
+					type: String,
+					value: '300px'
+				},
+
+				width: {
+					type: String,
+					value: '180px'
 				}
 			},
 
@@ -84,11 +94,6 @@
 				}
 				return mom.format('YYYY-MM-DDTHH:mm:ss');
 			},
-
-			_getDefaultWidth(editable) {
-				return editable ? '300px' : '180px';
-			},
-
 		});
 
 	</script>

--- a/cosmoz-omnitable-column-datetime.html
+++ b/cosmoz-omnitable-column-datetime.html
@@ -60,7 +60,7 @@
 					value: '300px'
 				},
 
-				width: {
+				cellWidth: {
 					type: String,
 					value: '180px'
 				}

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -114,7 +114,7 @@
 					type: String,
 					computed: '_computeTooltip(title, _filterText)'
 				},
-				width: {
+				cellWidth: {
 					type: String,
 					value: '30px'
 				},

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -118,6 +118,10 @@
 					type: String,
 					value: '30px'
 				},
+				editCellWidth: {
+					type: String,
+					value: '30px'
+				},
 				_toLocaleStringOptions: {
 					type: Object,
 					computed: '_computeToLocaleStringOptions(minimumFractionDigits, maximumFractionDigits)'

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -91,6 +91,10 @@
 				_tooltip: {
 					type: String,
 					computed: '_computeTooltip(title, _filterText)'
+				},
+				width: {
+					type: String,
+					value: '30px'
 				}
 			},
 
@@ -170,10 +174,6 @@
 					min: newFilter.min !== null && newFilter.min !== '' ? Number(newFilter.min) : null,
 					max: newFilter.max !== null && newFilter.max !== '' ? Number(newFilter.max) : null
 				});
-			},
-
-			_getDefaultWidth: function () {
-				return '30px';
 			},
 
 			_getDefaultFlex: function () {

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -121,6 +121,14 @@
 				_toLocaleStringOptions: {
 					type: Object,
 					computed: '_computeToLocaleStringOptions(minimumFractionDigits, maximumFractionDigits)'
+				},
+				cellClass: {
+					type: String,
+					value: 'number-cell align-right'
+				},
+				headerCellClass: {
+					type: String,
+					value: 'number-header-cell'
 				}
 			},
 
@@ -200,18 +208,6 @@
 					min: newFilter.min !== null && newFilter.min !== '' ? Number(newFilter.min) : null,
 					max: newFilter.max !== null && newFilter.max !== '' ? Number(newFilter.max) : null
 				});
-			},
-
-			_getDefaultFlex: function () {
-				return '1';
-			},
-
-			_getDefaultCellClass: function () {
-				return 'number-cell align-right';
-			},
-
-			_getDefaultHeaderCellClass: function () {
-				return 'number-header-cell';
 			},
 
 			_getMinMax: function (first, second, max) {

--- a/cosmoz-omnitable-item-row.html
+++ b/cosmoz-omnitable-item-row.html
@@ -70,7 +70,7 @@
 		},
 
 		_configureElement: function (element, column) {
-			element.style.flexBasis = column.width;
+			element.style.flexBasis = column.editable ? column.editCellWidth : column.cellWidth;
 			element.style.flexGrow = column.flex;
 			element.setAttribute('title', this._getCellTitle(column, this.item));
 			element.setAttribute('class', this._computeItemRowCellClasses(column));

--- a/demo/full-demo.html
+++ b/demo/full-demo.html
@@ -75,7 +75,7 @@
 				</div>
 
 				<cosmoz-omnitable loading="[[ loading ]]" id="omnitable" class="flex" data="[[ data ]]" selection-enabled selected-items="{{ selectedItems }}">
-					<cosmoz-omnitable-column-autocomplete title="Id" name="id" value-path="id" sort-on="id" group-on="id">
+					<cosmoz-omnitable-column-autocomplete cell-width="40px" flex="0" title="Id" name="id" value-path="id" sort-on="id" group-on="id">
 						<template class="cell">
 							<span on-tap="onTap">
 								<a href$="[[ _getItemLink(item) ]]">[[ item.id ]]</a>


### PR DESCRIPTION
The optimal default width does vary depending on the `editable` property.
Currently needed in column datetime.

Added properties
- cellWidth
- editCellWith

Removed property
- width