### PR TITLE
Fix for clear buttons always visible in polymer 2

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -2,8 +2,7 @@
   "schema_version": "1.0.0",
   "elements": [
     {
-      "description": "",
-      "summary": "",
+      "description":"",
       "path": "cosmoz-omnitable-templatizer.html",
       "properties": [
         {
@@ -72,11 +71,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/legacy/templatizer-behavior.html",
             "start": {
-              "line": 104,
+              "line": 105,
               "column": 6
             },
             "end": {
-              "line": 113,
+              "line": 114,
               "column": 7
             }
           },
@@ -84,7 +83,7 @@
           "params": [
             {
               "name": "template",
-              "type": "HTMLTemplateElement",
+              "type": "!HTMLTemplateElement",
               "description": "Template to prepare"
             },
             {
@@ -93,6 +92,9 @@
               "description": "When `true`, the generated class will skip\n  strict dirty-checking for objects and arrays (always consider them to\n  be \"dirty\"). Defaults to false."
             }
           ],
+          "return": {
+            "type": "void"
+          },
           "inheritedFrom": "Polymer.Templatizer"
         },
         {
@@ -102,11 +104,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/legacy/templatizer-behavior.html",
             "start": {
-              "line": 128,
+              "line": 129,
               "column": 6
             },
             "end": {
-              "line": 130,
+              "line": 131,
               "column": 7
             }
           },
@@ -131,11 +133,11 @@
           "sourceRange": {
             "file": "bower_components/polymer/lib/legacy/templatizer-behavior.html",
             "start": {
-              "line": 143,
+              "line": 144,
               "column": 6
             },
             "end": {
-              "line": 145,
+              "line": 146,
               "column": 7
             }
           },
@@ -421,6 +423,110 @@
       },
       "slots": [],
       "tagname": "cosmoz-omnitable-templatizer"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "ui-helpers/cosmoz-clear-button.html",
+      "properties": [
+        {
+          "name": "visible",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 44,
+              "column": 4
+            },
+            "end": {
+              "line": 48,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "light",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 50,
+              "column": 4
+            },
+            "end": {
+              "line": 54,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 41,
+          "column": 10
+        },
+        "end": {
+          "line": 56,
+          "column": 3
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "visible",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 44,
+              "column": 4
+            },
+            "end": {
+              "line": 48,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "light",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 50,
+              "column": 4
+            },
+            "end": {
+              "line": 54,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "cosmoz-clear-button"
     },
     {
       "description": "",
@@ -784,6 +890,46 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "minWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 29,
+              "column": 4
+            },
+            "end": {
+              "line": 32,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"55px\""
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 34,
+              "column": 4
+            },
+            "end": {
+              "line": 37,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"55px\""
+        },
+        {
           "name": "flex",
           "type": "string",
           "description": "Width growing factor for this column.",
@@ -791,11 +937,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 132,
+              "line": 148,
               "column": 3
             },
             "end": {
-              "line": 135,
+              "line": 151,
               "column": 4
             }
           },
@@ -813,11 +959,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -835,11 +981,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -857,11 +1003,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -878,11 +1024,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -900,11 +1046,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -922,11 +1068,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -945,11 +1091,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -968,11 +1114,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -989,11 +1135,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -1012,11 +1158,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -1034,11 +1180,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -1056,11 +1202,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -1078,11 +1224,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -1097,11 +1243,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -1120,11 +1266,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -1143,11 +1289,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -1162,11 +1308,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -1181,11 +1327,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -1200,11 +1346,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -1223,11 +1369,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -1246,11 +1392,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 283,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 305,
               "column": 3
             }
           },
@@ -1272,11 +1418,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 291,
+              "line": 307,
               "column": 2
             },
             "end": {
-              "line": 296,
+              "line": 312,
               "column": 3
             }
           },
@@ -1298,11 +1444,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -1324,11 +1470,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 310,
+              "line": 326,
               "column": 2
             },
             "end": {
-              "line": 312,
+              "line": 328,
               "column": 3
             }
           },
@@ -1350,11 +1496,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -1373,11 +1519,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -1405,11 +1551,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 336,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 347,
+              "line": 363,
               "column": 3
             }
           },
@@ -1422,18 +1568,45 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "start": {
+              "line": 52,
+              "column": 3
+            },
+            "end": {
+              "line": 54,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "hasFilter",
+          "description": "Returns whether `filterNotify.base` or `filter` is set to a usable value.",
+          "privacy": "public",
+          "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 374,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 385,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [],
+          "params": [
+            {
+              "name": "filterNotify",
+              "type": "(Object|void)",
+              "description": "filter.*"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "True if filter or filterNotify.base is set"
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -1443,11 +1616,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 353,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 394,
               "column": 3
             }
           },
@@ -1462,11 +1635,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 362,
+              "line": 396,
               "column": 2
             },
             "end": {
-              "line": 365,
+              "line": 402,
               "column": 3
             }
           },
@@ -1488,11 +1661,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 367,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 372,
+              "line": 409,
               "column": 3
             }
           },
@@ -1514,11 +1687,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -1533,11 +1706,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -1552,17 +1725,59 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 44,
+              "column": 3
+            },
+            "end": {
+              "line": 46,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filter = this.filter"
+            }
+          ]
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 48,
+              "column": 3
+            },
+            "end": {
+              "line": 50,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ]
         }
       ],
       "staticMethods": [],
@@ -1570,11 +1785,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 20,
+          "line": 24,
           "column": 10
         },
         "end": {
-          "line": 27,
+          "line": 55,
           "column": 3
         }
       },
@@ -1870,16 +2085,48 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 29,
+              "column": 4
+            },
+            "end": {
+              "line": 32,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "edit-min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 34,
+              "column": 4
+            },
+            "end": {
+              "line": 37,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
           "name": "flex",
           "description": "Width growing factor for this column.",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 132,
+              "line": 148,
               "column": 3
             },
             "end": {
-              "line": 135,
+              "line": 151,
               "column": 4
             }
           },
@@ -1893,11 +2140,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -1911,11 +2158,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -1929,11 +2176,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -1947,11 +2194,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -1965,11 +2212,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -1983,11 +2230,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -2001,11 +2248,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -2019,11 +2266,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -2037,11 +2284,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -2741,11 +2988,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 62,
+              "line": 63,
               "column": 2
             },
             "end": {
-              "line": 62,
+              "line": 63,
               "column": 21
             }
           },
@@ -2760,11 +3007,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 65,
               "column": 2
             },
             "end": {
-              "line": 64,
+              "line": 65,
               "column": 24
             }
           },
@@ -2779,11 +3026,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 42,
+              "line": 43,
               "column": 3
             },
             "end": {
-              "line": 44,
+              "line": 45,
               "column": 4
             }
           },
@@ -2798,11 +3045,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 46,
+              "line": 47,
               "column": 3
             },
             "end": {
-              "line": 49,
+              "line": 50,
               "column": 4
             }
           },
@@ -2819,11 +3066,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 52,
               "column": 3
             },
             "end": {
-              "line": 54,
+              "line": 55,
               "column": 4
             }
           },
@@ -2841,11 +3088,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 67,
               "column": 2
             },
             "end": {
-              "line": 68,
+              "line": 69,
               "column": 3
             }
           },
@@ -2862,11 +3109,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 71,
               "column": 2
             },
             "end": {
-              "line": 72,
+              "line": 73,
               "column": 3
             }
           },
@@ -2889,11 +3136,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 74,
+              "line": 75,
               "column": 2
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 3
             }
           },
@@ -2913,11 +3160,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 83,
               "column": 2
             },
             "end": {
-              "line": 88,
+              "line": 90,
               "column": 3
             }
           },
@@ -3244,11 +3491,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 92,
               "column": 2
             },
             "end": {
-              "line": 95,
+              "line": 97,
               "column": 3
             }
           },
@@ -3265,11 +3512,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 97,
+              "line": 99,
               "column": 2
             },
             "end": {
-              "line": 108,
+              "line": 110,
               "column": 3
             }
           },
@@ -3286,11 +3533,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 110,
+              "line": 112,
               "column": 2
             },
             "end": {
-              "line": 114,
+              "line": 116,
               "column": 3
             }
           },
@@ -3307,11 +3554,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 118,
               "column": 2
             },
             "end": {
-              "line": 120,
+              "line": 122,
               "column": 3
             }
           },
@@ -3328,11 +3575,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 124,
               "column": 2
             },
             "end": {
-              "line": 124,
+              "line": 126,
               "column": 3
             }
           },
@@ -3352,11 +3599,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 33,
+          "line": 34,
           "column": 9
         },
         "end": {
-          "line": 125,
+          "line": 127,
           "column": 2
         }
       },
@@ -3404,11 +3651,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 42,
+              "line": 43,
               "column": 3
             },
             "end": {
-              "line": 44,
+              "line": 45,
               "column": 4
             }
           },
@@ -3420,11 +3667,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 46,
+              "line": 47,
               "column": 3
             },
             "end": {
-              "line": 49,
+              "line": 50,
               "column": 4
             }
           },
@@ -3436,11 +3683,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 52,
               "column": 3
             },
             "end": {
-              "line": 54,
+              "line": 55,
               "column": 4
             }
           },
@@ -3460,11 +3707,11 @@
           "range": {
             "file": "cosmoz-omnitable-item-row.html",
             "start": {
-              "line": 25,
+              "line": 26,
               "column": 2
             },
             "end": {
-              "line": 25,
+              "line": 26,
               "column": 32
             }
           }
@@ -5309,7 +5556,7 @@
       "tagname": "cosmoz-omnitable-item"
     },
     {
-      "description": "global accounting",
+      "description": "",
       "summary": "",
       "path": "cosmoz-omnitable-column-amount.html",
       "properties": [
@@ -5499,13 +5746,14 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 47,
-              "column": 4
+              "line": 6,
+              "column": 3
             },
             "end": {
-              "line": 51,
-              "column": 5
+              "line": 10,
+              "column": 4
             }
           },
           "metadata": {
@@ -5513,7 +5761,8 @@
               "readOnly": true
             }
           },
-          "defaultValue": "true"
+          "defaultValue": "true",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -5542,19 +5791,21 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 97,
-              "column": 4
+              "line": 12,
+              "column": 3
             },
             "end": {
-              "line": 102,
-              "column": 5
+              "line": 17,
+              "column": 4
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "[]"
+          "defaultValue": "[]",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sortOn",
@@ -5629,11 +5880,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 104,
+              "line": 55,
               "column": 4
             },
             "end": {
-              "line": 107,
+              "line": 58,
               "column": 5
             }
           },
@@ -5649,11 +5900,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 109,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 112,
+              "line": 62,
               "column": 5
             }
           },
@@ -5663,9 +5914,9 @@
           "defaultValue": "\"70px\""
         },
         {
-          "name": "flex",
+          "name": "minWidth",
           "type": "string",
-          "description": "Width growing factor for this column.",
+          "description": "The minimum width of this column.",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
@@ -5675,6 +5926,50 @@
             },
             "end": {
               "line": 135,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "The minimum width of this column in edit mode.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "type": "string",
+          "description": "Width growing factor for this column.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
               "column": 4
             }
           },
@@ -5691,11 +5986,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 64,
               "column": 4
             },
             "end": {
-              "line": 117,
+              "line": 67,
               "column": 5
             }
           },
@@ -5711,11 +6006,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 118,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 121,
+              "line": 71,
               "column": 5
             }
           },
@@ -5732,11 +6027,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -5753,11 +6048,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -5775,11 +6070,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -5797,11 +6092,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -5820,11 +6115,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -5843,11 +6138,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -5864,11 +6159,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -5887,11 +6182,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -5909,11 +6204,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -5931,11 +6226,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -5967,44 +6262,181 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "type": "Object",
+          "name": "min",
+          "type": "number",
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 19,
+              "column": 3
             },
             "end": {
-              "line": 58,
-              "column": 5
+              "line": 22,
+              "column": 4
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "{}"
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
-          "name": "min",
+          "name": "max",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 24,
+              "column": 3
+            },
+            "end": {
+              "line": 27,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_filterInput",
           "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 34,
+              "column": 3
+            },
+            "end": {
+              "line": 39,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_range",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 41,
+              "column": 3
+            },
+            "end": {
+              "line": 44,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limit",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 46,
+              "column": 3
+            },
+            "end": {
+              "line": 52,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "defaultValue": "{}",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_tooltip",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 3
+            },
+            "end": {
+              "line": 57,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "defaultCurrency",
+          "type": "string",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 64,
+              "line": 54,
               "column": 5
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "{}"
+          "defaultValue": "\"SEK\""
         },
         {
           "name": "_filterText",
@@ -6013,32 +6445,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 65,
-              "column": 4
-            },
-            "end": {
-              "line": 68,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_possibleAmountRange",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 69,
-              "column": 4
-            },
-            "end": {
               "line": 72,
+              "column": 4
+            },
+            "end": {
+              "line": 75,
               "column": 5
             }
           },
@@ -6055,11 +6466,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 73,
-              "column": 4
-            },
-            "end": {
               "line": 76,
+              "column": 4
+            },
+            "end": {
+              "line": 79,
               "column": 5
             }
           },
@@ -6068,151 +6479,6 @@
               "readOnly": true
             }
           }
-        },
-        {
-          "name": "_fromMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 77,
-              "column": 4
-            },
-            "end": {
-              "line": 80,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_fromMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 81,
-              "column": 4
-            },
-            "end": {
-              "line": 84,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_toMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 85,
-              "column": 4
-            },
-            "end": {
-              "line": 88,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_toMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 4
-            },
-            "end": {
-              "line": 92,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_tooltip",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 93,
-              "column": 4
-            },
-            "end": {
-              "line": 96,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "defaultCurrency",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 122,
-              "column": 4
-            },
-            "end": {
-              "line": 125,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"SEK\""
-        },
-        {
-          "name": "locale",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 126,
-              "column": 4
-            },
-            "end": {
-              "line": 129,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "null"
         }
       ],
       "methods": [
@@ -6223,11 +6489,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -6242,11 +6508,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -6265,11 +6531,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -6288,11 +6554,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -6307,11 +6573,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -6326,11 +6592,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -6345,11 +6611,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -6368,11 +6634,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -6390,11 +6656,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 246,
+              "line": 166,
               "column": 3
             },
             "end": {
-              "line": 249,
+              "line": 175,
               "column": 4
             }
           },
@@ -6404,7 +6670,7 @@
               "name": "item"
             },
             {
-              "name": "valuePath"
+              "name": "valuePath = this.valuePath"
             }
           ]
         },
@@ -6414,16 +6680,23 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 250,
+              "line": 148,
               "column": 3
             },
             "end": {
-              "line": 253,
+              "line": 150,
               "column": 4
             }
           },
           "metadata": {},
-          "params": []
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath = this.valuePath"
+            }
+          ]
         },
         {
           "name": "valuePathChanged",
@@ -6432,11 +6705,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -6453,27 +6726,35 @@
         },
         {
           "name": "getComparableValue",
-          "description": "",
+          "description": "Get the comparable value of an item.",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 290,
+              "line": 159,
               "column": 3
             },
             "end": {
-              "line": 297,
+              "line": 165,
               "column": 4
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "item"
+              "name": "item",
+              "type": "Object",
+              "description": "Item to be processed"
             },
             {
-              "name": "valuePath"
+              "name": "valuePath",
+              "type": "String",
+              "description": "Property path"
             }
-          ]
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Valid value or void"
+          }
         },
         {
           "name": "_valueChanged",
@@ -6482,11 +6763,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -6505,11 +6786,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -6535,17 +6816,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 299,
-              "column": 3
+              "line": 187,
+              "column": 2
             },
             "end": {
-              "line": 307,
-              "column": 4
+              "line": 195,
+              "column": 3
             }
           },
           "metadata": {},
-          "params": []
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "resetFilter",
@@ -6554,11 +6837,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
@@ -6567,34 +6850,56 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "hasFilter",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 328,
+              "column": 2
+            },
+            "end": {
+              "line": 335,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
           "name": "_getDefaultFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 325,
-              "column": 3
+              "line": 251,
+              "column": 2
             },
             "end": {
-              "line": 330,
-              "column": 4
+              "line": 256,
+              "column": 3
             }
           },
           "metadata": {},
-          "params": []
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applySingleFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 309,
-              "column": 3
+              "line": 197,
+              "column": 2
             },
             "end": {
-              "line": 323,
-              "column": 4
+              "line": 211,
+              "column": 3
             }
           },
           "metadata": {},
@@ -6605,7 +6910,8 @@
             {
               "name": "item"
             }
-          ]
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applyMultiFilter",
@@ -6614,11 +6920,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 367,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 372,
+              "line": 409,
               "column": 3
             }
           },
@@ -6640,11 +6946,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -6659,11 +6965,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -6678,17 +6984,63 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 337,
+              "column": 2
+            },
+            "end": {
+              "line": 348,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filter = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 350,
+              "column": 2
+            },
+            "end": {
+              "line": 364,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_argumentsToObject",
@@ -6811,19 +7163,19 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "bower_components/cosmoz-i18next/cosmoz-i18next.js",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
               "line": 65,
               "column": 2
             },
             "end": {
-              "line": 70,
+              "line": 67,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "gettext",
@@ -6962,23 +7314,400 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "_computeFilterText",
+          "name": "toNumber",
+          "description": "Converts a value to number optionaly limiting it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 93,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "(Number|*)",
+              "description": "The value to convert to number"
+            },
+            {
+              "name": "limit",
+              "type": "(Number|*)",
+              "description": "The value used to limit the number"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "The function used to limit the number (Math.min|Math.max)"
+            }
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Value converted to Number or void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "toValue",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 144,
               "column": 3
             },
             "end": {
-              "line": 143,
+              "line": 146,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "renderValue",
+          "description": "Converts an amount to symbol and value to be rendered.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 189,
+              "column": 3
+            },
+            "end": {
+              "line": 200,
               "column": 4
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "filterNotify"
+              "name": "value",
+              "type": "Object",
+              "description": "Amount to be formated"
+            },
+            {
+              "name": "_formatters = this._formatters"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "Formated value or empty string."
+          }
+        },
+        {
+          "name": "getInputString",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 2
+            },
+            "end": {
+              "line": 143,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath = this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeRange",
+          "description": "Computes min/max range from values.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 151,
+              "column": 2
+            },
+            "end": {
+              "line": 168,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "`values` property changes"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Computed min/max"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeLimit",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 170,
+              "column": 2
+            },
+            "end": {
+              "line": 185,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "range"
+            },
+            {
+              "name": "inputChange"
+            },
+            {
+              "name": "min"
+            },
+            {
+              "name": "max"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeFilterText",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 213,
+              "column": 2
+            },
+            "end": {
+              "line": 230,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeTooltip",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "title"
+            },
+            {
+              "name": "text"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_fromInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 227,
+              "column": 3
+            },
+            "end": {
+              "line": 236,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            },
+            {
+              "name": "property"
+            }
+          ]
+        },
+        {
+          "name": "_toInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 219,
+              "column": 3
+            },
+            "end": {
+              "line": 225,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "_filterInputChanged",
+          "description": "Observes changes of _filterInput, saves the path, debounces _limitInput.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 264,
+              "column": 2
+            },
+            "end": {
+              "line": 268,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "'_filterInput' property changes"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limitInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 270,
+              "column": 2
+            },
+            "end": {
+              "line": 289,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_updateFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 291,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_filterChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 326,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_toHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 238,
+              "column": 3
+            },
+            "end": {
+              "line": 243,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "_fromHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 245,
+              "column": 3
+            },
+            "end": {
+              "line": 257,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
             }
           ]
         },
@@ -6988,11 +7717,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 145,
+              "line": 81,
               "column": 3
             },
             "end": {
-              "line": 166,
+              "line": 102,
               "column": 4
             }
           },
@@ -7007,199 +7736,53 @@
           ]
         },
         {
-          "name": "_computePossibleAmountRange",
-          "description": "",
-          "privacy": "protected",
+          "name": "toAmount",
+          "description": "Converts a value to an amount object optionaly limiting it.",
+          "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 168,
+              "line": 112,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 142,
               "column": 4
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "values"
+              "name": "value",
+              "type": "Object",
+              "description": "The value to convert to number"
+            },
+            {
+              "name": "limit",
+              "type": "Object",
+              "description": "The value used to limit the number"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "The function used to limit the number (Math.min|Math.max)"
             }
-          ]
+          ],
+          "return": {
+            "type": "(Object|void)",
+            "desc": "Value converted to Number or void"
+          }
         },
         {
-          "name": "_computeTooltip",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 187,
-              "column": 3
-            },
-            "end": {
-              "line": 193,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "title"
-            },
-            {
-              "name": "filterText"
-            }
-          ]
-        },
-        {
-          "name": "_getMinMax",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 195,
-              "column": 3
-            },
-            "end": {
-              "line": 216,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "first"
-            },
-            {
-              "name": "secondNotify"
-            },
-            {
-              "name": "max"
-            }
-          ]
-        },
-        {
-          "name": "_getNumberValue",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 218,
-              "column": 3
-            },
-            "end": {
-              "line": 228,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ]
-        },
-        {
-          "name": "_setMinValue",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 230,
-              "column": 3
-            },
-            "end": {
-              "line": 236,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_setMaxValue",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 238,
-              "column": 3
-            },
-            "end": {
-              "line": 244,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "renderAmount",
+          "name": "getCurrency",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 255,
+              "line": 177,
               "column": 3
             },
             "end": {
-              "line": 260,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            },
-            {
-              "name": "_formatters = this._formatters"
-            }
-          ]
-        },
-        {
-          "name": "renderAmountValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 262,
-              "column": 3
-            },
-            "end": {
-              "line": 267,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath"
-            }
-          ]
-        },
-        {
-          "name": "_getCurrency",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 269,
-              "column": 3
-            },
-            "end": {
-              "line": 272,
+              "line": 180,
               "column": 4
             }
           },
