### PR TITLE
Tests updated

### DIFF
--- a/test/range-date.html
+++ b/test/range-date.html
@@ -158,50 +158,51 @@
 			test('changing _filterInput updates filter', function (done) {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
-				column._filterInput = {
-					min: '2015-03-18',
-					max: '2023-03-21'
-				};
+
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.getTime(), new Date('2015-03-18T00:00:00').getTime());
 					assert.equal(column.filter.max.getTime(), new Date('2023-03-21T23:59:59').getTime(), 'Expecting max date included');
 					done();
 				});
+				column._filterInput = {
+					min: '2015-03-18',
+					max: '2023-03-21'
+				};
 			});
 
 			test('changing only _filterInput min updates filter min', function (done) {
-				column._filterInput.min = '2015-08-27';
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.getTime(), new Date('2015-08-27T00:00:00').getTime());
 					done();
 				});
+				column.set('_filterInput.min', '2015-08-27');
 			});
 
 			test('filtering on specific date with datetime source', function (done) {
 				// date: '2017-12-22T23:00:00Z'
 
 				assert.equal(column.getComparableValue(data[5], column.valuePath), new Date('2017-12-22T23:00:00Z').getTime());
-				column._filterInput.min = '2017-12-22';
-				column._filterInput.max = '2017-12-23';
 				column.addEventListener('filter-changed', function () {
-					let fn = column.getFilterFn();
-					assert.isTrue(fn(data[5]));
-
+					assert.isTrue(column.getFilterFn()(data[5]));
 					done();
 				});
+				column._filterInput = {
+					min: '2017-12-22',
+					max: '2017-12-23'
+				};
 			});
 
 			test('filtering on specific date with datetime source same day test', function (done) {
 				// date: '2017-12-22T23:00:00Z'
 
-				column._filterInput.min = '2017-12-23';
-				column._filterInput.max = '2017-12-23';
 				column.addEventListener('filter-changed', function () {
-					let fn = column.getFilterFn();
-					assert.isTrue(fn(data[5]));
-
+					assert.isTrue(column.getFilterFn()(data[5]));
 					done();
 				});
+				column._filterInput = {
+					min: '2017-12-23',
+					max: '2017-12-23'
+				};
 			});
 		});
 
@@ -251,23 +252,23 @@
 			});
 
 			test('changing _filterInput updates filter', function (done) {
-				column._filterInput = {
-					min: '1970-01-02T02:00:00',
-					max: '1999-06-24T11:33:30'
-				};
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.getTime(), 86400000);
 					assert.equal(column.filter.max.getTime(), new Date(99, 5, 24, 11, 33, 30, 0).getTime());
 					done();
 				});
+				column._filterInput = {
+					min: '1970-01-02T02:00:00',
+					max: '1999-06-24T11:33:30'
+				};
 			});
 
 			test('changing only _filterInput min updates filter min', function (done) {
-				column.set('_filterInput.min', '2014-06-24T11:33:30');
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.getTime(), new Date('2014-06-24T11:33:30').getTime());
 					done();
 				});
+				column.set('_filterInput.min', '2014-06-24T11:33:30');
 			});
 		});
 
@@ -357,29 +358,28 @@
 			test('changing _filterInput updates filter', function (done) {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
-				column._filterInput = {
-					min: '04:30:00',
-					max: '17:34:56'
-				};
+
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.getTime(), new Date(Date.UTC(1970, 0, 1, 2, 30)).getTime());
 					assert.equal(column.filter.max.getTime(), new Date(Date.UTC(1970, 0, 1, 15, 34, 56)).getTime());
 					done();
 				});
+				column._filterInput = {
+					min: '04:30:00',
+					max: '17:34:56'
+				};
 			});
 
 			test('changing only _filterInput min updates filter min', function (done) {
-				column._filterInput.min = '04:21:10';
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.getTime(), new Date(Date.UTC(1970, 0, 1, 2, 21, 10)).getTime());
 					done();
 				});
+				column.set('_filterInput.min', '04:21:10');
 			});
 
 		});
-
 	}());
-
 	</script>
 </body>
 </html>

--- a/test/range.html
+++ b/test/range.html
@@ -125,31 +125,30 @@
 			test('changing _filterInput updates filter', function (done) {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
-				column._filterInput = {
-					min: -10,
-					max: 15
-				};
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min, -10);
 					assert.equal(column.filter.max, 15);
 					done();
 				});
+				column._filterInput = {
+					min: -10,
+					max: 15
+				};
 			});
 
 			test('changing only _filterInput min updates filter min', function (done) {
-				column._filterInput.min = -21;
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min, -21);
 					done();
 				});
+				column.set('_filterInput.min', -21);
 			});
 
 			test('changing out of range _filterInput limits _filterInput', function (done) {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
 
-				let handler;
-				column.addEventListener('filter-changed', handler = function () {
+				column.addEventListener('filter-changed', function handler() {
 					assert.equal(column._filterInput.min, -11);
 					assert.equal(column._filterInput.max, 17);
 					assert.equal(column.filter.min, -11);
@@ -164,7 +163,7 @@
 						column.set('_filterInput.min', 20);
 					});
 				});
-				column._filterInput =  {min: -11, max: 17 };
+				column._filterInput =  {min: -11, max: 17};
 			});
 		});
 
@@ -261,31 +260,30 @@
 			test('changing _filterInput updates filter', function (done) {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
-				column._filterInput = {
-					min: 1,
-					max: 15
-				};
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.amount, 1);
 					assert.equal(column.filter.max.amount, 15);
 					done();
 				});
+				column._filterInput = {
+					min: 1,
+					max: 15
+				};
 			});
 
 			test('changing only _filterInput min updates filter min', function (done) {
-				column._filterInput.min = -2317;
 				column.addEventListener('filter-changed', function () {
 					assert.equal(column.filter.min.amount, -2317);
 					done();
 				});
+				column.set('_filterInput.min', -2317);
 			});
 
 			test('changing out of range _filterInput limits _filterInput', function (done) {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
 
-				let handler;
-				column.addEventListener('filter-changed', handler = function () {
+				column.addEventListener('filter-changed', function handler() {
 					assert.equal(column._filterInput.min, 7);
 					assert.equal(column._filterInput.max, 77);
 					assert.equal(column.filter.min.amount, 7);


### PR DESCRIPTION
Use `set` for `_filterInput` changes in tests.
Change order of property updates and event listeners. 