### PR TITLE
Moved csv/xlsx buttons to extra menu

### DIFF
--- a/cosmoz-omnitable-styles.html
+++ b/cosmoz-omnitable-styles.html
@@ -295,6 +295,28 @@
 				border-color: #b7b6c8;
 				cursor: not-allowed;
 			}
+
+			#dropdownExtra paper-button {
+				display: flex;
+				@apply --layout-center;
+				@apply --layout-horizontal;
+				position: relative;
+				@apply --cosmoz-bottom-bar-menu-item;
+			}
+
+			#dropdownExtra {
+				padding: 0;
+			}
+
+			#listboxSizer {
+				max-height: 0;
+				padding: 0 !important;
+			}
+
+			#dropdownExtraButton {
+				color: var(--cosmoz-bottom-bar-menubutton-color, var(--light-primary-color));
+				background-color: var(--cosmoz-bottom-bar-menubutton-background-color, var(--dark-primary-color));
+			}
 		</style>
 	</template>
 </dom-module>

--- a/cosmoz-omnitable.html
+++ b/cosmoz-omnitable.html
@@ -179,15 +179,36 @@
 					<span>[[ ngettext('{0} group', '{0} groups', _groupsCount, t) ]]</span>
 					<span>[[ ngettext('{0} row', '{0} rows', filteredItems.length, t) ]]</span>
 				</div>
-				<cosmoz-bottom-bar id="bottomBar" class="footer-actionBar" match-parent has-actions="{{ hasActions }}" on-action="_onAction" active$="[[ !_isEmpty(selectedItems.length) ]]">
+				<cosmoz-bottom-bar id="bottomBar" class="footer-actionBar" match-parent has-actions="{{ hasActions }}" on-action="_onAction" active$="[[ !_isEmpty(selectedItems.length) ]]" computed-bar-height="{{ computedBarHeight }}">
 					<div slot="info">[[ ngettext('{0} selected item', '{0} selected items', selectedItems.length, t) ]]</div>
 					<slot name="actions" id="actions"></slot>
 					<!-- These slots are neened by cosmoz-bottom-bar
 						as it might change the slot of the actions to distribute them in the menu -->
 					<slot name="bottom-bar-toolbar"></slot>
 					<slot name="bottom-bar-menu"></slot>
-					<paper-button on-action="_saveAsCsvAction">[[ _('Save as CSV', t) ]]</paper-button>
-					<paper-button on-action="_saveAsXlsxAction">[[ _('Save as XLSX', t) ]]</paper-button>
+					<paper-menu-button
+						id="extraMenu"
+						slot="extra"
+						no-animations
+						vertical-offset="[[ computedBarHeight ]]"
+						vertical-align="bottom"
+						horizontal-align="right">
+						<paper-icon-button id="dropdownExtraButton"
+							class="dropdown-trigger"
+							slot="dropdown-trigger"
+							icon="file-download"
+							toggles
+							raised>
+						</paper-icon-button>
+						<paper-listbox id="dropdownExtra"
+							class="dropdown-content"
+							slot="dropdown-content">
+							<span id="listboxSizer"></span>
+							<paper-button on-action="_saveAsCsvAction">[[ _('Save as CSV', t) ]]</paper-button>
+							<paper-button on-action="_saveAsXlsxAction">[[ _('Save as XLSX', t) ]]</paper-button>
+						</paper-listbox>
+					</paper-menu-button>
+
 				</cosmoz-bottom-bar>
 			</div>
 		</div>

--- a/test/xlsx-export.html
+++ b/test/xlsx-export.html
@@ -88,7 +88,7 @@
 				omnitable.selectItem(data[1]);
 
 				// click on Export as XLSX paper-button
-				MockInteractions.tap(omnitable.$.bottomBar.$.toolbar.queryAllEffectiveChildren('paper-button')[1]);
+				MockInteractions.tap(omnitable.$.dropdownExtra.queryAllEffectiveChildren('paper-button')[1]);
 				assert.calledOnce(spyXlsx);
 				assert.calledOnce(stubSaveAs);
 


### PR DESCRIPTION
Moved csv/xlsx buttons to extra menu in cosmoz-bottom-bar.
To be merged after https://github.com/Neovici/cosmoz-bottom-bar/pull/21