@@ -7219,11 +7802,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 274,
+              "line": 202,
               "column": 3
             },
             "end": {
-              "line": 288,
+              "line": 217,
               "column": 4
             }
           },
@@ -7240,11 +7823,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 38,
+          "line": 41,
           "column": 10
         },
         "end": {
-          "line": 331,
+          "line": 258,
           "column": 3
         }
       },
@@ -7399,17 +7982,19 @@
           "name": "bind-values",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 47,
-              "column": 4
+              "line": 6,
+              "column": 3
             },
             "end": {
-              "line": 51,
-              "column": 5
+              "line": 10,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "boolean"
+          "type": "boolean",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -7433,17 +8018,19 @@
           "name": "values",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 97,
-              "column": 4
+              "line": 12,
+              "column": 3
             },
             "end": {
-              "line": 102,
-              "column": 5
+              "line": 17,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "Array"
+          "type": "Array",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sort-on",
@@ -7504,11 +8091,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 104,
+              "line": 55,
               "column": 4
             },
             "end": {
-              "line": 107,
+              "line": 58,
               "column": 5
             }
           },
@@ -7520,11 +8107,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 109,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 112,
+              "line": 62,
               "column": 5
             }
           },
@@ -7532,8 +8119,8 @@
           "type": "string"
         },
         {
-          "name": "flex",
-          "description": "Width growing factor for this column.",
+          "name": "min-width",
+          "description": "The minimum width of this column.",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
@@ -7550,15 +8137,51 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "edit-min-width",
+          "description": "The minimum width of this column in edit mode.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "description": "Width growing factor for this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
           "name": "cell-class",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 64,
               "column": 4
             },
             "end": {
-              "line": 117,
+              "line": 67,
               "column": 5
             }
           },
@@ -7570,11 +8193,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 118,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 121,
+              "line": 71,
               "column": 5
             }
           },
@@ -7587,11 +8210,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -7605,11 +8228,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -7623,11 +8246,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -7641,11 +8264,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -7659,11 +8282,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -7677,11 +8300,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -7695,11 +8318,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -7726,63 +8349,69 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 53,
-              "column": 4
-            },
-            "end": {
-              "line": 58,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object"
-        },
-        {
           "name": "min",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 59,
-              "column": 4
+              "line": 19,
+              "column": 3
             },
             "end": {
-              "line": 64,
-              "column": 5
+              "line": 22,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "Object"
+          "type": "number",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "max",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 24,
+              "column": 3
+            },
+            "end": {
+              "line": 27,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "number",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "locale",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "default-currency",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 125,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "locale",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 126,
-              "column": 4
-            },
-            "end": {
-              "line": 129,
+              "line": 54,
               "column": 5
             }
           },
@@ -7936,11 +8565,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 54,
               "column": 5
             }
           },
@@ -8003,11 +8632,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 42,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 46,
               "column": 5
             }
           },
@@ -8171,6 +8800,46 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "minWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 4
+            },
+            "end": {
+              "line": 79,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"55px\""
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 81,
+              "column": 4
+            },
+            "end": {
+              "line": 84,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"55px\""
+        },
+        {
           "name": "flex",
           "type": "string",
           "description": "Width growing factor for this column.",
@@ -8178,11 +8847,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 132,
+              "line": 148,
               "column": 3
             },
             "end": {
-              "line": 135,
+              "line": 151,
               "column": 4
             }
           },
@@ -8200,11 +8869,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -8221,11 +8890,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 71,
               "column": 4
             },
             "end": {
-              "line": 73,
+              "line": 74,
               "column": 5
             }
           },
@@ -8242,11 +8911,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -8263,11 +8932,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -8285,11 +8954,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -8307,11 +8976,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -8330,11 +8999,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -8353,11 +9022,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -8374,11 +9043,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -8397,11 +9066,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -8419,11 +9088,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -8441,11 +9110,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -8461,11 +9130,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 55,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 58,
+              "line": 59,
               "column": 5
             }
           },
@@ -8482,11 +9151,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 64,
               "column": 5
             }
           },
@@ -8502,11 +9171,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 66,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 69,
               "column": 5
             }
           },
@@ -8514,6 +9183,27 @@
             "polymer": {}
           },
           "defaultValue": "\"\""
+        },
+        {
+          "name": "focused",
+          "type": "boolean",
+          "description": "`focused` If true, the autocomplete column currently has focus.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 4
+            },
+            "end": {
+              "line": 92,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
         }
       ],
       "methods": [
@@ -8524,11 +9214,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -8543,11 +9233,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -8566,11 +9256,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -8589,11 +9279,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -8608,11 +9298,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -8627,11 +9317,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -8646,11 +9336,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -8669,11 +9359,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -8691,11 +9381,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 99,
               "column": 3
             },
             "end": {
-              "line": 94,
+              "line": 113,
               "column": 4
             }
           },
@@ -8715,11 +9405,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 115,
               "column": 3
             },
             "end": {
-              "line": 101,
+              "line": 120,
               "column": 4
             }
           },
@@ -8740,11 +9430,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -8765,11 +9455,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 95,
               "column": 3
             },
             "end": {
-              "line": 78,
+              "line": 97,
               "column": 4
             }
           },
@@ -8790,11 +9480,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -8813,11 +9503,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -8845,11 +9535,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 336,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 347,
+              "line": 363,
               "column": 3
             }
           },
@@ -8864,16 +9554,45 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "hasFilter",
+          "description": "Returns whether `filterNotify.base` or `filter` is set to a usable value.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 374,
+              "column": 2
+            },
+            "end": {
+              "line": 385,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filterNotify",
+              "type": "(Object|void)",
+              "description": "filter.*"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "True if filter or filterNotify.base is set"
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -8883,11 +9602,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 353,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 394,
               "column": 3
             }
           },
@@ -8901,11 +9620,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 122,
               "column": 3
             },
             "end": {
-              "line": 106,
+              "line": 125,
               "column": 4
             }
           },
@@ -8925,11 +9644,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 108,
+              "line": 127,
               "column": 3
             },
             "end": {
-              "line": 130,
+              "line": 150,
               "column": 4
             }
           },
@@ -8950,11 +9669,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -8969,11 +9688,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -8988,11 +9707,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
@@ -9001,16 +9720,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 423,
+              "column": 2
+            },
+            "end": {
+              "line": 441,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 443,
+              "column": 2
+            },
+            "end": {
+              "line": 453,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
           "name": "_unique",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 152,
               "column": 3
             },
             "end": {
-              "line": 150,
+              "line": 170,
               "column": 4
             }
           },
@@ -9030,11 +9795,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 30,
+          "line": 31,
           "column": 10
         },
         "end": {
-          "line": 151,
+          "line": 171,
           "column": 3
         }
       },
@@ -9136,11 +9901,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 54,
               "column": 5
             }
           },
@@ -9188,11 +9953,11 @@
           "description": "Ask for a list of values",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 42,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 46,
               "column": 5
             }
           },
@@ -9326,16 +10091,48 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 4
+            },
+            "end": {
+              "line": 79,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "edit-min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 81,
+              "column": 4
+            },
+            "end": {
+              "line": 84,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
           "name": "flex",
           "description": "Width growing factor for this column.",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 132,
+              "line": 148,
               "column": 3
             },
             "end": {
-              "line": 135,
+              "line": 151,
               "column": 4
             }
           },
@@ -9349,11 +10146,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -9366,11 +10163,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 71,
               "column": 4
             },
             "end": {
-              "line": 73,
+              "line": 74,
               "column": 5
             }
           },
@@ -9383,11 +10180,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -9401,11 +10198,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -9419,11 +10216,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -9437,11 +10234,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -9455,11 +10252,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -9473,11 +10270,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -9491,11 +10288,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -9508,11 +10305,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 55,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 58,
+              "line": 59,
               "column": 5
             }
           },
@@ -9524,11 +10321,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 64,
               "column": 5
             }
           },
@@ -9540,16 +10337,32 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 66,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 69,
               "column": 5
             }
           },
           "metadata": {},
           "type": "string"
+        },
+        {
+          "name": "focused",
+          "description": "`focused` If true, the autocomplete column currently has focus.",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 4
+            },
+            "end": {
+              "line": 92,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
         }
       ],
       "events": [
@@ -9570,6 +10383,12 @@
           "type": "CustomEvent",
           "name": "query-changed",
           "description": "Fired when the `query` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "focused-changed",
+          "description": "Fired when the `focused` property changes.",
           "metadata": {}
         }
       ],
@@ -9940,6 +10759,50 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "minWidth",
+          "type": "string",
+          "description": "The minimum width of this column.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 132,
+              "column": 3
+            },
+            "end": {
+              "line": 135,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "The minimum width of this column in edit mode.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
           "name": "flex",
           "type": "string",
           "description": "No need to grow, as the values in a boolean column should have known fixed width",
@@ -9967,11 +10830,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -9989,11 +10852,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -10011,11 +10874,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -10032,11 +10895,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -10054,11 +10917,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -10076,11 +10939,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -10099,11 +10962,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -10122,11 +10985,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -10143,11 +11006,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -10166,11 +11029,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -10188,11 +11051,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -10210,11 +11073,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -10370,11 +11233,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -10389,11 +11252,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -10412,11 +11275,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -10435,11 +11298,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -10454,11 +11317,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -10473,11 +11336,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -10492,11 +11355,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -10515,11 +11378,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -10562,11 +11425,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 291,
+              "line": 307,
               "column": 2
             },
             "end": {
-              "line": 296,
+              "line": 312,
               "column": 3
             }
           },
@@ -10588,11 +11451,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -10614,11 +11477,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 310,
+              "line": 326,
               "column": 2
             },
             "end": {
-              "line": 312,
+              "line": 328,
               "column": 3
             }
           },
@@ -10661,11 +11524,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -10710,16 +11573,45 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "hasFilter",
+          "description": "Returns whether `filterNotify.base` or `filter` is set to a usable value.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 374,
+              "column": 2
+            },
+            "end": {
+              "line": 385,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filterNotify",
+              "type": "(Object|void)",
+              "description": "filter.*"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "True if filter or filterNotify.base is set"
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -10729,11 +11621,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 353,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 394,
               "column": 3
             }
           },
@@ -10769,11 +11661,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 367,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 372,
+              "line": 409,
               "column": 3
             }
           },
@@ -10795,11 +11687,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -10814,11 +11706,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -10833,16 +11725,62 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 423,
+              "column": 2
+            },
+            "end": {
+              "line": 441,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 443,
+              "column": 2
+            },
+            "end": {
+              "line": 453,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -11215,6 +12153,42 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "min-width",
+          "description": "The minimum width of this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 132,
+              "column": 3
+            },
+            "end": {
+              "line": 135,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "edit-min-width",
+          "description": "The minimum width of this column in edit mode.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
           "name": "flex",
           "description": "No need to grow, as the values in a boolean column should have known fixed width",
           "sourceRange": {
@@ -11236,11 +12210,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -11254,11 +12228,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -11272,11 +12246,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -11290,11 +12264,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -11308,11 +12282,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -11326,11 +12300,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -11344,11 +12318,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -11362,11 +12336,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -11380,11 +12354,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -11651,16 +12625,16 @@
         {
           "name": "bindValues",
           "type": "boolean",
-          "description": "Ask for a list of values",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 9,
+              "line": 6,
               "column": 3
             },
             "end": {
-              "line": 13,
+              "line": 10,
               "column": 4
             }
           },
@@ -11670,7 +12644,7 @@
             }
           },
           "defaultValue": "true",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -11699,13 +12673,13 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 29,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 34,
+              "line": 17,
               "column": 4
             }
           },
@@ -11713,7 +12687,7 @@
             "polymer": {}
           },
           "defaultValue": "[]",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sortOn",
@@ -11789,11 +12763,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 86,
+              "line": 22,
               "column": 3
             },
             "end": {
-              "line": 89,
+              "line": 25,
               "column": 4
             }
           },
@@ -11801,7 +12775,7 @@
             "polymer": {}
           },
           "defaultValue": "\"100px\"",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "editWidth",
@@ -11811,11 +12785,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 91,
+              "line": 27,
               "column": 3
             },
             "end": {
-              "line": 94,
+              "line": 30,
               "column": 4
             }
           },
@@ -11823,7 +12797,47 @@
             "polymer": {}
           },
           "defaultValue": "\"150px\"",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "minWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 49,
+              "column": 4
+            },
+            "end": {
+              "line": 52,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"82px\""
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 53,
+              "column": 4
+            },
+            "end": {
+              "line": 56,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"82px\""
         },
         {
           "name": "flex",
@@ -11833,11 +12847,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 100,
+              "line": 36,
               "column": 3
             },
             "end": {
-              "line": 103,
+              "line": 39,
               "column": 4
             }
           },
@@ -11845,7 +12859,7 @@
             "polymer": {}
           },
           "defaultValue": "\"0\"",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "cellClass",
@@ -11855,11 +12869,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -11875,21 +12889,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
-              "column": 3
+              "line": 45,
+              "column": 4
             },
             "end": {
-              "line": 145,
-              "column": 4
+              "line": 48,
+              "column": 5
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "\"default-header-cell\"",
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          "defaultValue": "\"date-header-cell\""
         },
         {
           "name": "styleModule",
@@ -11899,11 +12911,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -11920,11 +12932,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -11942,11 +12954,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -11964,11 +12976,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -11987,11 +12999,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -12010,11 +13022,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -12031,11 +13043,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -12054,11 +13066,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -12076,11 +13088,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -12098,11 +13110,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -12134,27 +13146,6 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "type": "Date",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 15,
-              "column": 3
-            },
-            "end": {
-              "line": 20,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
           "name": "min",
           "type": "Date",
           "description": "",
@@ -12162,18 +13153,63 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 22,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 27,
+              "line": 15,
               "column": 4
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "max",
+          "type": "Date",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 7,
+              "column": 3
+            },
+            "end": {
+              "line": 10,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_filterInput",
@@ -12181,9 +13217,30 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 36,
+              "line": 34,
+              "column": 3
+            },
+            "end": {
+              "line": 39,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_range",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 41,
               "column": 3
             },
             "end": {
@@ -12192,9 +13249,58 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "readOnly": true
+            }
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limit",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 46,
+              "column": 3
+            },
+            "end": {
+              "line": 52,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "defaultValue": "{}",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_tooltip",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 3
+            },
+            "end": {
+              "line": 57,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_filterText",
@@ -12204,11 +13310,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 46,
+              "line": 17,
               "column": 3
             },
             "end": {
-              "line": 49,
+              "line": 20,
               "column": 4
             }
           },
@@ -12217,168 +13323,7 @@
               "readOnly": true
             }
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_possibleDateRange",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 51,
-              "column": 3
-            },
-            "end": {
-              "line": 54,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_fromMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 56,
-              "column": 3
-            },
-            "end": {
-              "line": 59,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_fromMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 61,
-              "column": 3
-            },
-            "end": {
-              "line": 64,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 66,
-              "column": 3
-            },
-            "end": {
-              "line": 69,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 71,
-              "column": 3
-            },
-            "end": {
-              "line": 74,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_earliestBefore",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 76,
-              "column": 3
-            },
-            "end": {
-              "line": 79,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_tooltip",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 81,
-              "column": 3
-            },
-            "end": {
-              "line": 84,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "formatter",
@@ -12388,11 +13333,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 104,
+              "line": 40,
               "column": 3
             },
             "end": {
-              "line": 107,
+              "line": 43,
               "column": 4
             }
           },
@@ -12401,29 +13346,7 @@
               "readOnly": true
             }
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "locale",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 108,
-              "column": 3
-            },
-            "end": {
-              "line": 111,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         }
       ],
       "methods": [
@@ -12434,11 +13357,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -12453,11 +13376,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -12476,11 +13399,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -12499,11 +13422,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -12518,11 +13441,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -12537,11 +13460,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -12556,11 +13479,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -12579,11 +13502,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -12597,23 +13520,25 @@
         },
         {
           "name": "getString",
-          "description": "",
+          "description": "Get date of item as string",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 233,
+              "line": 101,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 110,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "item"
+              "name": "item",
+              "type": "Object",
+              "description": "Item to be processed"
             },
             {
               "name": "valuePath = this.valuePath"
@@ -12622,21 +13547,24 @@
               "name": "formatter = this.formatter"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "return": {
+            "type": "String",
+            "desc": "Date rendered as string or 'Invalid Date'"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "toXlsxValue",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 291,
-              "column": 2
+              "line": 78,
+              "column": 3
             },
             "end": {
-              "line": 296,
-              "column": 3
+              "line": 89,
+              "column": 4
             }
           },
           "metadata": {},
@@ -12647,8 +13575,7 @@
             {
               "name": "valuePath = this.valuePath"
             }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          ]
         },
         {
           "name": "valuePathChanged",
@@ -12657,11 +13584,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -12678,29 +13605,26 @@
         },
         {
           "name": "getComparableValue",
-          "description": "",
+          "description": "Get comparable number from date",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 217,
+              "line": 84,
               "column": 2
             },
             "end": {
-              "line": 223,
+              "line": 90,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "params": [],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Valid value or void"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "_valueChanged",
@@ -12709,11 +13633,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -12732,11 +13656,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -12762,23 +13686,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 253,
+              "line": 187,
               "column": 2
             },
             "end": {
-              "line": 258,
+              "line": 195,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "filter = this.filter"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "resetFilter",
@@ -12787,11 +13707,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
@@ -12800,36 +13720,55 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
-          "name": "_getDefaultFilter",
+          "name": "hasFilter",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 284,
+              "line": 328,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 335,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_getDefaultFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 251,
+              "column": 2
+            },
+            "end": {
+              "line": 256,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applySingleFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 259,
+              "line": 197,
               "column": 2
             },
             "end": {
-              "line": 268,
+              "line": 211,
               "column": 3
             }
           },
@@ -12842,7 +13781,7 @@
               "name": "item"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applyMultiFilter",
@@ -12851,11 +13790,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 367,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 372,
+              "line": 409,
               "column": 3
             }
           },
@@ -12877,11 +13816,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -12896,11 +13835,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -12915,17 +13854,63 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 337,
+              "column": 2
+            },
+            "end": {
+              "line": 348,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filter = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 350,
+              "column": 2
+            },
+            "end": {
+              "line": 364,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_argumentsToObject",
@@ -13048,19 +14033,19 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "bower_components/cosmoz-i18next/cosmoz-i18next.js",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
               "line": 65,
               "column": 2
             },
             "end": {
-              "line": 70,
+              "line": 67,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "gettext",
@@ -13199,65 +14184,123 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "_computeFormatter",
+          "name": "toNumber",
+          "description": "Converts a value to number optionaly limiting it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 93,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "(Number|*)",
+              "description": "The value to convert to number"
+            },
+            {
+              "name": "limit",
+              "type": "(Number|*)",
+              "description": "The value used to limit the number"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "The function used to limit the number (Math.min|Math.max)"
+            }
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Value converted to Number or void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "toValue",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
+              "line": 75,
+              "column": 2
+            },
+            "end": {
+              "line": 77,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "renderValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
               "line": 118,
-              "column": 2
-            },
-            "end": {
-              "line": 120,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "locale"
+              "name": "value"
+            },
+            {
+              "name": "formatter = this.formatter"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
-          "name": "_getMinMax",
+          "name": "getInputString",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 122,
+              "line": 140,
               "column": 2
             },
             "end": {
-              "line": 146,
+              "line": 143,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "firstRaw"
+              "name": "item"
             },
             {
-              "name": "secondRaw"
-            },
-            {
-              "name": "max"
+              "name": "valuePath = this.valuePath"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
-          "name": "_computePossibleDateRange",
-          "description": "",
+          "name": "_computeRange",
+          "description": "Computes min/max range from values.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 148,
+              "line": 151,
               "column": 2
             },
             "end": {
@@ -13268,23 +14311,84 @@
           "metadata": {},
           "params": [
             {
+              "name": "change",
+              "type": "Object",
+              "description": "`values` property changes"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Computed min/max"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeLimit",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 170,
+              "column": 2
+            },
+            "end": {
+              "line": 185,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "range"
+            },
+            {
+              "name": "inputChange"
+            },
+            {
+              "name": "min"
+            },
+            {
+              "name": "max"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeFilterText",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 213,
+              "column": 2
+            },
+            "end": {
+              "line": 230,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
               "name": "change"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_computeTooltip",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 170,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 176,
+              "line": 237,
               "column": 3
             }
           },
@@ -13294,121 +14398,47 @@
               "name": "title"
             },
             {
-              "name": "filterText"
+              "name": "text"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
-          "name": "_formatISODate",
+          "name": "_fromInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 64,
+              "column": 3
+            },
+            "end": {
+              "line": 76,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            },
+            {
+              "name": "property"
+            }
+          ]
+        },
+        {
+          "name": "_toInputString",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 178,
+              "line": 124,
               "column": 2
             },
             "end": {
-              "line": 183,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filterValue"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_computeFilterText",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 185,
-              "column": 2
-            },
-            "end": {
-              "line": 200,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filterNotify"
-            },
-            {
-              "name": "formatter = this.formatter"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_dateValueChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 202,
-              "column": 2
-            },
-            "end": {
-              "line": 215,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "renderISODateValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 225,
-              "column": 2
-            },
-            "end": {
-              "line": 231,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "getDate",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 243,
-              "column": 2
-            },
-            "end": {
-              "line": 251,
+              "line": 130,
               "column": 3
             }
           },
