### PR TITLE
Improve autocomplete serialize, deserialize

### DIFF
--- a/cosmoz-omnitable-column-autocomplete.html
+++ b/cosmoz-omnitable-column-autocomplete.html
@@ -168,6 +168,34 @@
 					}
 					return true;
 				});
+			},
+
+			_serializeFilter: function (obj = this.filter) {
+				if (!(Array.isArray(obj) && obj.length > 0)) {
+					return null;
+				}
+				return obj.map(item => {
+					const property = this.valueProperty;
+					if (!property) {
+						return item;
+					}
+					return this.get(property, item);
+				}).join('~');
+			},
+
+			_deserializeFilter: function (obj) {
+				if (obj == null || obj  === '') {
+					return null;
+				}
+				return obj.split('~').map(item => this.values.find(v => {
+					const property = this.valueProperty;
+					if (!property) {
+						const vv = typeof v === 'number' ? v.toString() : v;
+						const ii = typeof item === 'number' ? item.toString() : item;
+						return vv === ii;
+					}
+					return this.get(property, v) === item;
+				}));
 			}
 		});
 	</script>

--- a/cosmoz-omnitable-column-autocomplete.html
+++ b/cosmoz-omnitable-column-autocomplete.html
@@ -92,6 +92,9 @@
 					notify: true
 				},
 			},
+			observers: [
+				'_valuesForHashChanged(values.*)'
+			],
 
 			getComparableValue: function (item, valuePath = this.valuePath) {
 				return this.getString(item, valuePath);
@@ -170,33 +173,52 @@
 				});
 			},
 
-			_serializeFilter: function (obj = this.filter) {
-				if (!(Array.isArray(obj) && obj.length > 0)) {
-					return null;
+			_normalizeValue(value) {
+				if (value == null) {
+					return value;
 				}
-				return obj.map(item => {
-					const property = this.valueProperty;
-					if (!property) {
-						return item;
-					}
-					return this.get(property, item);
-				}).join('~');
+
+				return isNaN(value) ? value : Number(value);
 			},
 
-			_deserializeFilter: function (obj) {
-				if (obj == null || obj  === '') {
+			_serializeFilter(filter = this.filter) {
+				if (!Array.isArray(filter) || filter.length === 0) {
 					return null;
 				}
-				return obj.split('~').map(item => this.values.find(v => {
-					const property = this.valueProperty;
-					if (!property) {
-						const vv = typeof v === 'number' ? v.toString() : v;
-						const ii = typeof item === 'number' ? item.toString() : item;
-						return vv === ii;
-					}
-					return this.get(property, v) === item;
-				}));
+				const property = this.valueProperty;
+				return filter
+					.map(item => property ? this.get(property, item) : item)
+					.join('~');
+			},
+
+			_deserializeFilter(filterString) {
+				if (filterString == null || filterString  === '') {
+					return null;
+				}
+				const property = this.valueProperty;
+				return filterString
+					.split('~')
+					.map(item => this.values
+						.find(v => this._normalizeValue(property ? this.get(property, v) : v) === this._normalizeValue(item))
+					).filter(i => i != null);
+			},
+
+			_valuesForHashChanged() {
+				if (!Array.isArray(this.values) || this._pendingFilterString) {
+					return;
+				}
+				this.setFilterFromHash(this._pendingFilterString);
+				this._pendingFilterString = null;
+			},
+
+			setFilterFromHash(value) {
+				if (!Array.isArray(this.values)) {
+					this._pendingFilterString = value;
+					return;
+				}
+				Cosmoz.OmnitableColumnBehavior.setFilterFromHash.call(this, value);
 			}
+
 		});
 	</script>
 </dom-module>

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -457,6 +457,14 @@
 			return this.deserialize(obj, type);
 		},
 
+		setFilterFromHash(value) {
+			const deserialized = this._deserializeFilter(value);
+
+			if (deserialized === null) {
+				return this.resetFilter();
+			}
+			this.set('filter', deserialized);
+		}
 	};
 
 </script>

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -1152,13 +1152,7 @@
 				return;
 			}
 
