### PR TITLE
Don't handle hash param updates while updating route params fix #87

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -520,6 +520,7 @@
 		},
 
 		_groupOnColumnChanged: function (column) {
+			this._updateRouteParam('groupOn');
 			if (column && column.filter) {
 				column.resetFilter();
 			} else {
@@ -541,8 +542,6 @@
 				this._groupsCount = 0;
 				return;
 			}
-
-			this._updateRouteParam('groupOn');
 
 			var groupOnColumn = this.groupOnColumn,
 				groups;


### PR DESCRIPTION
related to #87 
When `groupOnColumn` changes in the same call stack `resetFilter` is called and hash params are updated. In the same stack than route hash params are checked and groupOn is different so it gets set to the value from hash-param.

fixes #87  