@@ -13418,89 +14448,86 @@
               "name": "value"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
-          "name": "_isValidDate",
+          "name": "_filterInputChanged",
+          "description": "Observes changes of _filterInput, saves the path, debounces _limitInput.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 264,
+              "column": 2
+            },
+            "end": {
+              "line": 268,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "'_filterInput' property changes"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limitInput",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
               "line": 270,
               "column": 2
             },
             "end": {
-              "line": 282,
+              "line": 289,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
-          "name": "_toISOString",
+          "name": "_updateFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
               "line": 291,
               "column": 2
             },
             "end": {
-              "line": 303,
+              "line": 304,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "date"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toStringValue",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 305,
-              "column": 2
-            },
-            "end": {
-              "line": 310,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_filterChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 312,
+              "line": 306,
               "column": 2
             },
             "end": {
-              "line": 328,
+              "line": 326,
               "column": 3
             }
           },
@@ -13510,33 +14537,164 @@
               "name": "change"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
-          "name": "_filterInputChanged",
+          "name": "_toHashString",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 330,
+              "line": 366,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 372,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "start"
-            },
-            {
-              "name": "end"
+              "name": "value"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_fromHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 374,
+              "column": 2
+            },
+            "end": {
+              "line": 376,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            },
+            {
+              "name": "property"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "toDate",
+          "description": "Converts an value to date optionaly limiting it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 2
+            },
+            "end": {
+              "line": 73,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "(Date|String)",
+              "description": "Value to convert to date"
+            },
+            {
+              "name": "limit",
+              "type": "(Date|String)",
+              "description": "Value used to limit the date"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "Function used to limit the date (Math.min|Math.max)"
+            }
+          ],
+          "return": {
+            "type": "(Date|void)",
+            "desc": "Value converted to date optionaly limitated"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "_computeFormatter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 120,
+              "column": 2
+            },
+            "end": {
+              "line": 122,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "locale"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "_dateValueChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 132,
+              "column": 2
+            },
+            "end": {
+              "line": 143,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "_toLocalISOString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 145,
+              "column": 2
+            },
+            "end": {
+              "line": 157,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "date"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         }
       ],
       "staticMethods": [],
@@ -13544,11 +14702,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 38,
+          "line": 42,
           "column": 10
         },
         "end": {
-          "line": 46,
+          "line": 90,
           "column": 3
         }
       },
@@ -13701,21 +14859,21 @@
         },
         {
           "name": "bind-values",
-          "description": "Ask for a list of values",
+          "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 9,
+              "line": 6,
               "column": 3
             },
             "end": {
-              "line": 13,
+              "line": 10,
               "column": 4
             }
           },
           "metadata": {},
           "type": "boolean",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -13739,19 +14897,19 @@
           "name": "values",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 29,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 34,
+              "line": 17,
               "column": 4
             }
           },
           "metadata": {},
           "type": "Array",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sort-on",
@@ -13813,17 +14971,17 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 86,
+              "line": 22,
               "column": 3
             },
             "end": {
-              "line": 89,
+              "line": 25,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "edit-width",
@@ -13831,17 +14989,49 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 91,
+              "line": 27,
               "column": 3
             },
             "end": {
-              "line": 94,
+              "line": 30,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 49,
+              "column": 4
+            },
+            "end": {
+              "line": 52,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "edit-min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 53,
+              "column": 4
+            },
+            "end": {
+              "line": 56,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
         },
         {
           "name": "flex",
@@ -13849,17 +15039,17 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 100,
+              "line": 36,
               "column": 3
             },
             "end": {
-              "line": 103,
+              "line": 39,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "cell-class",
@@ -13867,11 +15057,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -13883,19 +15073,17 @@
           "name": "header-cell-class",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
-              "column": 3
+              "line": 45,
+              "column": 4
             },
             "end": {
-              "line": 145,
-              "column": 4
+              "line": 48,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string",
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          "type": "string"
         },
         {
           "name": "style-module",
@@ -13903,11 +15091,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -13921,11 +15109,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -13939,11 +15127,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -13957,11 +15145,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -13975,11 +15163,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -13993,11 +15181,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -14011,11 +15199,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -14042,40 +15230,58 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 15,
-              "column": 3
-            },
-            "end": {
-              "line": 20,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "type": "Date",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
           "name": "min",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 22,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 27,
+              "line": 15,
               "column": 4
             }
           },
           "metadata": {},
           "type": "Date",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "max",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 7,
+              "column": 3
+            },
+            "end": {
+              "line": 10,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "Date",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "locale",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "formatter",
@@ -14083,35 +15289,17 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 104,
+              "line": 40,
               "column": 3
             },
             "end": {
-              "line": 107,
+              "line": 43,
               "column": 4
             }
           },
           "metadata": {},
           "type": "Object",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "locale",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 108,
-              "column": 3
-            },
-            "end": {
-              "line": 111,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         }
       ],
       "events": [
@@ -15575,9 +16763,9 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
-          "name": "flex",
+          "name": "minWidth",
           "type": "string",
-          "description": "Width growing factor for this column.",
+          "description": "The minimum width of this column.",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
@@ -15587,6 +16775,50 @@
             },
             "end": {
               "line": 135,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "The minimum width of this column in edit mode.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "type": "string",
+          "description": "Width growing factor for this column.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
               "column": 4
             }
           },
@@ -15604,11 +16836,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -15626,11 +16858,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -15648,11 +16880,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -15669,11 +16901,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -15691,11 +16923,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -15713,11 +16945,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -15736,11 +16968,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -15759,11 +16991,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -15780,11 +17012,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -15803,11 +17035,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -15825,11 +17057,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -15847,11 +17079,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -15932,11 +17164,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -15951,11 +17183,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -15974,11 +17206,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -15997,11 +17229,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -16016,11 +17248,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -16035,11 +17267,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -16054,11 +17286,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -16077,11 +17309,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -16100,11 +17332,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 283,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 305,
               "column": 3
             }
           },
@@ -16126,11 +17358,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 291,
+              "line": 307,
               "column": 2
             },
             "end": {
-              "line": 296,
+              "line": 312,
               "column": 3
             }
           },
@@ -16152,11 +17384,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -16178,11 +17410,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 310,
+              "line": 326,
               "column": 2
             },
             "end": {
-              "line": 312,
+              "line": 328,
               "column": 3
             }
           },
@@ -16204,11 +17436,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -16227,11 +17459,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -16259,11 +17491,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 336,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 347,
+              "line": 363,
               "column": 3
             }
           },
@@ -16278,16 +17510,45 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "hasFilter",
+          "description": "Returns whether `filterNotify.base` or `filter` is set to a usable value.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 374,
+              "column": 2
+            },
+            "end": {
+              "line": 385,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filterNotify",
+              "type": "(Object|void)",
+              "description": "filter.*"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "True if filter or filterNotify.base is set"
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -16297,11 +17558,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 353,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 394,
               "column": 3
             }
           },
@@ -16364,11 +17625,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -16383,11 +17644,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -16402,16 +17663,62 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 423,
+              "column": 2
+            },
+            "end": {
+              "line": 441,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 443,
+              "column": 2
+            },
+            "end": {
+              "line": 453,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -17066,8 +18373,8 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
-          "name": "flex",
-          "description": "Width growing factor for this column.",
+          "name": "min-width",
+          "description": "The minimum width of this column.",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
@@ -17084,16 +18391,52 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "edit-min-width",
+          "description": "The minimum width of this column in edit mode.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "description": "Width growing factor for this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
           "name": "cell-class",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -17107,11 +18450,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -17125,11 +18468,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -17143,11 +18486,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -17161,11 +18504,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -17179,11 +18522,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -17197,11 +18540,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -17215,11 +18558,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -17233,11 +18576,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -17682,9 +19025,9 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
-          "name": "flex",
+          "name": "minWidth",
           "type": "string",
-          "description": "Width growing factor for this column.",
+          "description": "The minimum width of this column.",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
@@ -17694,6 +19037,50 @@
             },
             "end": {
               "line": 135,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "The minimum width of this column in edit mode.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "type": "string",
+          "description": "Width growing factor for this column.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
               "column": 4
             }
           },
@@ -17711,11 +19098,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -17733,11 +19120,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -17755,11 +19142,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -17776,11 +19163,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -17798,11 +19185,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -17820,11 +19207,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -17843,11 +19230,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -17866,11 +19253,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -17887,11 +19274,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -17910,11 +19297,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -17932,11 +19319,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -17954,11 +19341,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -18057,11 +19444,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -18076,11 +19463,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -18099,11 +19486,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -18122,11 +19509,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -18141,11 +19528,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -18160,11 +19547,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -18179,11 +19566,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -18202,11 +19589,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -18249,11 +19636,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 291,
+              "line": 307,
               "column": 2
             },
             "end": {
-              "line": 296,
+              "line": 312,
               "column": 3
             }
           },
@@ -18275,11 +19662,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -18301,11 +19688,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 310,
+              "line": 326,
               "column": 2
             },
             "end": {
-              "line": 312,
+              "line": 328,
               "column": 3
             }
           },
@@ -18327,11 +19714,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -18350,11 +19737,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -18382,11 +19769,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 336,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 347,
+              "line": 363,
               "column": 3
             }
           },
@@ -18401,16 +19788,45 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "hasFilter",
+          "description": "Returns whether `filterNotify.base` or `filter` is set to a usable value.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 374,
+              "column": 2
+            },
+            "end": {
+              "line": 385,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filterNotify",
+              "type": "(Object|void)",
+              "description": "filter.*"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "True if filter or filterNotify.base is set"
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -18420,11 +19836,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 353,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 394,
               "column": 3
             }
           },
@@ -18487,11 +19903,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -18506,11 +19922,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -18525,16 +19941,62 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 423,
+              "column": 2
+            },
+            "end": {
+              "line": 441,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 443,
+              "column": 2
+            },
+            "end": {
+              "line": 453,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
@@ -19152,8 +20614,8 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
-          "name": "flex",
-          "description": "Width growing factor for this column.",
+          "name": "min-width",
+          "description": "The minimum width of this column.",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
@@ -19170,16 +20632,52 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "edit-min-width",
+          "description": "The minimum width of this column in edit mode.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "description": "Width growing factor for this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
           "name": "cell-class",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -19193,11 +20691,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 161,
               "column": 4
             }
           },
@@ -19211,11 +20709,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -19229,11 +20727,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -19247,11 +20745,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -19265,11 +20763,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -19283,11 +20781,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -19301,11 +20799,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -19319,11 +20817,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -19611,13 +21109,14 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 41,
-              "column": 4
+              "line": 6,
+              "column": 3
             },
             "end": {
-              "line": 45,
-              "column": 5
+              "line": 10,
+              "column": 4
             }
           },
           "metadata": {
@@ -19625,7 +21124,8 @@
               "readOnly": true
             }
           },
-          "defaultValue": "true"
+          "defaultValue": "true",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -19654,19 +21154,21 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 87,
-              "column": 4
+              "line": 12,
+              "column": 3
             },
             "end": {
-              "line": 92,
-              "column": 5
+              "line": 17,
+              "column": 4
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "[]"
+          "defaultValue": "[]",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sortOn",
@@ -19761,11 +21263,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 60,
+              "line": 59,
               "column": 5
             }
           },
@@ -19775,9 +21277,9 @@
           "defaultValue": "\"30px\""
         },
         {
-          "name": "flex",
+          "name": "minWidth",
           "type": "string",
-          "description": "Width growing factor for this column.",
+          "description": "The minimum width of this column.",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
@@ -19787,6 +21289,50 @@
             },
             "end": {
               "line": 135,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "The minimum width of this column in edit mode.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"40px\"",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "type": "string",
+          "description": "Width growing factor for this column.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
               "column": 4
             }
           },
@@ -19803,11 +21349,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 51,
               "column": 5
             }
           },
@@ -19823,11 +21369,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 60,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 63,
               "column": 5
             }
           },
@@ -19844,11 +21390,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -19865,11 +21411,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -19887,11 +21433,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -19909,11 +21455,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -19932,11 +21478,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -19955,11 +21501,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -19976,11 +21522,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -19999,11 +21545,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -20021,11 +21567,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -20043,11 +21589,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -20079,45 +21625,26 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "formatter",
-          "type": "Object",
+          "name": "min",
+          "type": "number",
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 61,
-              "column": 4
+              "line": 19,
+              "column": 3
             },
             "end": {
-              "line": 64,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "locale",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 69,
+              "line": 22,
               "column": 4
-            },
-            "end": {
-              "line": 72,
-              "column": 5
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "null"
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "max",
@@ -20125,18 +21652,134 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 73,
-              "column": 4
+              "line": 24,
+              "column": 3
             },
             "end": {
-              "line": 75,
-              "column": 5
+              "line": 27,
+              "column": 4
             }
           },
           "metadata": {
             "polymer": {}
-          }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_filterInput",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 34,
+              "column": 3
+            },
+            "end": {
+              "line": 39,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_range",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 41,
+              "column": 3
+            },
+            "end": {
+              "line": 44,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limit",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 46,
+              "column": 3
+            },
+            "end": {
+              "line": 52,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "defaultValue": "{}",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_tooltip",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 3
+            },
+            "end": {
+              "line": 57,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "maximumFractionDigits",
@@ -20145,11 +21788,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 64,
               "column": 4
             },
             "end": {
-              "line": 79,
+              "line": 67,
               "column": 5
             }
           },
@@ -20165,11 +21808,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 83,
+              "line": 71,
               "column": 5
             }
           },
@@ -20179,41 +21822,24 @@
           "defaultValue": "null"
         },
         {
-          "name": "min",
-          "type": "number",
+          "name": "formatter",
+          "type": "Object",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 84,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 86,
+              "line": 75,
               "column": 5
             }
           },
           "metadata": {
-            "polymer": {}
-          }
-        },
-        {
-          "name": "_filterInput",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 93,
-              "column": 4
-            },
-            "end": {
-              "line": 101,
-              "column": 5
+            "polymer": {
+              "readOnly": true
             }
-          },
-          "metadata": {
-            "polymer": {}
           }
         },
         {
@@ -20223,158 +21849,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 102,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 105,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_fromMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 106,
-              "column": 4
-            },
-            "end": {
-              "line": 109,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_fromMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 110,
-              "column": 4
-            },
-            "end": {
-              "line": 113,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_numberFormatOptions",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 114,
-              "column": 4
-            },
-            "end": {
-              "line": 117,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_possibleNumberRange",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 118,
-              "column": 4
-            },
-            "end": {
-              "line": 121,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_toMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 122,
-              "column": 4
-            },
-            "end": {
-              "line": 125,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_toMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 126,
-              "column": 4
-            },
-            "end": {
-              "line": 129,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "_tooltip",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 130,
-              "column": 4
-            },
-            "end": {
-              "line": 133,
+              "line": 79,
               "column": 5
             }
           },
@@ -20393,11 +21872,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -20412,11 +21891,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -20435,11 +21914,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -20458,11 +21937,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -20477,11 +21956,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -20496,11 +21975,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -20515,11 +21994,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -20538,11 +22017,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -20559,37 +22038,13 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 251,
-              "column": 3
-            },
-            "end": {
-              "line": 261,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath = this.valuePath"
-            }
-          ]
-        },
-        {
-          "name": "toXlsxValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
-            "start": {
-              "line": 291,
+              "line": 125,
               "column": 2
             },
             "end": {
-              "line": 296,
+              "line": 135,
               "column": 3
             }
           },
@@ -20602,7 +22057,33 @@
               "name": "valuePath = this.valuePath"
             }
           ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "toXlsxValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 117,
+              "column": 2
+            },
+            "end": {
+              "line": 123,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath = this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "valuePathChanged",
@@ -20611,11 +22092,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -20632,27 +22113,37 @@
         },
         {
           "name": "getComparableValue",
-          "description": "",
+          "description": "Get the comparable value of an item.",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 269,
-              "column": 3
+              "line": 106,
+              "column": 2
             },
             "end": {
-              "line": 274,
-              "column": 4
+              "line": 115,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "item"
+              "name": "item",
+              "type": "Object",
+              "description": "Item to be processed"
             },
             {
-              "name": "valuePath"
+              "name": "valuePath",
+              "type": "String",
+              "description": "Property path"
             }
-          ]
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Valid value or void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_valueChanged",
@@ -20661,11 +22152,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -20684,11 +22175,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -20714,17 +22205,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 263,
-              "column": 3
+              "line": 187,
+              "column": 2
             },
             "end": {
-              "line": 267,
-              "column": 4
+              "line": 195,
+              "column": 3
             }
           },
           "metadata": {},
-          "params": []
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "resetFilter",
@@ -20733,11 +22226,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
@@ -20746,34 +22239,56 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "hasFilter",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 328,
+              "column": 2
+            },
+            "end": {
+              "line": 335,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
           "name": "_getDefaultFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 300,
-              "column": 3
+              "line": 251,
+              "column": 2
             },
             "end": {
-              "line": 305,
-              "column": 4
+              "line": 256,
+              "column": 3
             }
           },
           "metadata": {},
-          "params": []
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applySingleFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 276,
-              "column": 3
+              "line": 197,
+              "column": 2
             },
             "end": {
-              "line": 290,
-              "column": 4
+              "line": 211,
+              "column": 3
             }
           },
           "metadata": {},
@@ -20784,7 +22299,8 @@
             {
               "name": "item"
             }
-          ]
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applyMultiFilter",
@@ -20793,11 +22309,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 367,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 372,
+              "line": 409,
               "column": 3
             }
           },
@@ -20819,11 +22335,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -20838,11 +22354,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -20857,17 +22373,63 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 337,
+              "column": 2
+            },
+            "end": {
+              "line": 348,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filter = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 350,
+              "column": 2
+            },
+            "end": {
+              "line": 364,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_argumentsToObject",
@@ -20990,19 +22552,19 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "bower_components/cosmoz-i18next/cosmoz-i18next.js",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
               "line": 65,
               "column": 2
             },
             "end": {
-              "line": 70,
+              "line": 67,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "gettext",
@@ -21141,243 +22703,100 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "_computeFilterText",
-          "description": "",
-          "privacy": "protected",
+          "name": "toNumber",
+          "description": "Converts a value to number optionaly limiting it.",
+          "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 140,
-              "column": 3
+              "line": 77,
+              "column": 2
             },
             "end": {
-              "line": 152,
-              "column": 4
+              "line": 93,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "locale"
+              "name": "value",
+              "type": "(Number|*)",
+              "description": "The value to convert to number"
             },
             {
-              "name": "filterNotify"
+              "name": "limit",
+              "type": "(Number|*)",
+              "description": "The value used to limit the number"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "The function used to limit the number (Math.min|Math.max)"
             }
-          ]
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Value converted to Number or void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
-          "name": "_computeFormatter",
+          "name": "toValue",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 154,
-              "column": 3
+              "line": 95,
+              "column": 2
             },
             "end": {
-              "line": 156,
-              "column": 4
+              "line": 97,
+              "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "locale"
-            },
-            {
-              "name": "_numberFormatOptions"
-            }
-          ]
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
-          "name": "_computePossibleNumberRange",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 158,
-              "column": 3
-            },
-            "end": {
-              "line": 176,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "change"
-            }
-          ]
-        },
-        {
-          "name": "_computeTooltip",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 178,
-              "column": 3
-            },
-            "end": {
-              "line": 184,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "title"
-            },
-            {
-              "name": "filterText"
-            }
-          ]
-        },
-        {
-          "name": "_debounceSetFilter",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 186,
-              "column": 3
-            },
-            "end": {
-              "line": 188,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_enforceLowestMax",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 190,
-              "column": 3
-            },
-            "end": {
-              "line": 197,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "minRangeValue"
-            },
-            {
-              "name": "minRangeMax"
-            }
-          ]
-        },
-        {
-          "name": "_enforceHighestMin",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 199,
-              "column": 3
-            },
-            "end": {
-              "line": 206,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "maxRangeValue"
-            },
-            {
-              "name": "maxRangeMin"
-            }
-          ]
-        },
-        {
-          "name": "_setFilter",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 208,
-              "column": 3
-            },
-            "end": {
-              "line": 216,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_getMinMax",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 218,
-              "column": 3
-            },
-            "end": {
-              "line": 236,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "first"
-            },
-            {
-              "name": "second"
-            },
-            {
-              "name": "max"
-            }
-          ]
-        },
-        {
-          "name": "_computeNumberFormatOptions",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 238,
-              "column": 3
-            },
-            "end": {
-              "line": 249,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "minimumFractionDigits"
-            },
-            {
-              "name": "maximumFractionDigits"
-            }
-          ]
-        },
-        {
-          "name": "renderNumberValue",
+          "name": "renderValue",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 292,
+              "line": 95,
               "column": 3
             },
             "end": {
-              "line": 298,
+              "line": 101,
               "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            },
+            {
+              "name": "formatter = this.formatter"
+            }
+          ]
+        },
+        {
+          "name": "getInputString",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 2
+            },
+            "end": {
+              "line": 143,
+              "column": 3
             }
           },
           "metadata": {},