-			let deserialized = column._deserializeFilter(value);
-
-			if (deserialized === null) {
-				column.resetFilter();
-				return;
-			}
-			column.set('filter', deserialized);
+			column.setFilterFromHash(value);
 		},
 		_computeRouteHashKeyRule(hashParam) {
 			if (!hashParam) {

--- a/test/autocomplete.html
+++ b/test/autocomplete.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html>
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+	<title>Autocomplete tests</title>
+
+	<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+	<script src="../../web-component-tester/browser.js"></script>
+	<script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+	<link rel="import" href="../../test-fixture/test-fixture.html">
+	<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+
+	<link rel="import" href="../cosmoz-omnitable.html">
+	<link rel="import" href="../cosmoz-omnitable-columns.html">
+	<link rel="import" href="../demo/table-demo-behavior.html">
+</head>
+<body>
+	<test-fixture id="default">
+		<template>
+			<cosmoz-omnitable id="omnitable" class="flex" selection-enabled>
+				<cosmoz-omnitable-column-autocomplete name="elementName" title="name" value-path="element" text-property="name" value-property="id">
+				</cosmoz-omnitable-column-autocomplete>
+			</cosmoz-omnitable>
+		</template>
+	</test-fixture>
+	<script>
+	/*global sinon chai flush */
+	(function () {
+		'use strict';
+
+		sinon.assert.expose(chai.assert, { prefix: '' });
+
+		suite('basic', function () {
+			var omnitable,
+				data = [
+					{ element: { id: 'a', name: 'aa' } },
+					{ element: { id: 'b', name: 'bb' } },
+					{ element: { id: 'c', name: 'cc' } },
+					{ element: { id: 'd', name: 'dd' } },
+					{ element: { id: 'e', name: 'ee' } },
+					{ element: { id: 'f', name: 'ff' } },
+					{ element: { id: 'g', name: 'gg' } }
+				];
+
+			setup(function (done) {
+				omnitable = fixture('default');
+				omnitable.data = data;
+
+				flush(function () {
+					Polymer.Base.async(done, 90);
+				});
+			});
+
+			test('serialize and deserialize one filter', function (done) {
+				assert.equal(omnitable.is, 'cosmoz-omnitable');
+				const column = omnitable.columns[0];
+				column.filter = [{ id: 'c', name: 'cc' }];
+
+				const serialized = column._serializeFilter(column.filter);
+				assert.equal(serialized, 'c', 'Expected valueProperty to be serialized');
+
+				const deserialized = column._deserializeFilter(serialized);
+				assert.deepEqual(deserialized[0], { id: 'c', name: 'cc' });
+				done();
+			});
+
+			test('serialize and deserialize two filters', function (done) {
+				assert.equal(omnitable.is, 'cosmoz-omnitable');
+				const column = omnitable.columns[0];
+				column.filter = [{ id: 'b', name: 'bb' }, { id: 'g', name: 'gg' }];
+
+				const serialized = column._serializeFilter(column.filter);
+				assert.equal(serialized, 'b~g', 'Expected valueProperty to be serialized');
+
+				const deserialized = column._deserializeFilter(serialized);
+				assert.deepEqual(deserialized[0], { id: 'b', name: 'bb' });
+				assert.deepEqual(deserialized[1], { id: 'g', name: 'gg' });
+				done();
+			});
+		});
+	}());
+
+	</script>
+</body>
+</html>

--- a/test/hash-param.html
+++ b/test/hash-param.html
@@ -89,11 +89,11 @@
 				});
 
 				test('updates filter from url hash', function (done) {
-					location.hash = '#/#test-filter--id=["1"]';
+					location.hash = '#/#test-filter--id=1';
 					instantiate(function () {
 						assert.isArray(omnitable.columns[0].filter);
 						assert.lengthOf(omnitable.columns[0].filter, 1);
-						assert.include(omnitable.columns[0].filter, '1');
+						assert.include(omnitable.columns[0].filter, 1);
 						done();
 					});
 				});
@@ -163,7 +163,7 @@
 						hash = omnitable._routeHash;
 					column.filter = [0, 1];
 					Polymer.Base.async(function () {
-						assert.equal(hash['test-filter--id'], '[0,1]');
+						assert.equal(hash['test-filter--id'], '0~1');
 						column.resetFilter();
 						Polymer.Base.async(function () {
 							assert.equal(hash['test-filter--id'], null);

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,7 @@
 				'hash-param.html',
 				'xlsx-export.html',
 				'range.html',
-				'fit-dropdowns.html'
+				'fit-dropdowns.html',
 				'autocomplete.html'
 			],
 			suites = [],

--- a/test/index.html
+++ b/test/index.html
@@ -13,8 +13,8 @@
 				'hash-param.html',
 				'xlsx-export.html',
 				'range.html',
-				'range-date.html',
 				'fit-dropdowns.html'
+				'autocomplete.html'
 			],
 			suites = [],
 			i;


### PR DESCRIPTION
_serializeFilter for example if valueProperty is id then in url will be only ids separated by ~
deserializeFilter splits ids and searches in column values for them and returns the items array.

Iulian: The problem is that when we set filter (from deserializeFilter) values might not be set if data property is not set so it can't set selection in paper-autocomplete-chips.

version 1:  Because of that I set the param from url as _pendingFilterString and next time values are set it will update filter.

version 2: ( without flag ) set an array of values in paper-autocomplete-chips. [WIP]

