### PR TITLE
Handle null/undefined in _applySingleFilter

### DIFF
--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -379,8 +379,11 @@
 		},
 
 		_applySingleFilter: function (filterString, item) {
-			var value = this.get(this.valuePath, item).toString().toLowerCase();
-			return value.indexOf(filterString) >= 0;
+			const value = this.get(this.valuePath, item);
+			if (value == null) {
+				return false;
+			}
+			return value.toString().toLowerCase().indexOf(filterString) > -1;
 		},
 
 		_applyMultiFilter: function (filter, item) {


### PR DESCRIPTION
Handle null/undefined in `_applySingleFilter`.
It is possible for `this.get(this.valuePath, item)` to be null sometimes.