@@ -21386,10 +22805,329 @@
               "name": "item"
             },
             {
-              "name": "valuePath"
+              "name": "valuePath = this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeRange",
+          "description": "Computes min/max range from values.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 151,
+              "column": 2
+            },
+            "end": {
+              "line": 168,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "`values` property changes"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Computed min/max"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeLimit",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 170,
+              "column": 2
+            },
+            "end": {
+              "line": 185,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "range"
             },
             {
-              "name": "formatter"
+              "name": "inputChange"
+            },
+            {
+              "name": "min"
+            },
+            {
+              "name": "max"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeFilterText",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 213,
+              "column": 2
+            },
+            "end": {
+              "line": 230,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeTooltip",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "title"
+            },
+            {
+              "name": "text"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_fromInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 239,
+              "column": 2
+            },
+            "end": {
+              "line": 241,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_toInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 243,
+              "column": 2
+            },
+            "end": {
+              "line": 249,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_filterInputChanged",
+          "description": "Observes changes of _filterInput, saves the path, debounces _limitInput.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 264,
+              "column": 2
+            },
+            "end": {
+              "line": 268,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "'_filterInput' property changes"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limitInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 270,
+              "column": 2
+            },
+            "end": {
+              "line": 289,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_updateFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 291,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_filterChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 326,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_toHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 366,
+              "column": 2
+            },
+            "end": {
+              "line": 372,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_fromHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 374,
+              "column": 2
+            },
+            "end": {
+              "line": 376,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            },
+            {
+              "name": "property"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeFormatter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 82,
+              "column": 3
+            },
+            "end": {
+              "line": 93,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "locale"
+            },
+            {
+              "name": "minimumFractionDigits"
+            },
+            {
+              "name": "maximumFractionDigits"
             }
           ]
         }
@@ -21399,11 +23137,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 32,
+          "line": 38,
           "column": 10
         },
         "end": {
-          "line": 306,
+          "line": 102,
           "column": 3
         }
       },
@@ -21558,17 +23296,19 @@
           "name": "bind-values",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 41,
-              "column": 4
+              "line": 6,
+              "column": 3
             },
             "end": {
-              "line": 45,
-              "column": 5
+              "line": 10,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "boolean"
+          "type": "boolean",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -21592,17 +23332,19 @@
           "name": "values",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 87,
-              "column": 4
+              "line": 12,
+              "column": 3
             },
             "end": {
-              "line": 92,
-              "column": 5
+              "line": 17,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "Array"
+          "type": "Array",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sort-on",
@@ -21679,11 +23421,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 60,
+              "line": 59,
               "column": 5
             }
           },
@@ -21691,8 +23433,8 @@
           "type": "string"
         },
         {
-          "name": "flex",
-          "description": "Width growing factor for this column.",
+          "name": "min-width",
+          "description": "The minimum width of this column.",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
@@ -21709,15 +23451,51 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
+          "name": "edit-min-width",
+          "description": "The minimum width of this column in edit mode.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 3
+            },
+            "end": {
+              "line": 143,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "flex",
+          "description": "Width growing factor for this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-behavior.html",
+            "start": {
+              "line": 148,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
           "name": "cell-class",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 51,
               "column": 5
             }
           },
@@ -21729,11 +23507,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 60,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 63,
               "column": 5
             }
           },
@@ -21746,11 +23524,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -21764,11 +23542,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -21782,11 +23560,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -21800,11 +23578,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -21818,11 +23596,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -21836,11 +23614,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -21854,11 +23632,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -21885,63 +23663,69 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "formatter",
+          "name": "min",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 61,
-              "column": 4
+              "line": 19,
+              "column": 3
             },
             "end": {
-              "line": 64,
-              "column": 5
+              "line": 22,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "Object"
-        },
-        {
-          "name": "locale",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 69,
-              "column": 4
-            },
-            "end": {
-              "line": 72,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string"
+          "type": "number",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "max",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 73,
-              "column": 4
+              "line": 24,
+              "column": 3
             },
             "end": {
-              "line": 75,
-              "column": 5
+              "line": 27,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "number"
+          "type": "number",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "locale",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "string",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "maximum-fraction-digits",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 64,
               "column": 4
             },
             "end": {
-              "line": 79,
+              "line": 67,
               "column": 5
             }
           },
@@ -21953,11 +23737,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 83,
+              "line": 71,
               "column": 5
             }
           },
@@ -21965,20 +23749,20 @@
           "type": "number"
         },
         {
-          "name": "min",
+          "name": "formatter",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 84,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 86,
+              "line": 75,
               "column": 5
             }
           },
           "metadata": {},
-          "type": "number"
+          "type": "Object"
         }
       ],
       "events": [
@@ -22192,16 +23976,16 @@
         {
           "name": "bindValues",
           "type": "boolean",
-          "description": "Ask for a list of values",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 9,
+              "line": 6,
               "column": 3
             },
             "end": {
-              "line": 13,
+              "line": 10,
               "column": 4
             }
           },
@@ -22211,7 +23995,7 @@
             }
           },
           "defaultValue": "true",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -22240,13 +24024,13 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 29,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 34,
+              "line": 17,
               "column": 4
             }
           },
@@ -22254,7 +24038,7 @@
             "polymer": {}
           },
           "defaultValue": "[]",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sortOn",
@@ -22330,11 +24114,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 86,
+              "line": 22,
               "column": 3
             },
             "end": {
-              "line": 89,
+              "line": 25,
               "column": 4
             }
           },
@@ -22342,7 +24126,7 @@
             "polymer": {}
           },
           "defaultValue": "\"100px\"",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "editWidth",
@@ -22352,11 +24136,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 91,
+              "line": 27,
               "column": 3
             },
             "end": {
-              "line": 94,
+              "line": 30,
               "column": 4
             }
           },
@@ -22364,7 +24148,47 @@
             "polymer": {}
           },
           "defaultValue": "\"150px\"",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "minWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 63,
+              "column": 4
+            },
+            "end": {
+              "line": 66,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"63px\""
+        },
+        {
+          "name": "editMinWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 68,
+              "column": 4
+            },
+            "end": {
+              "line": 71,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"63px\""
         },
         {
           "name": "flex",
@@ -22374,11 +24198,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 100,
+              "line": 36,
               "column": 3
             },
             "end": {
-              "line": 103,
+              "line": 39,
               "column": 4
             }
           },
@@ -22386,7 +24210,7 @@
             "polymer": {}
           },
           "defaultValue": "\"0\"",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "cellClass",
@@ -22396,11 +24220,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -22416,21 +24240,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
-              "column": 3
+              "line": 58,
+              "column": 4
             },
             "end": {
-              "line": 145,
-              "column": 4
+              "line": 61,
+              "column": 5
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "\"default-header-cell\"",
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          "defaultValue": "\"time-header-cell\""
         },
         {
           "name": "styleModule",
@@ -22440,11 +24262,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -22461,11 +24283,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -22483,11 +24305,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -22505,11 +24327,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -22528,11 +24350,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -22551,11 +24373,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -22572,11 +24394,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -22595,11 +24417,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -22617,11 +24439,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -22639,11 +24461,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -22675,27 +24497,6 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "type": "Date",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 15,
-              "column": 3
-            },
-            "end": {
-              "line": 20,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
           "name": "min",
           "type": "Date",
           "description": "",
@@ -22703,18 +24504,63 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 22,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 27,
+              "line": 15,
               "column": 4
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "max",
+          "type": "Date",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 7,
+              "column": 3
+            },
+            "end": {
+              "line": 10,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_filterInput",
@@ -22722,9 +24568,30 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 36,
+              "line": 34,
+              "column": 3
+            },
+            "end": {
+              "line": 39,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_range",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 41,
               "column": 3
             },
             "end": {
@@ -22733,9 +24600,58 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "readOnly": true
+            }
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limit",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 46,
+              "column": 3
+            },
+            "end": {
+              "line": 52,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "defaultValue": "{}",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_tooltip",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 3
+            },
+            "end": {
+              "line": 57,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_filterText",
@@ -22745,11 +24661,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 46,
+              "line": 17,
               "column": 3
             },
             "end": {
-              "line": 49,
+              "line": 20,
               "column": 4
             }
           },
@@ -22758,168 +24674,7 @@
               "readOnly": true
             }
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_possibleDateRange",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 51,
-              "column": 3
-            },
-            "end": {
-              "line": 54,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_fromMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 56,
-              "column": 3
-            },
-            "end": {
-              "line": 59,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_fromMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 61,
-              "column": 3
-            },
-            "end": {
-              "line": 64,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 66,
-              "column": 3
-            },
-            "end": {
-              "line": 69,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 71,
-              "column": 3
-            },
-            "end": {
-              "line": 74,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_earliestBefore",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 76,
-              "column": 3
-            },
-            "end": {
-              "line": 79,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_tooltip",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 81,
-              "column": 3
-            },
-            "end": {
-              "line": 84,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "formatter",
@@ -22927,42 +24682,22 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 56,
-              "column": 4
+              "line": 40,
+              "column": 3
             },
             "end": {
-              "line": 59,
-              "column": 5
+              "line": 43,
+              "column": 4
             }
           },
           "metadata": {
             "polymer": {
               "readOnly": true
             }
-          }
-        },
-        {
-          "name": "locale",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 108,
-              "column": 3
-            },
-            "end": {
-              "line": 111,
-              "column": 4
-            }
           },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "filterStep",
@@ -22971,11 +24706,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 53,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 56,
               "column": 5
             }
           },
@@ -22991,11 +24726,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 62,
+              "line": 74,
               "column": 3
             },
             "end": {
-              "line": 62,
+              "line": 74,
               "column": 27
             }
           },
@@ -23012,11 +24747,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -23031,11 +24766,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -23054,11 +24789,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -23077,11 +24812,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -23096,11 +24831,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -23115,11 +24850,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -23134,11 +24869,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -23157,11 +24892,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -23175,15 +24910,50 @@
         },
         {
           "name": "getString",
+          "description": "Get date of item as string",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 101,
+              "column": 2
+            },
+            "end": {
+              "line": 110,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item",
+              "type": "Object",
+              "description": "Item to be processed"
+            },
+            {
+              "name": "valuePath = this.valuePath"
+            },
+            {
+              "name": "formatter = this.formatter"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "Date rendered as string or 'Invalid Date'"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "toXlsxValue",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 87,
+              "line": 136,
               "column": 3
             },
             "end": {
-              "line": 89,
+              "line": 141,
               "column": 4
             }
           },
@@ -23198,43 +24968,17 @@
           ]
         },
         {
-          "name": "toXlsxValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
-            "start": {
-              "line": 291,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath = this.valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
-        },
-        {
           "name": "valuePathChanged",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -23251,27 +24995,35 @@
         },
         {
           "name": "getComparableValue",
-          "description": "",
+          "description": "Get the comparable value of an item.",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 121,
               "column": 3
             },
             "end": {
-              "line": 85,
+              "line": 134,
               "column": 4
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "item"
+              "name": "item",
+              "type": "Object",
+              "description": "Item to be processed"
             },
             {
-              "name": "valuePath"
+              "name": "valuePath",
+              "type": "String",
+              "description": "Property path"
             }
-          ]
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Valid value or void"
+          }
         },
         {
           "name": "_valueChanged",
@@ -23280,11 +25032,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -23303,11 +25055,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -23333,23 +25085,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 253,
+              "line": 187,
               "column": 2
             },
             "end": {
-              "line": 258,
+              "line": 195,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "filter = this.filter"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "resetFilter",
@@ -23358,11 +25106,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
@@ -23371,36 +25119,56 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
-          "name": "_getDefaultFilter",
+          "name": "hasFilter",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 284,
+              "line": 328,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 335,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_getDefaultFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 251,
+              "column": 2
+            },
+            "end": {
+              "line": 256,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applySingleFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 110,
-              "column": 3
+              "line": 197,
+              "column": 2
             },
             "end": {
-              "line": 145,
-              "column": 4
+              "line": 211,
+              "column": 3
             }
           },
           "metadata": {},
@@ -23411,7 +25179,8 @@
             {
               "name": "item"
             }
-          ]
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applyMultiFilter",
@@ -23420,11 +25189,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 367,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 372,
+              "line": 409,
               "column": 3
             }
           },
@@ -23446,11 +25215,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -23465,11 +25234,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -23484,17 +25253,63 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 337,
+              "column": 2
+            },
+            "end": {
+              "line": 348,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filter = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 350,
+              "column": 2
+            },
+            "end": {
+              "line": 364,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_argumentsToObject",
@@ -23617,19 +25432,19 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "bower_components/cosmoz-i18next/cosmoz-i18next.js",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
               "line": 65,
               "column": 2
             },
             "end": {
-              "line": 70,
+              "line": 67,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "gettext",
@@ -23768,16 +25583,448 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
+          "name": "toNumber",
+          "description": "Converts a value to number optionaly limiting it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 93,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "(Number|*)",
+              "description": "The value to convert to number"
+            },
+            {
+              "name": "limit",
+              "type": "(Number|*)",
+              "description": "The value used to limit the number"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "The function used to limit the number (Math.min|Math.max)"
+            }
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Value converted to Number or void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "toValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 75,
+              "column": 2
+            },
+            "end": {
+              "line": 77,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "renderValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            },
+            {
+              "name": "formatter = this.formatter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "getInputString",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 2
+            },
+            "end": {
+              "line": 143,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath = this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeRange",
+          "description": "Computes min/max range from values.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 151,
+              "column": 2
+            },
+            "end": {
+              "line": 168,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "`values` property changes"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Computed min/max"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeLimit",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 170,
+              "column": 2
+            },
+            "end": {
+              "line": 185,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "range"
+            },
+            {
+              "name": "inputChange"
+            },
+            {
+              "name": "min"
+            },
+            {
+              "name": "max"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeFilterText",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 213,
+              "column": 2
+            },
+            "end": {
+              "line": 230,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeTooltip",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "title"
+            },
+            {
+              "name": "text"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_fromInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 239,
+              "column": 2
+            },
+            "end": {
+              "line": 241,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_toInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 3
+            },
+            "end": {
+              "line": 95,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "_filterInputChanged",
+          "description": "Observes changes of _filterInput, saves the path, debounces _limitInput.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 264,
+              "column": 2
+            },
+            "end": {
+              "line": 268,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "'_filterInput' property changes"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limitInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 270,
+              "column": 2
+            },
+            "end": {
+              "line": 289,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_updateFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 291,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_filterChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 326,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_toHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 97,
+              "column": 3
+            },
+            "end": {
+              "line": 104,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "_fromHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 106,
+              "column": 3
+            },
+            "end": {
+              "line": 112,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "toDate",
+          "description": "Converts time to date optionaly limiting it.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 84,
+              "column": 3
+            },
+            "end": {
+              "line": 87,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "(Date|Number)",
+              "description": "Date or Timestamp ( miliseconds since property _fixedDate ) to be converted"
+            },
+            {
+              "name": "limit",
+              "type": "(Date|Number)",
+              "description": "Optional value to limit the date."
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "Function used to limit the date (Math.min|Math.max)"
+            }
+          ],
+          "return": {
+            "type": "(Date|void)",
+            "desc": "Value converted to date optionaly limitated"
+          }
+        },
+        {
           "name": "_computeFormatter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 160,
               "column": 3
             },
             "end": {
-              "line": 101,
+              "line": 167,
               "column": 4
             }
           },
@@ -23789,142 +26036,17 @@
           ]
         },
         {
-          "name": "_getMinMax",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 122,
-              "column": 2
-            },
-            "end": {
-              "line": 146,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "firstRaw"
-            },
-            {
-              "name": "secondRaw"
-            },
-            {
-              "name": "max"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_computePossibleDateRange",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 148,
-              "column": 2
-            },
-            "end": {
-              "line": 168,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "change"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_computeTooltip",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 170,
-              "column": 2
-            },
-            "end": {
-              "line": 176,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "title"
-            },
-            {
-              "name": "filterText"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_formatISODate",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 178,
-              "column": 2
-            },
-            "end": {
-              "line": 183,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filterValue"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_computeFilterText",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 170,
-              "column": 3
-            },
-            "end": {
-              "line": 186,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filterNotify"
-            },
-            {
-              "name": "formatter = this.formatter"
-            }
-          ]
-        },
-        {
           "name": "_dateValueChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 202,
+              "line": 132,
               "column": 2
             },
             "end": {
-              "line": 215,
+              "line": 143,
               "column": 3
             }
           },
@@ -23934,92 +26056,20 @@
               "name": "event"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
-          "name": "renderISODateValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 225,
-              "column": 2
-            },
-            "end": {
-              "line": 231,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "getDate",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 243,
-              "column": 2
-            },
-            "end": {
-              "line": 251,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_isValidDate",
+          "name": "_toLocalISOString",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 270,
+              "line": 145,
               "column": 2
             },
             "end": {
-              "line": 282,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toISOString",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 291,
-              "column": 2
-            },
-            "end": {
-              "line": 303,
+              "line": 157,
               "column": 3
             }
           },
@@ -24029,75 +26079,7 @@
               "name": "date"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toStringValue",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 305,
-              "column": 2
-            },
-            "end": {
-              "line": 310,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_filterChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 147,
-              "column": 3
-            },
-            "end": {
-              "line": 160,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "change"
-            }
-          ]
-        },
-        {
-          "name": "_filterInputChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 162,
-              "column": 3
-            },
-            "end": {
-              "line": 168,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "start"
-            },
-            {
-              "name": "end"
-            }
-          ]
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "_timeValueChanged",
@@ -24105,11 +26087,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 143,
               "column": 3
             },
             "end": {
-              "line": 76,
+              "line": 155,
               "column": 4
             }
           },
@@ -24119,27 +26101,6 @@
               "name": "e"
             }
           ]
-        },
-        {
-          "name": "getTime",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 103,
-              "column": 3
-            },
-            "end": {
-              "line": 108,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "input"
-            }
-          ]
         }
       ],
       "staticMethods": [],
@@ -24147,11 +26108,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 10
         },
         "end": {
-          "line": 188,
+          "line": 168,
           "column": 3
         }
       },
@@ -24304,21 +26265,21 @@
         },
         {
           "name": "bind-values",
-          "description": "Ask for a list of values",
+          "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 9,
+              "line": 6,
               "column": 3
             },
             "end": {
-              "line": 13,
+              "line": 10,
               "column": 4
             }
           },
           "metadata": {},
           "type": "boolean",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -24342,19 +26303,19 @@
           "name": "values",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 29,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 34,
+              "line": 17,
               "column": 4
             }
           },
           "metadata": {},
           "type": "Array",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sort-on",
@@ -24416,17 +26377,17 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 86,
+              "line": 22,
               "column": 3
             },
             "end": {
-              "line": 89,
+              "line": 25,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "edit-width",
@@ -24434,17 +26395,49 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 91,
+              "line": 27,
               "column": 3
             },
             "end": {
-              "line": 94,
+              "line": 30,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 63,
+              "column": 4
+            },
+            "end": {
+              "line": 66,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "edit-min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 68,
+              "column": 4
+            },
+            "end": {
+              "line": 71,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
         },
         {
           "name": "flex",
@@ -24452,17 +26445,17 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 100,
+              "line": 36,
               "column": 3
             },
             "end": {
-              "line": 103,
+              "line": 39,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "cell-class",
@@ -24470,11 +26463,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -24486,19 +26479,17 @@
           "name": "header-cell-class",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
-              "column": 3
+              "line": 58,
+              "column": 4
             },
             "end": {
-              "line": 145,
-              "column": 4
+              "line": 61,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string",
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          "type": "string"
         },
         {
           "name": "style-module",
@@ -24506,11 +26497,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -24524,11 +26515,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -24542,11 +26533,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -24560,11 +26551,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -24578,11 +26569,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -24596,11 +26587,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -24614,11 +26605,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -24645,85 +26636,87 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 15,
-              "column": 3
-            },
-            "end": {
-              "line": 20,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "type": "Date",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
           "name": "min",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 22,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 27,
+              "line": 15,
               "column": 4
             }
           },
           "metadata": {},
           "type": "Date",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
-          "name": "formatter",
+          "name": "max",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 56,
-              "column": 4
+              "line": 7,
+              "column": 3
             },
             "end": {
-              "line": 59,
-              "column": 5
+              "line": 10,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "Object"
+          "type": "Date",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "locale",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 108,
+              "line": 29,
               "column": 3
             },
             "end": {
-              "line": 111,
+              "line": 32,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "formatter",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 40,
+              "column": 3
+            },
+            "end": {
+              "line": 43,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "Object",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "filter-step",
           "description": "Specifies the value granularity of the time input's value in the filter.\n1 => full seconds\n0.1 => milliseconds",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 53,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 56,
               "column": 5
             }
           },
@@ -24942,16 +26935,16 @@
         {
           "name": "bindValues",
           "type": "boolean",
-          "description": "Ask for a list of values",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 9,
+              "line": 6,
               "column": 3
             },
             "end": {
-              "line": 13,
+              "line": 10,
               "column": 4
             }
           },
@@ -24961,7 +26954,7 @@
             }
           },
           "defaultValue": "true",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -24990,13 +26983,13 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 29,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 34,
+              "line": 17,
               "column": 4
             }
           },
@@ -25004,7 +26997,7 @@
             "polymer": {}
           },
           "defaultValue": "[]",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sortOn",
@@ -25079,6 +27072,46 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
+              "line": 49,
+              "column": 4
+            },
+            "end": {
+              "line": 52,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"210px\""
+        },
+        {
+          "name": "editWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 4
+            },
+            "end": {
+              "line": 57,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"320px\""
+        },
+        {
+          "name": "minWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
               "line": 59,
               "column": 4
             },
