### PR TITLE
Set _methodHost  to the host property

### DIFF
--- a/cosmoz-omnitable-templatizer.html
+++ b/cosmoz-omnitable-templatizer.html
@@ -32,6 +32,7 @@
 		init: function (template, host) {
 			this._template = template;
 			this._templateHost = host;
+			this._methodHost = host;
 			this.dataHost = host;
 		},
 


### PR DESCRIPTION
Set _methodHost  to the host property to fix` method hasFilter not defined` warning.