### PR TITLE
Add immediateDataInit property

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -227,6 +227,11 @@
 				computed: '_computeRouteHashKeyRule(hashParam)'
 			},
 
+			immediateDataInit: {
+				type: Boolean,
+				value: false
+			},
+
 			/**
 			 * True when all items are selected.
 			 */
@@ -308,7 +313,7 @@
 		},
 
 		visibleChanged(turnedVisible) {
-			if (turnedVisible && !Array.isArray(this.columns)) {
+			if (turnedVisible && !Array.isArray(this.columns) || this.immediateDataInit && !Array.isArray(this.visibleColumns)) {
 				this._debounceUpdateColumns();
 			}
 		},
@@ -403,7 +408,7 @@
 
 			this._setVisible(this.offsetParent != null);
 
-			if (!this.visible) {
+			if (!this.visible && !this.immediateDataInit) {
 				return;
 			}
 
@@ -444,7 +449,10 @@
 			});
 
 			this.columns = columns;
-			this.visibleColumns = columns.slice();
+
+			if (this.visible) {
+				this.visibleColumns = columns.slice();
+			}
 
 			this._updateParamsFromHash();
 


### PR DESCRIPTION
Add `immediateDataInit` property to get columns, update from hash params and debounce filter event when omnitable is not visible