@@ -25090,10 +27123,10 @@
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "\"210px\""
+          "defaultValue": "\"128px\""
         },
         {
-          "name": "editWidth",
+          "name": "editMinWidth",
           "type": "string",
           "description": "",
           "privacy": "public",
@@ -25110,7 +27143,7 @@
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "\"320px\""
+          "defaultValue": "\"128px\""
         },
         {
           "name": "flex",
@@ -25120,11 +27153,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 100,
+              "line": 36,
               "column": 3
             },
             "end": {
-              "line": 103,
+              "line": 39,
               "column": 4
             }
           },
@@ -25132,7 +27165,7 @@
             "polymer": {}
           },
           "defaultValue": "\"0\"",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "cellClass",
@@ -25142,11 +27175,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -25162,21 +27195,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
-              "column": 3
+              "line": 69,
+              "column": 4
             },
             "end": {
-              "line": 145,
-              "column": 4
+              "line": 72,
+              "column": 5
             }
           },
           "metadata": {
             "polymer": {}
           },
-          "defaultValue": "\"default-header-cell\"",
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          "defaultValue": "\"datetime-header-cell\""
         },
         {
           "name": "styleModule",
@@ -25186,11 +27217,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -25207,11 +27238,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -25229,11 +27260,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -25251,11 +27282,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -25274,11 +27305,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -25297,11 +27328,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -25318,11 +27349,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -25341,11 +27372,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 187,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 206,
               "column": 4
             }
           },
@@ -25363,11 +27394,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 192,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 211,
               "column": 4
             }
           },
@@ -25385,11 +27416,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 198,
+              "line": 214,
               "column": 2
             },
             "end": {
-              "line": 198,
+              "line": 214,
               "column": 18
             }
           },
@@ -25421,42 +27452,70 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "type": "Date",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 45,
-              "column": 4
-            },
-            "end": {
-              "line": 50,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          }
-        },
-        {
           "name": "min",
           "type": "Date",
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 52,
-              "column": 4
+              "line": 12,
+              "column": 3
             },
             "end": {
-              "line": 57,
-              "column": 5
+              "line": 15,
+              "column": 4
             }
           },
           "metadata": {
             "polymer": {}
-          }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "max",
+          "type": "Date",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 7,
+              "column": 3
+            },
+            "end": {
+              "line": 10,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "locale",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 29,
+              "column": 3
+            },
+            "end": {
+              "line": 32,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_filterInput",
@@ -25464,9 +27523,30 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 36,
+              "line": 34,
+              "column": 3
+            },
+            "end": {
+              "line": 39,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_range",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 41,
               "column": 3
             },
             "end": {
@@ -25475,9 +27555,58 @@
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "readOnly": true
+            }
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limit",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 46,
+              "column": 3
+            },
+            "end": {
+              "line": 52,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "defaultValue": "{}",
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_tooltip",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 3
+            },
+            "end": {
+              "line": 57,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_filterText",
@@ -25487,11 +27616,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 46,
+              "line": 17,
               "column": 3
             },
             "end": {
-              "line": 49,
+              "line": 20,
               "column": 4
             }
           },
@@ -25500,168 +27629,7 @@
               "readOnly": true
             }
           },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_possibleDateRange",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 51,
-              "column": 3
-            },
-            "end": {
-              "line": 54,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_fromMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 56,
-              "column": 3
-            },
-            "end": {
-              "line": 59,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_fromMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 61,
-              "column": 3
-            },
-            "end": {
-              "line": 64,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toMax",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 66,
-              "column": 3
-            },
-            "end": {
-              "line": 69,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toMin",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 71,
-              "column": 3
-            },
-            "end": {
-              "line": 74,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_earliestBefore",
-          "type": "Object",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 76,
-              "column": 3
-            },
-            "end": {
-              "line": 79,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_tooltip",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 81,
-              "column": 3
-            },
-            "end": {
-              "line": 84,
-              "column": 4
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "formatter",
@@ -25669,42 +27637,22 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 69,
-              "column": 4
+              "line": 40,
+              "column": 3
             },
             "end": {
-              "line": 72,
-              "column": 5
+              "line": 43,
+              "column": 4
             }
           },
           "metadata": {
             "polymer": {
               "readOnly": true
             }
-          }
-        },
-        {
-          "name": "locale",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 108,
-              "column": 3
-            },
-            "end": {
-              "line": 111,
-              "column": 4
-            }
           },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "filterStep",
@@ -25713,11 +27661,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -25735,11 +27683,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 204,
+              "line": 220,
               "column": 2
             },
             "end": {
-              "line": 207,
+              "line": 223,
               "column": 3
             }
           },
@@ -25754,11 +27702,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 209,
+              "line": 225,
               "column": 2
             },
             "end": {
-              "line": 236,
+              "line": 252,
               "column": 3
             }
           },
@@ -25777,11 +27725,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 238,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 258,
               "column": 3
             }
           },
@@ -25800,11 +27748,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 245,
+              "line": 261,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 272,
               "column": 3
             }
           },
@@ -25819,11 +27767,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 258,
+              "line": 274,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 276,
               "column": 3
             }
           },
@@ -25838,11 +27786,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 262,
+              "line": 278,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 283,
               "column": 3
             }
           },
@@ -25857,11 +27805,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 269,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 273,
+              "line": 289,
               "column": 3
             }
           },
@@ -25880,11 +27828,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 279,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 281,
+              "line": 297,
               "column": 3
             }
           },
@@ -25898,23 +27846,25 @@
         },
         {
           "name": "getString",
-          "description": "",
+          "description": "Get date of item as string",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 233,
+              "line": 101,
               "column": 2
             },
             "end": {
-              "line": 242,
+              "line": 110,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "item"
+              "name": "item",
+              "type": "Object",
+              "description": "Item to be processed"
             },
             {
               "name": "valuePath = this.valuePath"
@@ -25923,21 +27873,24 @@
               "name": "formatter = this.formatter"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "return": {
+            "type": "String",
+            "desc": "Date rendered as string or 'Invalid Date'"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "toXlsxValue",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 291,
-              "column": 2
+              "line": 106,
+              "column": 3
             },
             "end": {
-              "line": 296,
-              "column": 3
+              "line": 111,
+              "column": 4
             }
           },
           "metadata": {},
@@ -25948,8 +27901,7 @@
             {
               "name": "valuePath = this.valuePath"
             }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          ]
         },
         {
           "name": "valuePathChanged",
@@ -25958,11 +27910,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 298,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 308,
+              "line": 324,
               "column": 3
             }
           },
@@ -25979,29 +27931,26 @@
         },
         {
           "name": "getComparableValue",
-          "description": "",
+          "description": "Get comparable number from date",
           "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 217,
+              "line": 84,
               "column": 2
             },
             "end": {
-              "line": 223,
+              "line": 90,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "params": [],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Valid value or void"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "_valueChanged",
@@ -26010,11 +27959,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 314,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 323,
+              "line": 339,
               "column": 3
             }
           },
@@ -26033,11 +27982,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 325,
+              "line": 341,
               "column": 2
             },
             "end": {
-              "line": 334,
+              "line": 350,
               "column": 3
             }
           },
@@ -26063,23 +28012,19 @@
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 253,
+              "line": 187,
               "column": 2
             },
             "end": {
-              "line": 258,
+              "line": 195,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "filter = this.filter"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "resetFilter",
@@ -26088,11 +28033,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 349,
+              "line": 365,
               "column": 2
             },
             "end": {
-              "line": 351,
+              "line": 367,
               "column": 3
             }
           },
@@ -26101,36 +28046,55 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
         },
         {
-          "name": "_getDefaultFilter",
+          "name": "hasFilter",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 284,
+              "line": 328,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 335,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_getDefaultFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 251,
+              "column": 2
+            },
+            "end": {
+              "line": 256,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applySingleFilter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 259,
+              "line": 197,
               "column": 2
             },
             "end": {
-              "line": 268,
+              "line": 211,
               "column": 3
             }
           },
@@ -26143,7 +28107,7 @@
               "name": "item"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_applyMultiFilter",
@@ -26152,11 +28116,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 367,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 372,
+              "line": 409,
               "column": 3
             }
           },
@@ -26178,11 +28142,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 374,
+              "line": 411,
               "column": 2
             },
             "end": {
-              "line": 376,
+              "line": 413,
               "column": 3
             }
           },
@@ -26197,11 +28161,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 378,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 417,
               "column": 3
             }
           },
@@ -26216,17 +28180,63 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 382,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 421,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+        },
+        {
+          "name": "_serializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 337,
+              "column": 2
+            },
+            "end": {
+              "line": 348,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "filter = this.filter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_deserializeFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 350,
+              "column": 2
+            },
+            "end": {
+              "line": 364,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "obj"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "_argumentsToObject",
@@ -26349,19 +28359,19 @@
           "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "bower_components/cosmoz-i18next/cosmoz-i18next.js",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
               "line": 65,
               "column": 2
             },
             "end": {
-              "line": 70,
+              "line": 67,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "inheritedFrom": "Cosmoz.TranslatableBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "gettext",
@@ -26500,16 +28510,450 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
+          "name": "toNumber",
+          "description": "Converts a value to number optionaly limiting it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 93,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "(Number|*)",
+              "description": "The value to convert to number"
+            },
+            {
+              "name": "limit",
+              "type": "(Number|*)",
+              "description": "The value used to limit the number"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "The function used to limit the number (Math.min|Math.max)"
+            }
+          ],
+          "return": {
+            "type": "(Number|void)",
+            "desc": "Value converted to Number or void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "toValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 75,
+              "column": 2
+            },
+            "end": {
+              "line": 77,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "renderValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            },
+            {
+              "name": "formatter = this.formatter"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
+          "name": "getInputString",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 140,
+              "column": 2
+            },
+            "end": {
+              "line": 143,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath = this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeRange",
+          "description": "Computes min/max range from values.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 151,
+              "column": 2
+            },
+            "end": {
+              "line": 168,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "`values` property changes"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Computed min/max"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeLimit",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 170,
+              "column": 2
+            },
+            "end": {
+              "line": 185,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "range"
+            },
+            {
+              "name": "inputChange"
+            },
+            {
+              "name": "min"
+            },
+            {
+              "name": "max"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeFilterText",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 213,
+              "column": 2
+            },
+            "end": {
+              "line": 230,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_computeTooltip",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "title"
+            },
+            {
+              "name": "text"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_fromInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 239,
+              "column": 2
+            },
+            "end": {
+              "line": 241,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_toInputString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 81,
+              "column": 3
+            },
+            "end": {
+              "line": 87,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "_filterInputChanged",
+          "description": "Observes changes of _filterInput, saves the path, debounces _limitInput.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 264,
+              "column": 2
+            },
+            "end": {
+              "line": 268,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change",
+              "type": "Object",
+              "description": "'_filterInput' property changes"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_limitInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 270,
+              "column": 2
+            },
+            "end": {
+              "line": 289,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_updateFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 291,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_filterChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-range-behavior.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 326,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "change"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "_toHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 3
+            },
+            "end": {
+              "line": 96,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "_fromHashString",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 98,
+              "column": 3
+            },
+            "end": {
+              "line": 104,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value"
+            }
+          ]
+        },
+        {
+          "name": "toDate",
+          "description": "Converts an value to date optionaly limiting it.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 54,
+              "column": 2
+            },
+            "end": {
+              "line": 73,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "(Date|String)",
+              "description": "Value to convert to date"
+            },
+            {
+              "name": "limit",
+              "type": "(Date|String)",
+              "description": "Value used to limit the date"
+            },
+            {
+              "name": "limitFunc",
+              "type": "Function",
+              "description": "Function used to limit the date (Math.min|Math.max)"
+            }
+          ],
+          "return": {
+            "type": "(Date|void)",
+            "desc": "Value converted to date optionaly limitated"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+        },
+        {
           "name": "_computeFormatter",
           "description": "OVERRIDES",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 114,
               "column": 3
             },
             "end": {
-              "line": 102,
+              "line": 123,
               "column": 4
             }
           },
@@ -26521,144 +28965,17 @@
           ]
         },
         {
-          "name": "_getMinMax",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 122,
-              "column": 2
-            },
-            "end": {
-              "line": 146,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "firstRaw"
-            },
-            {
-              "name": "secondRaw"
-            },
-            {
-              "name": "max"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_computePossibleDateRange",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 148,
-              "column": 2
-            },
-            "end": {
-              "line": 168,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "change"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_computeTooltip",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 170,
-              "column": 2
-            },
-            "end": {
-              "line": 176,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "title"
-            },
-            {
-              "name": "filterText"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_formatISODate",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 178,
-              "column": 2
-            },
-            "end": {
-              "line": 183,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filterValue"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_computeFilterText",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 185,
-              "column": 2
-            },
-            "end": {
-              "line": 200,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filterNotify"
-            },
-            {
-              "name": "formatter = this.formatter"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
           "name": "_dateValueChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 202,
+              "line": 132,
               "column": 2
             },
             "end": {
-              "line": 215,
+              "line": 143,
               "column": 3
             }
           },
@@ -26668,92 +28985,20 @@
               "name": "event"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
-          "name": "renderISODateValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 225,
-              "column": 2
-            },
-            "end": {
-              "line": 231,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "getDate",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 243,
-              "column": 2
-            },
-            "end": {
-              "line": 251,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_isValidDate",
+          "name": "_toLocalISOString",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 270,
+              "line": 145,
               "column": 2
             },
             "end": {
-              "line": 282,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toISOString",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 291,
-              "column": 2
-            },
-            "end": {
-              "line": 303,
+              "line": 157,
               "column": 3
             }
           },
@@ -26763,122 +29008,7 @@
               "name": "date"
             }
           ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_toStringValue",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 103,
-              "column": 3
-            },
-            "end": {
-              "line": 108,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value"
-            }
-          ]
-        },
-        {
-          "name": "_filterChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 312,
-              "column": 2
-            },
-            "end": {
-              "line": 328,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "change"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "_filterInputChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
-            "start": {
-              "line": 330,
-              "column": 2
-            },
-            "end": {
-              "line": 340,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "start"
-            },
-            {
-              "name": "end"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
-        },
-        {
-          "name": "renderISODateTimeValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 81,
-              "column": 3
-            },
-            "end": {
-              "line": 84,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath"
-            }
-          ]
-        },
-        {
-          "name": "_getISODate",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 85,
-              "column": 3
-            },
-            "end": {
-              "line": 90,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filterValue"
-            }
-          ]
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         }
       ],
       "staticMethods": [],
@@ -26886,11 +29016,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 36,
+          "line": 40,
           "column": 10
         },
         "end": {
-          "line": 109,
+          "line": 124,
           "column": 3
         }
       },
@@ -27043,21 +29173,21 @@
         },
         {
           "name": "bind-values",
-          "description": "Ask for a list of values",
+          "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 9,
+              "line": 6,
               "column": 3
             },
             "end": {
-              "line": 13,
+              "line": 10,
               "column": 4
             }
           },
           "metadata": {},
           "type": "boolean",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "name",
@@ -27081,19 +29211,19 @@
           "name": "values",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 29,
+              "line": 12,
               "column": 3
             },
             "end": {
-              "line": 34,
+              "line": 17,
               "column": 4
             }
           },
           "metadata": {},
           "type": "Array",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
         },
         {
           "name": "sort-on",
@@ -27154,6 +29284,38 @@
           "description": "",
           "sourceRange": {
             "start": {
+              "line": 49,
+              "column": 4
+            },
+            "end": {
+              "line": 52,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "edit-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 4
+            },
+            "end": {
+              "line": 57,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "min-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
               "line": 59,
               "column": 4
             },
@@ -27166,7 +29328,7 @@
           "type": "string"
         },
         {
-          "name": "edit-width",
+          "name": "edit-min-width",
           "description": "",
           "sourceRange": {
             "start": {
@@ -27187,17 +29349,17 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 100,
+              "line": 36,
               "column": 3
             },
             "end": {
-              "line": 103,
+              "line": 39,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "cell-class",
@@ -27205,11 +29367,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 137,
+              "line": 153,
               "column": 3
             },
             "end": {
-              "line": 140,
+              "line": 156,
               "column": 4
             }
           },
@@ -27221,19 +29383,17 @@
           "name": "header-cell-class",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 142,
-              "column": 3
+              "line": 69,
+              "column": 4
             },
             "end": {
-              "line": 145,
-              "column": 4
+              "line": 72,
+              "column": 5
             }
           },
           "metadata": {},
-          "type": "string",
-          "inheritedFrom": "Cosmoz.OmnitableColumnBehavior"
+          "type": "string"
         },
         {
           "name": "style-module",
@@ -27241,11 +29401,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 147,
+              "line": 163,
               "column": 3
             },
             "end": {
-              "line": 149,
+              "line": 165,
               "column": 4
             }
           },
@@ -27259,11 +29419,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 155,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 174,
               "column": 4
             }
           },
@@ -27277,11 +29437,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 160,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 179,
               "column": 4
             }
           },
@@ -27295,11 +29455,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 165,
+              "line": 181,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 184,
               "column": 4
             }
           },
@@ -27313,11 +29473,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 170,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 190,
               "column": 4
             }
           },
@@ -27331,11 +29491,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 178,
+              "line": 194,
               "column": 3
             },
             "end": {
-              "line": 180,
+              "line": 196,
               "column": 4
             }
           },
@@ -27349,11 +29509,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-behavior.html",
             "start": {
-              "line": 182,
+              "line": 198,
               "column": 3
             },
             "end": {
-              "line": 185,
+              "line": 201,
               "column": 4
             }
           },
@@ -27380,81 +29540,87 @@
           "inheritedFrom": "Cosmoz.TranslatableBehavior"
         },
         {
-          "name": "max",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 45,
-              "column": 4
-            },
-            "end": {
-              "line": 50,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Date"
-        },
-        {
           "name": "min",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 52,
-              "column": 4
+              "line": 12,
+              "column": 3
             },
             "end": {
-              "line": 57,
-              "column": 5
+              "line": 15,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "Date"
+          "type": "Date",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
-          "name": "formatter",
+          "name": "max",
           "description": "",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
             "start": {
-              "line": 69,
-              "column": 4
+              "line": 7,
+              "column": 3
             },
             "end": {
-              "line": 72,
-              "column": 5
+              "line": 10,
+              "column": 4
             }
           },
           "metadata": {},
-          "type": "Object"
+          "type": "Date",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "locale",
           "description": "",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "file": "cosmoz-omnitable-column-range-behavior.html",
             "start": {
-              "line": 108,
+              "line": 29,
               "column": 3
             },
             "end": {
-              "line": 111,
+              "line": 32,
               "column": 4
             }
           },
           "metadata": {},
           "type": "string",
-          "inheritedFrom": "Cosmoz.DateColumnBehavior"
+          "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+        },
+        {
+          "name": "formatter",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-behavior.html",
+            "start": {
+              "line": 40,
+              "column": 3
+            },
+            "end": {
+              "line": 43,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "Object",
+          "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
         },
         {
           "name": "filter-step",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -27813,12 +29979,14 @@
               "column": 3
             },
             "end": {
-              "line": 109,
+              "line": 110,
               "column": 4
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "notify": true
+            }
           },
           "defaultValue": "false"
         },
@@ -27829,16 +29997,18 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 111,
+              "line": 112,
               "column": 3
             },
             "end": {
-              "line": 114,
+              "line": 116,
               "column": 4
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "notify": true
+            }
           },
           "defaultValue": "\"\""
         },
@@ -27849,11 +30019,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 118,
               "column": 3
             },
             "end": {
-              "line": 119,
+              "line": 121,
               "column": 4
             }
           },
@@ -27870,11 +30040,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 123,
               "column": 3
             },
             "end": {
-              "line": 125,
+              "line": 127,
               "column": 4
             }
           },
@@ -27892,11 +30062,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 129,
+              "line": 131,
               "column": 3
             },
             "end": {
-              "line": 133,
+              "line": 135,
               "column": 4
             }
           },
@@ -27914,11 +30084,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 138,
+              "line": 140,
               "column": 3
             },
             "end": {
-              "line": 143,
+              "line": 145,
               "column": 4
             }
           },
@@ -27937,11 +30107,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 148,
+              "line": 150,
               "column": 3
             },
             "end": {
-              "line": 151,
+              "line": 153,
               "column": 4
             }
           },
@@ -27958,11 +30128,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 160,
               "column": 4
             }
           },
@@ -27977,11 +30147,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 163,
+              "line": 165,
               "column": 3
             },
             "end": {
-              "line": 166,
+              "line": 168,
               "column": 4
             }
           },
@@ -27998,11 +30168,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 171,
+              "line": 173,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 176,
               "column": 4
             }
           },
@@ -28018,11 +30188,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 176,
+              "line": 178,
               "column": 3
             },
             "end": {
-              "line": 179,
+              "line": 181,
               "column": 4
             }
           },
@@ -28038,11 +30208,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 184,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 187,
+              "line": 189,
               "column": 4
             }
           },
@@ -28053,17 +30223,41 @@
           }
         },
         {
+          "name": "visible",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 191,
+              "column": 3
+            },
+            "end": {
+              "line": 197,
+              "column": 4
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"visibleChanged\"",
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
           "name": "visibleColumns",
           "type": "Array",
           "description": "List of <b>visible</b> columns.",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 192,
+              "line": 202,
               "column": 3
             },
             "end": {
-              "line": 196,
+              "line": 206,
               "column": 4
             }
           },
@@ -28081,11 +30275,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 198,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 201,
+              "line": 211,
               "column": 4
             }
           },
@@ -28102,11 +30296,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 203,
+              "line": 213,
               "column": 3
             },
             "end": {
-              "line": 206,
+              "line": 216,
               "column": 4
             }
           },
@@ -28123,11 +30317,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 3
             },
             "end": {
-              "line": 210,
+              "line": 220,
               "column": 4
             }
           },
