### PR TITLE
Do not override sortOn and groupOn properties on columns with valuePath when they are defined

### DIFF
--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -94,12 +94,12 @@
 
 			sortOn: {
 				type: String,
-				value: '' // need a default value for compatibility with Polymer 1.x, to trigger _pathsChanged observer
+				value: null // need a default value for compatibility with Polymer 1.x, to trigger _pathsChanged observer
 			},
 
 			groupOn: {
 				type: String,
-				value: '' // need a default value for compatibility with Polymer 1.x, to trigger _pathsChanged observer
+				value: null // need a default value for compatibility with Polymer 1.x, to trigger _pathsChanged observer
 			},
 
 			/**
@@ -315,15 +315,15 @@
 		},
 
 		_pathsChanged(valuePath, groupOn, sortOn) {
-			if (valuePath === undefined || valuePath === null) {
+			if (valuePath == null) {
 				return;
 			}
 
-			if (groupOn === undefined || groupOn === '') {
+			if (groupOn == null) {
 				this.set('groupOn', valuePath);
 			}
 
-			if (sortOn === undefined || sortOn === '') {
+			if (sortOn == null) {
 				this.set('sortOn', valuePath);
 			}
 		},

--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -17,8 +17,7 @@
 			},
 
 			valuePath: {
-				type: String,
-				observer: 'valuePathChanged'
+				type: String
 			},
 
 			/**
@@ -94,11 +93,13 @@
 			},
 
 			sortOn: {
-				type: String
+				type: String,
+				value: '' // need a default value for compatibility with Polymer 1.x, to trigger _pathsChanged observer
 			},
 
 			groupOn: {
-				type: String
+				type: String,
+				value: '' // need a default value for compatibility with Polymer 1.x, to trigger _pathsChanged observer
 			},
 
 			/**
@@ -215,7 +216,8 @@
 		StyleModules: [],
 
 		observers: [
-			'__filterChanged(filter.*)'
+			'__filterChanged(filter.*)',
+			'_pathsChanged(valuePath, groupOn, sortOn)'
 		],
 
 		ready: function () {
@@ -312,15 +314,17 @@
 			return this.get(valuePath, item);
 		},
 
-		valuePathChanged: function (newPath, oldPath) {
-			if (newPath === undefined || newPath === null) {
+		_pathsChanged(valuePath, groupOn, sortOn) {
+			if (valuePath === undefined || valuePath === null) {
 				return;
 			}
-			if (this.groupOn === oldPath || this.groupOn === undefined) {
-				this.set('groupOn', newPath);
+
+			if (groupOn === undefined || groupOn === '') {
+				this.set('groupOn', valuePath);
 			}
-			if (this.sortOn === oldPath || this.sortOn === undefined) {
-				this.set('sortOn', newPath);
+
+			if (sortOn === undefined || sortOn === '') {
+				this.set('sortOn', valuePath);
 			}
 		},
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -47,6 +47,7 @@
 				</cosmoz-omnitable-column-date>
 				<cosmoz-omnitable-column-date id="date3" value-path="date">
 				</cosmoz-omnitable-column-date>
+			</cosmoz-omnitable>
 		</template>
 	</test-fixture>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -26,6 +26,14 @@
 				</cosmoz-omnitable-column-date>
 				<cosmoz-omnitable-column-date id="date3" name="date3" value-path="date">
 				</cosmoz-omnitable-column-date>
+				<cosmoz-omnitable-column name="columnWithGroupOn" value-path="valuePath" group-on="groupOnValuePath">
+				</cosmoz-omnitable-column>
+				<cosmoz-omnitable-column name="columnWithoutGroupOn" value-path="valuePath">
+				</cosmoz-omnitable-column>
+				<cosmoz-omnitable-column name="columnWithSortOn" value-path="valuePath" sort-on="sortOnValuePath">
+				</cosmoz-omnitable-column>
+				<cosmoz-omnitable-column name="columnWithoutSortOn" value-path="valuePath">
+				</cosmoz-omnitable-column>
 			</cosmoz-omnitable>
 		</template>
 	</test-fixture>
@@ -39,7 +47,6 @@
 				</cosmoz-omnitable-column-date>
 				<cosmoz-omnitable-column-date id="date3" value-path="date">
 				</cosmoz-omnitable-column-date>
-			</cosmoz-omnitable>
 		</template>
 	</test-fixture>
 
@@ -54,10 +61,10 @@
 			setup(function (done) {
 				omnitable = fixture('basic');
 				data = Cosmoz.TableDemoBehavior.generateTableDemoData(10, 11, 25);
-				omnitable.data = data;
 				omnitable.addEventListener('visible-columns-changed', function () {
 					Polymer.Base.async(done, 30);
 				});
+				omnitable.data = data;
 				omnitable.notifyResize();
 			});
 
@@ -82,6 +89,37 @@
 
 					done();
 				}, 60);
+			});
+
+			test('sets column groupOn property to valuePath when group-on attribute is missing', function () {
+				var column = omnitable.columns.find(function (col) {
+					return col.name === 'columnWithoutGroupOn';
+				});
+
+				assert.equal(column.groupOn, 'valuePath');
+			});
+
+			test('sets column groupOn property to group-on attribute', function () {
+				var column = omnitable.columns.find(function (col) {
+					return col.name === 'columnWithGroupOn';
+				});
+
+				assert.equal(column.groupOn, 'groupOnValuePath');
+			});
+
+			test('sets column sortOn property to valuePath when sort-on attribute is missing', function () {
+				var column = omnitable.columns.find(function (col) {
+					return col.name === 'columnWithoutSortOn';
+				});
+
+				assert.equal(column.sortOn, 'valuePath');
+			});
+			test('sets column sortOn property to sort-on attribute', function () {
+				var column = omnitable.columns.find(function (col) {
+					return col.name === 'columnWithSortOn';
+				});
+
+				assert.equal(column.sortOn, 'sortOnValuePath');
 			});
 		});
 


### PR DESCRIPTION
* Do not update `sortOn` or `groupOn` property of columns with `valuePath` if they have been set
* Added test to show issue with column's groupOn and sortOn properties
* Attempt to fix weird timeout when running tests