### PR TITLE
Fix filtering when data is empty

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -1165,6 +1165,7 @@
 				deserialized = this._deserializeFilter(hashValue, filter && filter.constructor || undefined);
 
 				if (deserialized === null) {
+					column.resetFilter();
 					return;
 				}
 
@@ -1191,7 +1192,7 @@
 		},
 
 		_filterForRouteChanged: function (column) {
-			if (!this.hashParam || !this._routeHashParams || !this.data || !this.data.length)  {
+			if (!this.hashParam || !this._routeHashParams || !this.data)  {
 				return;
 			}
 


### PR DESCRIPTION
* Removed data.length condition
* Call `column.resetFilter` when a hash-param is `null`

fixes #83 