@@ -28142,18 +30336,16 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 212,
+              "line": 222,
               "column": 3
             },
             "end": {
-              "line": 215,
+              "line": 225,
               "column": 4
             }
           },
           "metadata": {
-            "polymer": {
-              "notify": true
-            }
+            "polymer": {}
           }
         },
         {
@@ -28163,11 +30355,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 216,
+              "line": 226,
               "column": 3
             },
             "end": {
-              "line": 219,
+              "line": 229,
               "column": 4
             }
           },
@@ -28184,11 +30376,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 224,
+              "line": 234,
               "column": 3
             },
             "end": {
-              "line": 226,
+              "line": 236,
               "column": 4
             }
           },
@@ -28203,56 +30395,16 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 283,
+              "line": 294,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 294,
               "column": 31
             }
           },
           "metadata": {
             "polymer": {}
-          }
-        },
-        {
-          "name": "_scalingUp",
-          "type": "boolean",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 285,
-              "column": 2
-            },
-            "end": {
-              "line": 285,
-              "column": 19
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          }
-        },
-        {
-          "name": "_isVisible",
-          "type": "Function",
-          "description": "True if the current list is visible.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 713,
-              "column": 2
-            },
-            "end": {
-              "line": 715,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
           }
         }
       ],
@@ -28282,11 +30434,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 248,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 267,
+              "line": 278,
               "column": 3
             }
           },
@@ -28299,11 +30451,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 269,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 279,
+              "line": 290,
               "column": 3
             }
           },
@@ -28773,11 +30925,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 286,
+              "line": 296,
               "column": 2
             },
             "end": {
-              "line": 288,
+              "line": 298,
               "column": 3
             }
           },
@@ -28794,11 +30946,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 290,
+              "line": 300,
               "column": 2
             },
             "end": {
-              "line": 292,
+              "line": 302,
               "column": 3
             }
           },
@@ -28818,11 +30970,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 294,
+              "line": 304,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 307,
               "column": 3
             }
           },
@@ -28839,11 +30991,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 299,
+              "line": 309,
               "column": 2
             },
             "end": {
-              "line": 301,
+              "line": 311,
               "column": 3
             }
           },
@@ -28858,16 +31010,37 @@
           ]
         },
         {
+          "name": "visibleChanged",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 313,
+              "column": 2
+            },
+            "end": {
+              "line": 317,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "turnedVisible"
+            }
+          ]
+        },
+        {
           "name": "_visibleColumnsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 303,
+              "line": 319,
               "column": 2
             },
             "end": {
-              "line": 306,
+              "line": 322,
               "column": 3
             }
           },
@@ -28880,11 +31053,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 308,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 313,
+              "line": 329,
               "column": 3
             }
           },
@@ -28904,11 +31077,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 315,
+              "line": 331,
               "column": 2
             },
             "end": {
-              "line": 333,
+              "line": 349,
               "column": 3
             }
           },
@@ -28925,11 +31098,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 336,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 349,
+              "line": 365,
               "column": 3
             }
           },
@@ -28946,11 +31119,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 352,
+              "line": 368,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 378,
               "column": 3
             }
           },
@@ -28967,11 +31140,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 364,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 383,
               "column": 3
             }
           },
@@ -28988,11 +31161,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 369,
+              "line": 385,
               "column": 2
             },
             "end": {
-              "line": 371,
+              "line": 388,
               "column": 3
             }
           },
@@ -29005,11 +31178,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 373,
+              "line": 390,
               "column": 2
             },
             "end": {
-              "line": 379,
+              "line": 396,
               "column": 3
             }
           },
@@ -29022,11 +31195,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 381,
+              "line": 398,
               "column": 2
             },
             "end": {
-              "line": 383,
+              "line": 400,
               "column": 3
             }
           },
@@ -29039,11 +31212,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 385,
+              "line": 402,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 461,
               "column": 3
             }
           },
@@ -29056,11 +31229,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 440,
+              "line": 469,
               "column": 2
             },
             "end": {
-              "line": 457,
+              "line": 486,
               "column": 3
             }
           },
@@ -29086,11 +31259,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 460,
+              "line": 489,
               "column": 2
             },
             "end": {
-              "line": 481,
+              "line": 510,
               "column": 3
             }
           },
@@ -29107,11 +31280,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 488,
+              "line": 517,
               "column": 2
             },
             "end": {
-              "line": 497,
+              "line": 526,
               "column": 3
             }
           },
@@ -29140,11 +31313,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 499,
+              "line": 528,
               "column": 2
             },
             "end": {
-              "line": 505,
+              "line": 534,
               "column": 3
             }
           },
@@ -29164,11 +31337,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 507,
+              "line": 536,
               "column": 2
             },
             "end": {
-              "line": 509,
+              "line": 538,
               "column": 3
             }
           },
@@ -29181,11 +31354,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 511,
+              "line": 540,
               "column": 2
             },
             "end": {
-              "line": 531,
+              "line": 560,
               "column": 3
             }
           },
@@ -29198,11 +31371,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 533,
+              "line": 562,
               "column": 2
             },
             "end": {
-              "line": 540,
+              "line": 568,
               "column": 3
             }
           },
@@ -29219,11 +31392,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 542,
+              "line": 570,
               "column": 2
             },
             "end": {
-              "line": 547,
+              "line": 575,
               "column": 3
             }
           },
@@ -29236,11 +31409,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 549,
+              "line": 577,
               "column": 2
             },
             "end": {
-              "line": 615,
+              "line": 645,
               "column": 3
             }
           },
@@ -29253,11 +31426,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 617,
+              "line": 647,
               "column": 2
             },
             "end": {
-              "line": 622,
+              "line": 652,
               "column": 3
             }
           },
@@ -29270,11 +31443,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 630,
+              "line": 660,
               "column": 2
             },
             "end": {
-              "line": 663,
+              "line": 693,
               "column": 3
             }
           },
@@ -29301,11 +31474,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 665,
+              "line": 695,
               "column": 2
             },
             "end": {
-              "line": 709,
+              "line": 739,
               "column": 3
             }
           },
@@ -29318,11 +31491,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 717,
+              "line": 741,
               "column": 2
             },
             "end": {
-              "line": 722,
+              "line": 746,
               "column": 3
             }
           },
@@ -29335,11 +31508,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 729,
+              "line": 753,
               "column": 2
             },
             "end": {
-              "line": 788,
+              "line": 812,
               "column": 3
             }
           },
@@ -29356,11 +31529,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 790,
+              "line": 814,
               "column": 2
             },
             "end": {
-              "line": 807,
+              "line": 831,
               "column": 3
             }
           },
@@ -29377,11 +31550,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 809,
+              "line": 833,
               "column": 2
             },
             "end": {
-              "line": 827,
+              "line": 851,
               "column": 3
             }
           },
@@ -29398,11 +31571,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 829,
+              "line": 853,
               "column": 2
             },
             "end": {
-              "line": 846,
+              "line": 870,
               "column": 3
             }
           },
@@ -29415,11 +31588,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 848,
+              "line": 872,
               "column": 2
             },
             "end": {
-              "line": 856,
+              "line": 880,
               "column": 3
             }
           },
@@ -29432,11 +31605,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 865,
+              "line": 889,
               "column": 2
             },
             "end": {
-              "line": 880,
+              "line": 904,
               "column": 3
             }
           },
@@ -29459,11 +31632,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 882,
+              "line": 906,
               "column": 2
             },
             "end": {
-              "line": 888,
+              "line": 912,
               "column": 3
             }
           },
@@ -29480,11 +31653,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 893,
+              "line": 917,
               "column": 2
             },
             "end": {
-              "line": 912,
+              "line": 936,
               "column": 3
             }
           },
@@ -29500,11 +31673,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 918,
+              "line": 942,
               "column": 2
             },
             "end": {
-              "line": 932,
+              "line": 956,
               "column": 3
             }
           },
@@ -29521,11 +31694,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 939,
+              "line": 963,
               "column": 2
             },
             "end": {
-              "line": 946,
+              "line": 970,
               "column": 3
             }
           },
@@ -29541,11 +31714,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 950,
+              "line": 974,
               "column": 2
             },
             "end": {
-              "line": 952,
+              "line": 976,
               "column": 3
             }
           },
@@ -29562,11 +31735,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 954,
+              "line": 978,
               "column": 2
             },
             "end": {
-              "line": 956,
+              "line": 980,
               "column": 3
             }
           },
@@ -29583,11 +31756,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 963,
+              "line": 987,
               "column": 2
             },
             "end": {
-              "line": 975,
+              "line": 999,
               "column": 3
             }
           },
@@ -29609,11 +31782,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 981,
+              "line": 1005,
               "column": 2
             },
             "end": {
-              "line": 990,
+              "line": 1014,
               "column": 3
             }
           },
@@ -29635,11 +31808,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 992,
+              "line": 1016,
               "column": 2
             },
             "end": {
-              "line": 995,
+              "line": 1019,
               "column": 3
             }
           },
@@ -29656,11 +31829,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1002,
+              "line": 1026,
               "column": 2
             },
             "end": {
-              "line": 1012,
+              "line": 1036,
               "column": 3
             }
           },
@@ -29687,11 +31860,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1014,
+              "line": 1038,
               "column": 2
             },
             "end": {
-              "line": 1018,
+              "line": 1042,
               "column": 3
             }
           },
@@ -29708,11 +31881,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1020,
+              "line": 1044,
               "column": 2
             },
             "end": {
-              "line": 1031,
+              "line": 1055,
               "column": 3
             }
           },
@@ -29729,11 +31902,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1040,
+              "line": 1064,
               "column": 2
             },
             "end": {
-              "line": 1052,
+              "line": 1076,
               "column": 3
             }
           },
@@ -29756,11 +31929,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1058,
+              "line": 1082,
               "column": 2
             },
             "end": {
-              "line": 1063,
+              "line": 1087,
               "column": 3
             }
           },
@@ -29783,11 +31956,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1072,
+              "line": 1096,
               "column": 2
             },
             "end": {
-              "line": 1077,
+              "line": 1101,
               "column": 3
             }
           },
@@ -29819,11 +31992,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1079,
+              "line": 1103,
               "column": 2
             },
             "end": {
-              "line": 1081,
+              "line": 1105,
               "column": 3
             }
           },
@@ -29840,11 +32013,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1083,
+              "line": 1107,
               "column": 2
             },
             "end": {
-              "line": 1085,
+              "line": 1109,
               "column": 3
             }
           },
@@ -29861,11 +32034,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1087,
+              "line": 1111,
               "column": 2
             },
             "end": {
-              "line": 1089,
+              "line": 1113,
               "column": 3
             }
           },
@@ -29882,11 +32055,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1091,
+              "line": 1115,
               "column": 2
             },
             "end": {
-              "line": 1093,
+              "line": 1117,
               "column": 3
             }
           },
@@ -29903,11 +32076,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1095,
+              "line": 1119,
               "column": 2
             },
             "end": {
-              "line": 1105,
+              "line": 1129,
               "column": 3
             }
           },
@@ -29922,61 +32095,16 @@
           ]
         },
         {
-          "name": "_serializeFilter",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 1107,
-              "column": 2
-            },
-            "end": {
-              "line": 1125,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "obj"
-            }
-          ]
-        },
-        {
-          "name": "_deserializeFilter",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 1127,
-              "column": 2
-            },
-            "end": {
-              "line": 1135,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "obj"
-            },
-            {
-              "name": "type = Object"
-            }
-          ]
-        },
-        {
           "name": "_routeHashPropertyChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1137,
+              "line": 1131,
               "column": 2
             },
             "end": {
-              "line": 1143,
+              "line": 1137,
               "column": 3
             }
           },
@@ -29996,11 +32124,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1145,
+              "line": 1139,
               "column": 2
             },
             "end": {
-              "line": 1167,
+              "line": 1161,
               "column": 3
             }
           },
@@ -30020,11 +32148,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1168,
+              "line": 1162,
               "column": 2
             },
             "end": {
-              "line": 1173,
+              "line": 1167,
               "column": 3
             }
           },
@@ -30041,11 +32169,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1174,
+              "line": 1168,
               "column": 2
             },
             "end": {
-              "line": 1188,
+              "line": 1182,
               "column": 3
             }
           },
@@ -30060,31 +32188,21 @@
           ]
         },
         {
-          "name": "_routeHashChanged",
+          "name": "_updateParamsFromHash",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1190,
+              "line": 1184,
               "column": 2
             },
             "end": {
-              "line": 1207,
+              "line": 1192,
               "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "changes"
-            },
-            {
-              "name": "hashParam"
-            },
-            {
-              "name": "columns"
-            }
-          ]
+          "params": []
         },
         {
           "name": "_updateRouteParam",
@@ -30092,11 +32210,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1209,
+              "line": 1194,
               "column": 2
             },
             "end": {
-              "line": 1224,
+              "line": 1208,
               "column": 3
             }
           },
@@ -30113,11 +32231,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1226,
+              "line": 1210,
               "column": 2
             },
             "end": {
-              "line": 1240,
+              "line": 1224,
               "column": 3
             }
           },
@@ -30127,6 +32245,23 @@
               "name": "column"
             }
           ]
+        },
+        {
+          "name": "_fitDropdowns",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 1226,
+              "column": 2
+            },
+            "end": {
+              "line": 1233,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": []
         }
       ],
       "staticMethods": [],
@@ -30143,7 +32278,7 @@
           "column": 9
         },
         "end": {
-          "line": 1241,
+          "line": 1234,
           "column": 2
         }
       },
@@ -30337,7 +32472,7 @@
               "column": 3
             },
             "end": {
-              "line": 109,
+              "line": 110,
               "column": 4
             }
           },
@@ -30349,11 +32484,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 111,
+              "line": 112,
               "column": 3
             },
             "end": {
-              "line": 114,
+              "line": 116,
               "column": 4
             }
           },
@@ -30365,11 +32500,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 118,
               "column": 3
             },
             "end": {
-              "line": 119,
+              "line": 121,
               "column": 4
             }
           },
@@ -30381,11 +32516,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 123,
               "column": 3
             },
             "end": {
-              "line": 125,
+              "line": 127,
               "column": 4
             }
           },
@@ -30397,11 +32532,11 @@
           "description": "The column name to group on.",
           "sourceRange": {
             "start": {
-              "line": 129,
+              "line": 131,
               "column": 3
             },
             "end": {
-              "line": 133,
+              "line": 135,
               "column": 4
             }
           },
@@ -30413,11 +32548,11 @@
           "description": "The column that matches the current `groupOn` value.",
           "sourceRange": {
             "start": {
-              "line": 138,
+              "line": 140,
               "column": 3
             },
             "end": {
-              "line": 143,
+              "line": 145,
               "column": 4
             }
           },
@@ -30429,11 +32564,11 @@
           "description": "Items matching current set filter(s)",
           "sourceRange": {
             "start": {
-              "line": 148,
+              "line": 150,
               "column": 3
             },
             "end": {
-              "line": 151,
+              "line": 153,
               "column": 4
             }
           },
@@ -30445,11 +32580,11 @@
           "description": "Grouped items structure after filtering.",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 158,
+              "line": 160,
               "column": 4
             }
           },
@@ -30461,11 +32596,11 @@
           "description": "Sorted items structure after filtering and grouping.",
           "sourceRange": {
             "start": {
-              "line": 163,
+              "line": 165,
               "column": 3
             },
             "end": {
-              "line": 166,
+              "line": 168,
               "column": 4
             }
           },
@@ -30477,11 +32612,11 @@
           "description": "List of columns definition for this table.",
           "sourceRange": {
             "start": {
-              "line": 184,
+              "line": 186,
               "column": 3
             },
             "end": {
-              "line": 187,
+              "line": 189,
               "column": 4
             }
           },
@@ -30489,15 +32624,31 @@
           "type": "Array"
         },
         {
+          "name": "visible",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 191,
+              "column": 3
+            },
+            "end": {
+              "line": 197,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
           "name": "visible-columns",
           "description": "List of <b>visible</b> columns.",
           "sourceRange": {
             "start": {
-              "line": 192,
+              "line": 202,
               "column": 3
             },
             "end": {
-              "line": 196,
+              "line": 206,
               "column": 4
             }
           },
@@ -30509,11 +32660,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 198,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 201,
+              "line": 211,
               "column": 4
             }
           },
@@ -30525,11 +32676,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 3
             },
             "end": {
-              "line": 210,
+              "line": 220,
               "column": 4
             }
           },
@@ -30548,6 +32699,18 @@
           "type": "CustomEvent",
           "name": "highlighted-items-changed",
           "description": "Fired when the `highlightedItems` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "descending-changed",
+          "description": "Fired when the `descending` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "sort-on-changed",
+          "description": "Fired when the `sortOn` property changes.",
           "metadata": {}
         },
         {
@@ -30572,6 +32735,12 @@
           "type": "CustomEvent",
           "name": "columns-changed",
           "description": "Fired when the `columns` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "visible-changed",
+          "description": "Fired when the `visible` property changes.",
           "metadata": {}
         },
         {
@@ -30643,11 +32812,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 195,
+              "line": 216,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 216,
               "column": 16
             }
           }
@@ -30989,9 +33158,9 @@
               "defaultValue": "\"75px\""
             },
             {
-              "name": "flex",
+              "name": "minWidth",
               "type": "string",
-              "description": "Width growing factor for this column.",
+              "description": "The minimum width of this column.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
@@ -31000,6 +33169,46 @@
                 },
                 "end": {
                   "line": 135,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"40px\""
+            },
+            {
+              "name": "editMinWidth",
+              "type": "string",
+              "description": "The minimum width of this column in edit mode.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 140,
+                  "column": 3
+                },
+                "end": {
+                  "line": 143,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"40px\""
+            },
+            {
+              "name": "flex",
+              "type": "string",
+              "description": "Width growing factor for this column.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 148,
+                  "column": 3
+                },
+                "end": {
+                  "line": 151,
                   "column": 4
                 }
               },
@@ -31015,11 +33224,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 137,
+                  "line": 153,
                   "column": 3
                 },
                 "end": {
-                  "line": 140,
+                  "line": 156,
                   "column": 4
                 }
               },
@@ -31035,11 +33244,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 142,
+                  "line": 158,
                   "column": 3
                 },
                 "end": {
-                  "line": 145,
+                  "line": 161,
                   "column": 4
                 }
               },
@@ -31055,11 +33264,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 147,
+                  "line": 163,
                   "column": 3
                 },
                 "end": {
-                  "line": 149,
+                  "line": 165,
                   "column": 4
                 }
               },
@@ -31074,11 +33283,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 155,
+                  "line": 171,
                   "column": 3
                 },
                 "end": {
-                  "line": 158,
+                  "line": 174,
                   "column": 4
                 }
               },
@@ -31094,11 +33303,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 160,
+                  "line": 176,
                   "column": 3
                 },
                 "end": {
-                  "line": 163,
+                  "line": 179,
                   "column": 4
                 }
               },
@@ -31114,11 +33323,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 165,
+                  "line": 181,
                   "column": 3
                 },
                 "end": {
-                  "line": 168,
+                  "line": 184,
                   "column": 4
                 }
               },
@@ -31135,11 +33344,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 170,
+                  "line": 186,
                   "column": 3
                 },
                 "end": {
-                  "line": 174,
+                  "line": 190,
                   "column": 4
                 }
               },
@@ -31156,11 +33365,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 178,
+                  "line": 194,
                   "column": 3
                 },
                 "end": {
-                  "line": 180,
+                  "line": 196,
                   "column": 4
                 }
               },
@@ -31175,11 +33384,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 182,
+                  "line": 198,
                   "column": 3
                 },
                 "end": {
-                  "line": 185,
+                  "line": 201,
                   "column": 4
                 }
               },
@@ -31196,11 +33405,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 187,
+                  "line": 203,
                   "column": 3
                 },
                 "end": {
-                  "line": 190,
+                  "line": 206,
                   "column": 4
                 }
               },
@@ -31216,11 +33425,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 192,
+                  "line": 208,
                   "column": 3
                 },
                 "end": {
-                  "line": 195,
+                  "line": 211,
                   "column": 4
                 }
               },
@@ -31236,11 +33445,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 198,
+                  "line": 214,
                   "column": 2
                 },
                 "end": {
-                  "line": 198,
+                  "line": 214,
                   "column": 18
                 }
               },
@@ -31256,11 +33465,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 204,
+                  "line": 220,
                   "column": 2
                 },
                 "end": {
-                  "line": 207,
+                  "line": 223,
                   "column": 3
                 }
               },
@@ -31273,11 +33482,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 209,
+                  "line": 225,
                   "column": 2
                 },
                 "end": {
-                  "line": 236,
+                  "line": 252,
                   "column": 3
                 }
               },
@@ -31294,11 +33503,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 238,
+                  "line": 254,
                   "column": 2
                 },
                 "end": {
-                  "line": 242,
+                  "line": 258,
                   "column": 3
                 }
               },
@@ -31315,11 +33524,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 245,
+                  "line": 261,
                   "column": 2
                 },
                 "end": {
-                  "line": 256,
+                  "line": 272,
                   "column": 3
                 }
               },
@@ -31332,11 +33541,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 258,
+                  "line": 274,
                   "column": 2
                 },
                 "end": {
-                  "line": 260,
+                  "line": 276,
                   "column": 3
                 }
               },
@@ -31349,11 +33558,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 262,
+                  "line": 278,
                   "column": 2
                 },
                 "end": {
-                  "line": 267,
+                  "line": 283,
                   "column": 3
                 }
               },
