### PR TITLE
omnitable render on visible

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -268,7 +268,7 @@
 
 				this._setColumnValues(addedColumns);
 
-				this._updateColumns();
+				this._debounceUpdateColumns();
 			});
 			this.$.groupedList.scrollTarget = this.$.scroller;
 			this.listen(this,  'cosmoz-column-hidden-changed', '_debounceUpdateColumns');
@@ -393,7 +393,7 @@
 		},
 
 		_debounceUpdateColumns() {
-			this.debounce('updateColumns', this._updateColumns);
+			this.debounce('updateColumns', this._updateColumns, 1);
 		},
 
 		_updateColumns() {

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -393,7 +393,7 @@
 		},
 
 		_debounceUpdateColumns() {
-			this.debounce('updateColumns', this._updateColumns, 1);
+			this.debounce('updateColumns', this._updateColumns, 10);
 		},
 
 		_updateColumns() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -62,7 +62,7 @@
 				Polymer.Base.async(function () {
 					assert.equal(date, omnitable._getColumn('date1'));
 					done();
-				}, 60);
+				}, 260);
 
 			});
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -62,7 +62,7 @@
 				Polymer.Base.async(function () {
 					assert.equal(date, omnitable._getColumn('date1'));
 					done();
-				}, 260);
+				}, 280);
 
 			});
 

--- a/test/hash-param.html
+++ b/test/hash-param.html
@@ -49,7 +49,7 @@
 				instantiate = function (done) {
 					omnitable = fixture('basic');
 					omnitable.data = data;
-					Polymer.Base.async(done, 130);
+					Polymer.Base.async(done, 230);
 				};
 
 			suite('basic-read', function () {

--- a/test/hash-param.html
+++ b/test/hash-param.html
@@ -49,7 +49,7 @@
 				instantiate = function (done) {
 					omnitable = fixture('basic');
 					omnitable.data = data;
-					Polymer.Base.async(done, 30);
+					Polymer.Base.async(done, 130);
 				};
 
 			suite('basic-read', function () {


### PR DESCRIPTION
The most expensive operation when rendering views right now is the
omnitable setup. When a data-nav renders a view with 2-3 omnitables
each, hidden away behind tabs, it doesn't make sense that one of the
biggest rendering chunks is _updateColumns.

This PR tries to reduce omnitable setup overhead.

The visibility control is done earlier, in _updateColumns rather than
_adjustColumns, and will prevent _updateColumns to run if not visible.

Also, resize will trigger visibility re-evaluation.

When omnitable turns visible, _updateColumns will not have run, so we
make sure to trigger it then.

Finally, an immediate _updateColumns in _columnObserver will prevent it
to run twice when loaded visibly.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>