### PR TITLE
Check for null formatter in date columns

### DIFF
--- a/cosmoz-omnitable-column-date-behavior.html
+++ b/cosmoz-omnitable-column-date-behavior.html
@@ -111,6 +111,9 @@
 		},
 
 		renderValue(value, formatter = this.formatter) {
+			if (formatter == null) {
+				return;
+			}
 			const date = this.toValue(value);
 			if (date == null) {
 				return;


### PR DESCRIPTION
Check for null formatter in date columns.
Formatter can be null/undefined in 2.x when filter is set to value before the column is initialized.