@@ -31366,11 +33575,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 269,
+                  "line": 285,
                   "column": 2
                 },
                 "end": {
-                  "line": 273,
+                  "line": 289,
                   "column": 3
                 }
               },
@@ -31387,11 +33596,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 279,
+                  "line": 295,
                   "column": 2
                 },
                 "end": {
-                  "line": 281,
+                  "line": 297,
                   "column": 3
                 }
               },
@@ -31408,11 +33617,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 283,
+                  "line": 299,
                   "column": 2
                 },
                 "end": {
-                  "line": 289,
+                  "line": 305,
                   "column": 3
                 }
               },
@@ -31432,11 +33641,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 291,
+                  "line": 307,
                   "column": 2
                 },
                 "end": {
-                  "line": 296,
+                  "line": 312,
                   "column": 3
                 }
               },
@@ -31456,11 +33665,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 298,
+                  "line": 314,
                   "column": 2
                 },
                 "end": {
-                  "line": 308,
+                  "line": 324,
                   "column": 3
                 }
               },
@@ -31480,11 +33689,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 310,
+                  "line": 326,
                   "column": 2
                 },
                 "end": {
-                  "line": 312,
+                  "line": 328,
                   "column": 3
                 }
               },
@@ -31504,11 +33713,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 314,
+                  "line": 330,
                   "column": 2
                 },
                 "end": {
-                  "line": 323,
+                  "line": 339,
                   "column": 3
                 }
               },
@@ -31525,11 +33734,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 325,
+                  "line": 341,
                   "column": 2
                 },
                 "end": {
-                  "line": 334,
+                  "line": 350,
                   "column": 3
                 }
               },
@@ -31555,11 +33764,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 336,
+                  "line": 352,
                   "column": 2
                 },
                 "end": {
-                  "line": 347,
+                  "line": 363,
                   "column": 3
                 }
               },
@@ -31572,11 +33781,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 349,
+                  "line": 365,
                   "column": 2
                 },
                 "end": {
-                  "line": 351,
+                  "line": 367,
                   "column": 3
                 }
               },
@@ -31584,16 +33793,43 @@
               "params": []
             },
             {
+              "name": "hasFilter",
+              "description": "Returns whether `filterNotify.base` or `filter` is set to a usable value.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 374,
+                  "column": 2
+                },
+                "end": {
+                  "line": 385,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "filterNotify",
+                  "type": "(Object|void)",
+                  "description": "filter.*"
+                }
+              ],
+              "return": {
+                "type": "Boolean",
+                "desc": "True if filter or filterNotify.base is set"
+              }
+            },
+            {
               "name": "_getDefaultFilter",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 353,
+                  "line": 387,
                   "column": 2
                 },
                 "end": {
-                  "line": 360,
+                  "line": 394,
                   "column": 3
                 }
               },
@@ -31606,11 +33842,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 362,
+                  "line": 396,
                   "column": 2
                 },
                 "end": {
-                  "line": 365,
+                  "line": 402,
                   "column": 3
                 }
               },
@@ -31630,11 +33866,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 367,
+                  "line": 404,
                   "column": 2
                 },
                 "end": {
-                  "line": 372,
+                  "line": 409,
                   "column": 3
                 }
               },
@@ -31654,11 +33890,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 374,
+                  "line": 411,
                   "column": 2
                 },
                 "end": {
-                  "line": 376,
+                  "line": 413,
                   "column": 3
                 }
               },
@@ -31671,11 +33907,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 378,
+                  "line": 415,
                   "column": 2
                 },
                 "end": {
-                  "line": 380,
+                  "line": 417,
                   "column": 3
                 }
               },
@@ -31688,16 +33924,58 @@
               "privacy": "private",
               "sourceRange": {
                 "start": {
-                  "line": 382,
+                  "line": 419,
                   "column": 2
                 },
                 "end": {
-                  "line": 384,
+                  "line": 421,
                   "column": 3
                 }
               },
               "metadata": {},
               "params": []
+            },
+            {
+              "name": "_serializeFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 423,
+                  "column": 2
+                },
+                "end": {
+                  "line": 441,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "obj = this.filter"
+                }
+              ]
+            },
+            {
+              "name": "_deserializeFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 443,
+                  "column": 2
+                },
+                "end": {
+                  "line": 453,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "obj"
+                }
+              ]
             }
           ],
           "staticMethods": [],
@@ -31709,7 +33987,7 @@
               "column": 1
             },
             "end": {
-              "line": 386,
+              "line": 455,
               "column": 3
             }
           },
@@ -31973,8 +34251,8 @@
               "type": "string"
             },
             {
-              "name": "flex",
-              "description": "Width growing factor for this column.",
+              "name": "min-width",
+              "description": "The minimum width of this column.",
               "sourceRange": {
                 "start": {
                   "line": 132,
@@ -31989,15 +34267,47 @@
               "type": "string"
             },
             {
+              "name": "edit-min-width",
+              "description": "The minimum width of this column in edit mode.",
+              "sourceRange": {
+                "start": {
+                  "line": 140,
+                  "column": 3
+                },
+                "end": {
+                  "line": 143,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "flex",
+              "description": "Width growing factor for this column.",
+              "sourceRange": {
+                "start": {
+                  "line": 148,
+                  "column": 3
+                },
+                "end": {
+                  "line": 151,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
               "name": "cell-class",
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 137,
+                  "line": 153,
                   "column": 3
                 },
                 "end": {
-                  "line": 140,
+                  "line": 156,
                   "column": 4
                 }
               },
@@ -32009,11 +34319,11 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 142,
+                  "line": 158,
                   "column": 3
                 },
                 "end": {
-                  "line": 145,
+                  "line": 161,
                   "column": 4
                 }
               },
@@ -32025,11 +34335,11 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 147,
+                  "line": 163,
                   "column": 3
                 },
                 "end": {
-                  "line": 149,
+                  "line": 165,
                   "column": 4
                 }
               },
@@ -32041,55 +34351,7 @@
               "description": "Allow column to overflow without triggering\ncolumn folding (good for long descriptions)",
               "sourceRange": {
                 "start": {
-                  "line": 155,
-                  "column": 3
-                },
-                "end": {
-                  "line": 158,
-                  "column": 4
-                }
-              },
-              "metadata": {},
-              "type": "boolean"
-            },
-            {
-              "name": "priority",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 160,
-                  "column": 3
-                },
-                "end": {
-                  "line": 163,
-                  "column": 4
-                }
-              },
-              "metadata": {},
-              "type": "number"
-            },
-            {
-              "name": "cell-template",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 165,
-                  "column": 3
-                },
-                "end": {
-                  "line": 168,
-                  "column": 4
-                }
-              },
-              "metadata": {},
-              "type": "Object"
-            },
-            {
-              "name": "hidden",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 170,
+                  "line": 171,
                   "column": 3
                 },
                 "end": {
@@ -32101,15 +34363,63 @@
               "type": "boolean"
             },
             {
+              "name": "priority",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 176,
+                  "column": 3
+                },
+                "end": {
+                  "line": 179,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "cell-template",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 181,
+                  "column": 3
+                },
+                "end": {
+                  "line": 184,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "Object"
+            },
+            {
+              "name": "hidden",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 186,
+                  "column": 3
+                },
+                "end": {
+                  "line": 190,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
               "name": "column-index",
               "description": "Index of this column in the list of displayed columns (excluding disabled/hidden columns).",
               "sourceRange": {
                 "start": {
-                  "line": 178,
+                  "line": 194,
                   "column": 3
                 },
                 "end": {
-                  "line": 180,
+                  "line": 196,
                   "column": 4
                 }
               },
@@ -32121,11 +34431,11 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 182,
+                  "line": 198,
                   "column": 3
                 },
                 "end": {
-                  "line": 185,
+                  "line": 201,
                   "column": 4
                 }
               },
@@ -32718,20 +35028,20 @@
         {
           "description": "",
           "summary": "",
-          "path": "cosmoz-omnitable-column-date-behavior.html",
+          "path": "cosmoz-omnitable-column-range-behavior.html",
           "properties": [
             {
               "name": "bindValues",
               "type": "boolean",
-              "description": "Ask for a list of values",
+              "description": "",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 9,
+                  "line": 6,
                   "column": 3
                 },
                 "end": {
-                  "line": 13,
+                  "line": 10,
                   "column": 4
                 }
               },
@@ -32743,55 +35053,17 @@
               "defaultValue": "true"
             },
             {
-              "name": "max",
-              "type": "Date",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 15,
-                  "column": 3
-                },
-                "end": {
-                  "line": 20,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
-              "name": "min",
-              "type": "Date",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 22,
-                  "column": 3
-                },
-                "end": {
-                  "line": 27,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
               "name": "values",
               "type": "Array",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 29,
+                  "line": 12,
                   "column": 3
                 },
                 "end": {
-                  "line": 34,
+                  "line": 17,
                   "column": 4
                 }
               },
@@ -32801,272 +35073,44 @@
               "defaultValue": "[]"
             },
             {
-              "name": "_filterInput",
-              "type": "Object",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 36,
-                  "column": 3
-                },
-                "end": {
-                  "line": 44,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
-              "name": "_filterText",
-              "type": "string",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 46,
-                  "column": 3
-                },
-                "end": {
-                  "line": 49,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "_possibleDateRange",
-              "type": "Object",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 51,
-                  "column": 3
-                },
-                "end": {
-                  "line": 54,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "_fromMax",
-              "type": "Object",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 56,
-                  "column": 3
-                },
-                "end": {
-                  "line": 59,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "_fromMin",
-              "type": "Object",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 61,
-                  "column": 3
-                },
-                "end": {
-                  "line": 64,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "_toMax",
-              "type": "Object",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 66,
-                  "column": 3
-                },
-                "end": {
-                  "line": 69,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "_toMin",
-              "type": "Object",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 71,
-                  "column": 3
-                },
-                "end": {
-                  "line": 74,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "_earliestBefore",
-              "type": "Object",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 76,
-                  "column": 3
-                },
-                "end": {
-                  "line": 79,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "_tooltip",
-              "type": "string",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 81,
-                  "column": 3
-                },
-                "end": {
-                  "line": 84,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
-            },
-            {
-              "name": "width",
-              "type": "string",
+              "name": "min",
+              "type": "number",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 86,
+                  "line": 19,
                   "column": 3
                 },
                 "end": {
-                  "line": 89,
+                  "line": 22,
                   "column": 4
                 }
               },
               "metadata": {
                 "polymer": {}
               },
-              "defaultValue": "\"100px\""
+              "defaultValue": "null"
             },
             {
-              "name": "editWidth",
-              "type": "string",
+              "name": "max",
+              "type": "number",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 91,
+                  "line": 24,
                   "column": 3
                 },
                 "end": {
-                  "line": 94,
+                  "line": 27,
                   "column": 4
                 }
               },
               "metadata": {
                 "polymer": {}
               },
-              "defaultValue": "\"150px\""
-            },
-            {
-              "name": "flex",
-              "type": "string",
-              "description": "No need to grow, as the values in a date column should have known fixed width",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 100,
-                  "column": 3
-                },
-                "end": {
-                  "line": 103,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              },
-              "defaultValue": "\"0\""
-            },
-            {
-              "name": "formatter",
-              "type": "Object",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 104,
-                  "column": 3
-                },
-                "end": {
-                  "line": 107,
-                  "column": 4
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "readOnly": true
-                }
-              }
+              "defaultValue": "null"
             },
             {
               "name": "locale",
@@ -33075,11 +35119,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 108,
+                  "line": 29,
                   "column": 3
                 },
                 "end": {
-                  "line": 111,
+                  "line": 32,
                   "column": 4
                 }
               },
@@ -33087,51 +35131,335 @@
                 "polymer": {}
               },
               "defaultValue": "null"
+            },
+            {
+              "name": "_filterInput",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 34,
+                  "column": 3
+                },
+                "end": {
+                  "line": 39,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_range",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 41,
+                  "column": 3
+                },
+                "end": {
+                  "line": 44,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              }
+            },
+            {
+              "name": "_limit",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 46,
+                  "column": 3
+                },
+                "end": {
+                  "line": 52,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "defaultValue": "{}"
+            },
+            {
+              "name": "_tooltip",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 54,
+                  "column": 3
+                },
+                "end": {
+                  "line": 57,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              }
             }
           ],
           "methods": [
             {
-              "name": "_computeFormatter",
+              "name": "detached",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 118,
+                  "line": 65,
                   "column": 2
                 },
                 "end": {
-                  "line": 120,
+                  "line": 67,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "toNumber",
+              "description": "Converts a value to number optionaly limiting it.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 77,
+                  "column": 2
+                },
+                "end": {
+                  "line": 93,
                   "column": 3
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "locale"
+                  "name": "value",
+                  "type": "(Number|*)",
+                  "description": "The value to convert to number"
+                },
+                {
+                  "name": "limit",
+                  "type": "(Number|*)",
+                  "description": "The value used to limit the number"
+                },
+                {
+                  "name": "limitFunc",
+                  "type": "Function",
+                  "description": "The function used to limit the number (Math.min|Math.max)"
+                }
+              ],
+              "return": {
+                "type": "(Number|void)",
+                "desc": "Value converted to Number or void"
+              }
+            },
+            {
+              "name": "toValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 95,
+                  "column": 2
+                },
+                "end": {
+                  "line": 97,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "getComparableValue",
+              "description": "Get the comparable value of an item.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 106,
+                  "column": 2
+                },
+                "end": {
+                  "line": 115,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item",
+                  "type": "Object",
+                  "description": "Item to be processed"
+                },
+                {
+                  "name": "valuePath",
+                  "type": "String",
+                  "description": "Property path"
+                }
+              ],
+              "return": {
+                "type": "(Number|void)",
+                "desc": "Valid value or void"
+              }
+            },
+            {
+              "name": "toXlsxValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 117,
+                  "column": 2
+                },
+                "end": {
+                  "line": 123,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "valuePath = this.valuePath"
                 }
               ]
             },
             {
-              "name": "_getMinMax",
+              "name": "getString",
               "description": "",
-              "privacy": "protected",
+              "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 122,
+                  "line": 125,
                   "column": 2
                 },
                 "end": {
-                  "line": 146,
+                  "line": 135,
                   "column": 3
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "firstRaw"
+                  "name": "item"
                 },
                 {
-                  "name": "secondRaw"
+                  "name": "valuePath = this.valuePath"
+                }
+              ]
+            },
+            {
+              "name": "renderValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 136,
+                  "column": 2
+                },
+                "end": {
+                  "line": 138,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "getInputString",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 140,
+                  "column": 2
+                },
+                "end": {
+                  "line": 143,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "valuePath = this.valuePath"
+                }
+              ]
+            },
+            {
+              "name": "_computeRange",
+              "description": "Computes min/max range from values.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 151,
+                  "column": 2
+                },
+                "end": {
+                  "line": 168,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "change",
+                  "type": "Object",
+                  "description": "`values` property changes"
+                }
+              ],
+              "return": {
+                "type": "Object",
+                "desc": "Computed min/max"
+              }
+            },
+            {
+              "name": "_computeLimit",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 170,
+                  "column": 2
+                },
+                "end": {
+                  "line": 185,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "range"
+                },
+                {
+                  "name": "inputChange"
+                },
+                {
+                  "name": "min"
                 },
                 {
                   "name": "max"
@@ -33139,16 +35467,57 @@
               ]
             },
             {
-              "name": "_computePossibleDateRange",
+              "name": "getFilterFn",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 187,
+                  "column": 2
+                },
+                "end": {
+                  "line": 195,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_applySingleFilter",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 148,
+                  "line": 197,
                   "column": 2
                 },
                 "end": {
-                  "line": 168,
+                  "line": 211,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "filter"
+                },
+                {
+                  "name": "item"
+                }
+              ]
+            },
+            {
+              "name": "_computeFilterText",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 213,
+                  "column": 2
+                },
+                "end": {
+                  "line": 230,
                   "column": 3
                 }
               },
@@ -33165,11 +35534,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 170,
+                  "line": 232,
                   "column": 2
                 },
                 "end": {
-                  "line": 176,
+                  "line": 237,
                   "column": 3
                 }
               },
@@ -33179,162 +35548,21 @@
                   "name": "title"
                 },
                 {
-                  "name": "filterText"
+                  "name": "text"
                 }
               ]
             },
             {
-              "name": "_formatISODate",
+              "name": "_fromInputString",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 178,
+                  "line": 239,
                   "column": 2
                 },
                 "end": {
-                  "line": 183,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "filterValue"
-                }
-              ]
-            },
-            {
-              "name": "_computeFilterText",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 185,
-                  "column": 2
-                },
-                "end": {
-                  "line": 200,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "filterNotify"
-                },
-                {
-                  "name": "formatter = this.formatter"
-                }
-              ]
-            },
-            {
-              "name": "_dateValueChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 202,
-                  "column": 2
-                },
-                "end": {
-                  "line": 215,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "event"
-                }
-              ]
-            },
-            {
-              "name": "getComparableValue",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 217,
-                  "column": 2
-                },
-                "end": {
-                  "line": 223,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "item"
-                },
-                {
-                  "name": "valuePath"
-                }
-              ]
-            },
-            {
-              "name": "renderISODateValue",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 225,
-                  "column": 2
-                },
-                "end": {
-                  "line": 231,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "item"
-                },
-                {
-                  "name": "valuePath"
-                }
-              ]
-            },
-            {
-              "name": "getString",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 233,
-                  "column": 2
-                },
-                "end": {
-                  "line": 242,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "item"
-                },
-                {
-                  "name": "valuePath = this.valuePath"
-                },
-                {
-                  "name": "formatter = this.formatter"
-                }
-              ]
-            },
-            {
-              "name": "getDate",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 243,
-                  "column": 2
-                },
-                "end": {
-                  "line": 251,
+                  "line": 241,
                   "column": 3
                 }
               },
@@ -33346,61 +35574,16 @@
               ]
             },
             {
-              "name": "getFilterFn",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 253,
-                  "column": 2
-                },
-                "end": {
-                  "line": 258,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "filter = this.filter"
-                }
-              ]
-            },
-            {
-              "name": "_applySingleFilter",
+              "name": "_toInputString",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 259,
+                  "line": 243,
                   "column": 2
                 },
                 "end": {
-                  "line": 268,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "filter"
-                },
-                {
-                  "name": "item"
-                }
-              ]
-            },
-            {
-              "name": "_isValidDate",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 270,
-                  "column": 2
-                },
-                "end": {
-                  "line": 282,
+                  "line": 249,
                   "column": 3
                 }
               },
@@ -33417,7 +35600,50 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 284,
+                  "line": 251,
+                  "column": 2
+                },
+                "end": {
+                  "line": 256,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_filterInputChanged",
+              "description": "Observes changes of _filterInput, saves the path, debounces _limitInput.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 264,
+                  "column": 2
+                },
+                "end": {
+                  "line": 268,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "change",
+                  "type": "Object",
+                  "description": "'_filterInput' property changes"
+                }
+              ],
+              "return": {
+                "type": "void"
+              }
+            },
+            {
+              "name": "_limitInput",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 270,
                   "column": 2
                 },
                 "end": {
@@ -33429,7 +35655,7 @@
               "params": []
             },
             {
-              "name": "_toISOString",
+              "name": "_updateFilter",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
@@ -33438,37 +35664,12 @@
                   "column": 2
                 },
                 "end": {
-                  "line": 303,
+                  "line": 304,
                   "column": 3
                 }
               },
               "metadata": {},
-              "params": [
-                {
-                  "name": "date"
-                }
-              ]
-            },
-            {
-              "name": "_toStringValue",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 305,
-                  "column": 2
-                },
-                "end": {
-                  "line": 310,
-                  "column": 3
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                }
-              ]
+              "params": []
             },
             {
               "name": "_filterChanged",
@@ -33476,11 +35677,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 312,
+                  "line": 306,
                   "column": 2
                 },
                 "end": {
-                  "line": 328,
+                  "line": 326,
                   "column": 3
                 }
               },
@@ -33492,26 +35693,106 @@
               ]
             },
             {
-              "name": "_filterInputChanged",
+              "name": "hasFilter",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 328,
+                  "column": 2
+                },
+                "end": {
+                  "line": 335,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_serializeFilter",
               "description": "",
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 330,
+                  "line": 337,
                   "column": 2
                 },
                 "end": {
-                  "line": 340,
+                  "line": 348,
                   "column": 3
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "start"
+                  "name": "filter = this.filter"
+                }
+              ]
+            },
+            {
+              "name": "_deserializeFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 350,
+                  "column": 2
+                },
+                "end": {
+                  "line": 364,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "obj"
+                }
+              ]
+            },
+            {
+              "name": "_toHashString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 366,
+                  "column": 2
+                },
+                "end": {
+                  "line": 372,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ]
+            },
+            {
+              "name": "_fromHashString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 374,
+                  "column": 2
+                },
+                "end": {
+                  "line": 376,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
                 },
                 {
-                  "name": "end"
+                  "name": "property"
                 }
               ]
             }
@@ -33525,23 +35806,23 @@
               "column": 1
             },
             "end": {
-              "line": 342,
+              "line": 377,
               "column": 3
             }
           },
           "privacy": "public",
-          "name": "Cosmoz.DateColumnBehavior",
+          "name": "Cosmoz.RangeColumnBehavior",
           "attributes": [
             {
               "name": "bind-values",
-              "description": "Ask for a list of values",
+              "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 9,
+                  "line": 6,
                   "column": 3
                 },
                 "end": {
-                  "line": 13,
+                  "line": 10,
                   "column": 4
                 }
               },
@@ -33549,15 +35830,469 @@
               "type": "boolean"
             },
             {
+              "name": "values",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 12,
+                  "column": 3
+                },
+                "end": {
+                  "line": 17,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "Array"
+            },
+            {
+              "name": "min",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 19,
+                  "column": 3
+                },
+                "end": {
+                  "line": 22,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
               "name": "max",
               "description": "",
               "sourceRange": {
                 "start": {
+                  "line": 24,
+                  "column": 3
+                },
+                "end": {
+                  "line": 27,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "locale",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 29,
+                  "column": 3
+                },
+                "end": {
+                  "line": 32,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": []
+        },
+        {
+          "description": "",
+          "summary": "",
+          "path": "cosmoz-omnitable-column-date-behavior.html",
+          "properties": [
+            {
+              "name": "max",
+              "type": "Date",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 7,
+                  "column": 3
+                },
+                "end": {
+                  "line": 10,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "null"
+            },
+            {
+              "name": "min",
+              "type": "Date",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 12,
+                  "column": 3
+                },
+                "end": {
                   "line": 15,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "null"
+            },
+            {
+              "name": "_filterText",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 17,
                   "column": 3
                 },
                 "end": {
                   "line": 20,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              }
+            },
+            {
+              "name": "width",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 22,
+                  "column": 3
+                },
+                "end": {
+                  "line": 25,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"100px\""
+            },
+            {
+              "name": "editWidth",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 27,
+                  "column": 3
+                },
+                "end": {
+                  "line": 30,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"150px\""
+            },
+            {
+              "name": "flex",
+              "type": "string",
+              "description": "No need to grow, as the values in a date column should have known fixed width",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 36,
+                  "column": 3
+                },
+                "end": {
+                  "line": 39,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"0\""
+            },
+            {
+              "name": "formatter",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 3
+                },
+                "end": {
+                  "line": 43,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "toDate",
+              "description": "Converts an value to date optionaly limiting it.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 54,
+                  "column": 2
+                },
+                "end": {
+                  "line": 73,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "(Date|String)",
+                  "description": "Value to convert to date"
+                },
+                {
+                  "name": "limit",
+                  "type": "(Date|String)",
+                  "description": "Value used to limit the date"
+                },
+                {
+                  "name": "limitFunc",
+                  "type": "Function",
+                  "description": "Function used to limit the date (Math.min|Math.max)"
+                }
+              ],
+              "return": {
+                "type": "(Date|void)",
+                "desc": "Value converted to date optionaly limitated"
+              }
+            },
+            {
+              "name": "toValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 75,
+                  "column": 2
+                },
+                "end": {
+                  "line": 77,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "getComparableValue",
+              "description": "Get comparable number from date",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 84,
+                  "column": 2
+                },
+                "end": {
+                  "line": 90,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "(Number|void)",
+                "desc": "Valid value or void"
+              }
+            },
+            {
+              "name": "getString",
+              "description": "Get date of item as string",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 101,
+                  "column": 2
+                },
+                "end": {
+                  "line": 110,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item",
+                  "type": "Object",
+                  "description": "Item to be processed"
+                },
+                {
+                  "name": "valuePath = this.valuePath"
+                },
+                {
+                  "name": "formatter = this.formatter"
+                }
+              ],
+              "return": {
+                "type": "String",
+                "desc": "Date rendered as string or 'Invalid Date'"
+              }
+            },
+            {
+              "name": "renderValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 112,
+                  "column": 2
+                },
+                "end": {
+                  "line": 118,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "formatter = this.formatter"
+                }
+              ]
+            },
+            {
+              "name": "_computeFormatter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 120,
+                  "column": 2
+                },
+                "end": {
+                  "line": 122,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "locale"
+                }
+              ]
+            },
+            {
+              "name": "_toInputString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 124,
+                  "column": 2
+                },
+                "end": {
+                  "line": 130,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ]
+            },
+            {
+              "name": "_dateValueChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 132,
+                  "column": 2
+                },
+                "end": {
+                  "line": 143,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_toLocalISOString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 145,
+                  "column": 2
+                },
+                "end": {
+                  "line": 157,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "date"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 5,
+              "column": 1
+            },
+            "end": {
+              "line": 158,
+              "column": 3
+            }
+          },
+          "privacy": "public",
+          "name": "Cosmoz.DateColumnBehaviorImpl",
+          "attributes": [
+            {
+              "name": "max",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 7,
+                  "column": 3
+                },
+                "end": {
+                  "line": 10,
                   "column": 4
                 }
               },
@@ -33569,11 +36304,11 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 22,
+                  "line": 12,
                   "column": 3
                 },
                 "end": {
-                  "line": 27,
+                  "line": 15,
                   "column": 4
                 }
               },
@@ -33581,31 +36316,15 @@
               "type": "Date"
             },
             {
-              "name": "values",
-              "description": "",
-              "sourceRange": {
-                "start": {
-                  "line": 29,
-                  "column": 3
-                },
-                "end": {
-                  "line": 34,
-                  "column": 4
-                }
-              },
-              "metadata": {},
-              "type": "Array"
-            },
-            {
               "name": "width",
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 86,
+                  "line": 22,
                   "column": 3
                 },
                 "end": {
-                  "line": 89,
+                  "line": 25,
                   "column": 4
                 }
               },
@@ -33617,11 +36336,11 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 91,
+                  "line": 27,
                   "column": 3
                 },
                 "end": {
-                  "line": 94,
+                  "line": 30,
                   "column": 4
                 }
               },
@@ -33633,11 +36352,11 @@
               "description": "No need to grow, as the values in a date column should have known fixed width",
               "sourceRange": {
                 "start": {
-                  "line": 100,
+                  "line": 36,
                   "column": 3
                 },
                 "end": {
-                  "line": 103,
+                  "line": 39,
                   "column": 4
                 }
               },
@@ -33649,32 +36368,1247 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 104,
+                  "line": 40,
                   "column": 3
                 },
                 "end": {
-                  "line": 107,
+                  "line": 43,
                   "column": 4
                 }
               },
               "metadata": {},
               "type": "Object"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": []
+        },
+        {
+          "description": "",
+          "summary": "",
+          "path": "cosmoz-omnitable-column-date-behavior.html",
+          "properties": [
+            {
+              "name": "bindValues",
+              "type": "boolean",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 6,
+                  "column": 3
+                },
+                "end": {
+                  "line": 10,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "defaultValue": "true",
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "values",
+              "type": "Array",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 12,
+                  "column": 3
+                },
+                "end": {
+                  "line": 17,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "[]",
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "min",
+              "type": "Date",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 12,
+                  "column": 3
+                },
+                "end": {
+                  "line": 15,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "null",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "max",
+              "type": "Date",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 7,
+                  "column": 3
+                },
+                "end": {
+                  "line": 10,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "null",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "locale",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 29,
+                  "column": 3
+                },
+                "end": {
+                  "line": 32,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "null",
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_filterInput",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 34,
+                  "column": 3
+                },
+                "end": {
+                  "line": 39,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_range",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 41,
+                  "column": 3
+                },
+                "end": {
+                  "line": 44,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_limit",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 46,
+                  "column": 3
+                },
+                "end": {
+                  "line": 52,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "defaultValue": "{}",
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_tooltip",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 54,
+                  "column": 3
+                },
+                "end": {
+                  "line": 57,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_filterText",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 17,
+                  "column": 3
+                },
+                "end": {
+                  "line": 20,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "width",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 22,
+                  "column": 3
+                },
+                "end": {
+                  "line": 25,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"100px\"",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "editWidth",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 27,
+                  "column": 3
+                },
+                "end": {
+                  "line": 30,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"150px\"",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "flex",
+              "type": "string",
+              "description": "No need to grow, as the values in a date column should have known fixed width",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 36,
+                  "column": 3
+                },
+                "end": {
+                  "line": 39,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"0\"",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "formatter",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 3
+                },
+                "end": {
+                  "line": 43,
+                  "column": 4
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            }
+          ],
+          "methods": [
+            {
+              "name": "detached",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 65,
+                  "column": 2
+                },
+                "end": {
+                  "line": 67,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "toNumber",
+              "description": "Converts a value to number optionaly limiting it.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 77,
+                  "column": 2
+                },
+                "end": {
+                  "line": 93,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "(Number|*)",
+                  "description": "The value to convert to number"
+                },
+                {
+                  "name": "limit",
+                  "type": "(Number|*)",
+                  "description": "The value used to limit the number"
+                },
+                {
+                  "name": "limitFunc",
+                  "type": "Function",
+                  "description": "The function used to limit the number (Math.min|Math.max)"
+                }
+              ],
+              "return": {
+                "type": "(Number|void)",
+                "desc": "Value converted to Number or void"
+              },
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "toValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 75,
+                  "column": 2
+                },
+                "end": {
+                  "line": 77,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "getComparableValue",
+              "description": "Get comparable number from date",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 84,
+                  "column": 2
+                },
+                "end": {
+                  "line": 90,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "(Number|void)",
+                "desc": "Valid value or void"
+              },
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "toXlsxValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 117,
+                  "column": 2
+                },
+                "end": {
+                  "line": 123,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "valuePath = this.valuePath"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "getString",
+              "description": "Get date of item as string",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 101,
+                  "column": 2
+                },
+                "end": {
+                  "line": 110,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item",
+                  "type": "Object",
+                  "description": "Item to be processed"
+                },
+                {
+                  "name": "valuePath = this.valuePath"
+                },
+                {
+                  "name": "formatter = this.formatter"
+                }
+              ],
+              "return": {
+                "type": "String",
+                "desc": "Date rendered as string or 'Invalid Date'"
+              },
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "renderValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 112,
+                  "column": 2
+                },
+                "end": {
+                  "line": 118,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "formatter = this.formatter"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "getInputString",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 140,
+                  "column": 2
+                },
+                "end": {
+                  "line": 143,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "valuePath = this.valuePath"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_computeRange",
+              "description": "Computes min/max range from values.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 151,
+                  "column": 2
+                },
+                "end": {
+                  "line": 168,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "change",
+                  "type": "Object",
+                  "description": "`values` property changes"
+                }
+              ],
+              "return": {
+                "type": "Object",
+                "desc": "Computed min/max"
+              },
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_computeLimit",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 170,
+                  "column": 2
+                },
+                "end": {
+                  "line": 185,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "range"
+                },
+                {
+                  "name": "inputChange"
+                },
+                {
+                  "name": "min"
+                },
+                {
+                  "name": "max"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "getFilterFn",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 187,
+                  "column": 2
+                },
+                "end": {
+                  "line": 195,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_applySingleFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 197,
+                  "column": 2
+                },
+                "end": {
+                  "line": 211,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "filter"
+                },
+                {
+                  "name": "item"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_computeFilterText",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 213,
+                  "column": 2
+                },
+                "end": {
+                  "line": 230,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "change"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_computeTooltip",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 232,
+                  "column": 2
+                },
+                "end": {
+                  "line": 237,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "title"
+                },
+                {
+                  "name": "text"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_fromInputString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 239,
+                  "column": 2
+                },
+                "end": {
+                  "line": 241,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_toInputString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 124,
+                  "column": 2
+                },
+                "end": {
+                  "line": 130,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "_getDefaultFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 251,
+                  "column": 2
+                },
+                "end": {
+                  "line": 256,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_filterInputChanged",
+              "description": "Observes changes of _filterInput, saves the path, debounces _limitInput.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 264,
+                  "column": 2
+                },
+                "end": {
+                  "line": 268,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "change",
+                  "type": "Object",
+                  "description": "'_filterInput' property changes"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_limitInput",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 270,
+                  "column": 2
+                },
+                "end": {
+                  "line": 289,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_updateFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 291,
+                  "column": 2
+                },
+                "end": {
+                  "line": 304,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_filterChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 306,
+                  "column": 2
+                },
+                "end": {
+                  "line": 326,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "change"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "hasFilter",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 328,
+                  "column": 2
+                },
+                "end": {
+                  "line": 335,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_serializeFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 337,
+                  "column": 2
+                },
+                "end": {
+                  "line": 348,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "filter = this.filter"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_deserializeFilter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 350,
+                  "column": 2
+                },
+                "end": {
+                  "line": 364,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "obj"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_toHashString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 366,
+                  "column": 2
+                },
+                "end": {
+                  "line": 372,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "_fromHashString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 374,
+                  "column": 2
+                },
+                "end": {
+                  "line": 376,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "property"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "toDate",
+              "description": "Converts an value to date optionaly limiting it.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 54,
+                  "column": 2
+                },
+                "end": {
+                  "line": 73,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "(Date|String)",
+                  "description": "Value to convert to date"
+                },
+                {
+                  "name": "limit",
+                  "type": "(Date|String)",
+                  "description": "Value used to limit the date"
+                },
+                {
+                  "name": "limitFunc",
+                  "type": "Function",
+                  "description": "Function used to limit the date (Math.min|Math.max)"
+                }
+              ],
+              "return": {
+                "type": "(Date|void)",
+                "desc": "Value converted to date optionaly limitated"
+              },
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "_computeFormatter",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 120,
+                  "column": 2
+                },
+                "end": {
+                  "line": 122,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "locale"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "_dateValueChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 132,
+                  "column": 2
+                },
+                "end": {
+                  "line": 143,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "_toLocalISOString",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 145,
+                  "column": 2
+                },
+                "end": {
+                  "line": 157,
+                  "column": 3
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "date"
+                }
+              ],
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            }
+          ],
+          "staticMethods": [],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 160,
+              "column": 1
+            },
+            "end": {
+              "line": 160,
+              "column": 89
+            }
+          },
+          "privacy": "public",
+          "name": "Cosmoz.DateColumnBehavior",
+          "attributes": [
+            {
+              "name": "bind-values",
+              "description": "",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 6,
+                  "column": 3
+                },
+                "end": {
+                  "line": 10,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "values",
+              "description": "",
+              "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
+                "start": {
+                  "line": 12,
+                  "column": 3
+                },
+                "end": {
+                  "line": 17,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "Array",
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "min",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 12,
+                  "column": 3
+                },
+                "end": {
+                  "line": 15,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "Date",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "max",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 7,
+                  "column": 3
+                },
+                "end": {
+                  "line": 10,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "Date",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
             },
             {
               "name": "locale",
               "description": "",
               "sourceRange": {
+                "file": "cosmoz-omnitable-column-range-behavior.html",
                 "start": {
-                  "line": 108,
+                  "line": 29,
                   "column": 3
                 },
                 "end": {
-                  "line": 111,
+                  "line": 32,
                   "column": 4
                 }
               },
               "metadata": {},
-              "type": "string"
+              "type": "string",
+              "inheritedFrom": "Cosmoz.RangeColumnBehavior"
+            },
+            {
+              "name": "width",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 22,
+                  "column": 3
+                },
+                "end": {
+                  "line": 25,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "edit-width",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 27,
+                  "column": 3
+                },
+                "end": {
+                  "line": 30,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "flex",
+              "description": "No need to grow, as the values in a date column should have known fixed width",
+              "sourceRange": {
+                "start": {
+                  "line": 36,
+                  "column": 3
+                },
+                "end": {
+                  "line": 39,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
+            },
+            {
+              "name": "formatter",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 3
+                },
+                "end": {
+                  "line": 43,
+                  "column": 4
+                }
+              },
+              "metadata": {},
+              "type": "Object",
+              "inheritedFrom": "Cosmoz.DateColumnBehaviorImpl"
             }
           ],
           "events": [],

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -368,12 +368,12 @@
 		},
 
 		/**
-		 * Returns whether `filter` is set to a usable value.
-		 *
-		 * @returns {Boolean}  True if filter is set
+		 * Returns whether 'filterNotify.base' or `filter` is set to a usable value.
+		 * @param {Object|void} filterNotify filter.*
+		 * @returns {Boolean}  True if filter or filterNotify.base is set
 		 */
-		hasFilter() {
-			const filter = this.filter,
+		hasFilter(filterNotify) {
+			const filter = filterNotify == null ? this.filter : filterNotify.base,
 				isArray = Array.isArray(filter);
 
 			if (filter == null || filter === ''

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -368,7 +368,7 @@
 		},
 
 		/**
-		 * Returns whether 'filterNotify.base' or `filter` is set to a usable value.
+		 * Returns whether `filterNotify.base` or `filter` is set to a usable value.
 		 * @param {Object|void} filterNotify filter.*
 		 * @returns {Boolean}  True if filter or filterNotify.base is set
 		 */

--- a/cosmoz-omnitable-column.html
+++ b/cosmoz-omnitable-column.html
@@ -16,7 +16,7 @@
 
 		<template class="header">
 			<paper-input label="[[ title ]]" value="{{ filter }}" focused="{{ headerFocused }}">
-				<cosmoz-clear-button suffix slot="suffix" visible="[[ hasFilter(filter.*) ]]" filter=true on-click="resetFilter"></cosmoz-clear-button>
+				<cosmoz-clear-button suffix slot="suffix" visible="[[ hasFilter(filter.*) ]]" light on-click="resetFilter"></cosmoz-clear-button>
 			</paper-input>
 		</template>
 

--- a/cosmoz-omnitable-column.html
+++ b/cosmoz-omnitable-column.html
@@ -1,6 +1,7 @@
 <link rel="import" href="cosmoz-omnitable-column-behavior.html">
 <link rel="import" href="../iron-icon/iron-icon.html"/>
 <link rel="import" href="../paper-input/paper-input.html"/>
+<link rel="import" href="ui-helpers/cosmoz-clear-button.html">
 
 <dom-module id="cosmoz-omnitable-column">
 	<template>
@@ -15,7 +16,7 @@
 
 		<template class="header">
 			<paper-input label="[[ title ]]" value="{{ filter }}" focused="{{ headerFocused }}">
-				<iron-icon icon="clear" suffix slot="suffix" hidden$="[[ !filter.length ]]" style="cursor: pointer;" on-click="resetFilter"></iron-icon>
+				<cosmoz-clear-button suffix slot="suffix" visible="[[ hasFilter(filter.*) ]]" filter=true on-click="resetFilter"></cosmoz-clear-button>
 			</paper-input>
 		</template>
 

--- a/ui-helpers/cosmoz-clear-button.html
+++ b/ui-helpers/cosmoz-clear-button.html
@@ -4,7 +4,7 @@
 <dom-module id="cosmoz-clear-button">
 	<template>
 		<style is="custom-style">
-			:host(:not([filter])) {
+			:host(:not([light])) {
 				position: absolute;
 				right: 0;
 				z-index: +1;
@@ -14,7 +14,7 @@
 				display: none !important;
 			}
 
-			:host(:not([filter])) iron-icon {
+			:host(:not([light])) iron-icon {
 				top: 10px;
 				margin: 2px 7px;
 				color: #cdcdcd;
@@ -31,7 +31,7 @@
 				float: right;
 			}
 
-			:host(:not([filter])) iron-icon:hover {
+			:host(:not([light])) iron-icon:hover {
 				background-color: #b0b0b0;
 				color: #dfdfdf;
 			}
@@ -46,6 +46,12 @@
 					type: Boolean,
 					value: false,
 					reflectToAttribute: true
+				},
+
+				light: {
+					type: Boolean,
+					reflectToAttribute: true,
+					value: false
 				}
 			}
 		});

--- a/ui-helpers/cosmoz-clear-button.html
+++ b/ui-helpers/cosmoz-clear-button.html
@@ -2,42 +2,42 @@
 <link rel="import" href="../../iron-icons/iron-icons.html">
 
 <dom-module id="cosmoz-clear-button">
-    <template>
-        <style is="custom-style">
-            :host {
-                position: absolute;
-                right: 0;
-                z-index: +1;
-            }
+	<template>
+		<style is="custom-style">
+			:host(:not([filter])) {
+				position: absolute;
+				right: 0;
+				z-index: +1;
+			}
 
-			:host:not([visible]){
+			:host(:not([visible])){
 				display: none !important;
 			}
 
-            iron-icon {
-                top: 10px;
-                margin: 2px 7px;
-                color: #cdcdcd;
-                background-color: #a6a6a6;
-                border-radius: 500px;
-                cursor: pointer;
-                min-width: 16px;
-                width: 16px !important;
-                min-height: 16px;
-                height: 16px;
-                padding: 2px;
-                box-sizing: border-box;
-                transition: background-color 0.25s, color 0.25s;
-                float: right;
-            }
+			:host(:not([filter])) iron-icon {
+				top: 10px;
+				margin: 2px 7px;
+				color: #cdcdcd;
+				background-color: #a6a6a6;
+				border-radius: 500px;
+				cursor: pointer;
+				min-width: 16px;
+				width: 16px !important;
+				min-height: 16px;
+				height: 16px;
+				padding: 2px;
+				box-sizing: border-box;
+				transition: background-color 0.25s, color 0.25s;
+				float: right;
+			}
 
-			iron-icon:hover {
+			:host(:not([filter])) iron-icon:hover {
 				background-color: #b0b0b0;
 				color: #dfdfdf;
 			}
-        </style>
-        <iron-icon icon="clear"></iron-icon>
-    </template>
+		</style>
+		<iron-icon icon="clear"></iron-icon>
+	</template>
 	<script type="text/javascript">
 		Polymer({
 			is: 'cosmoz-clear-button',


### PR DESCRIPTION
fixes https://github.com/Neovici/cosmoz-omnitable/issues/151
In cosmoz-omnitable-column the close iron-icon with hidden attribute was visible because of suffix ::slotted(*) { display: inline-block;  Used the existing ui-helper: cosmoz-clear-button fixing css for visible attribute. Added light attribute to keep the original css of iron-icon close.