### PR TITLE
Column list, column list, fix for suggestions not displayed when text property is used

### DIFF
--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -20,8 +20,8 @@
 				source="[[ autocompleteItems ]]"
 				label="[[ title ]]"
 				selected-items="{{ autocompleteSelectedItems }}"
-				text-property="label"
-				value-property="value"
+				text-property="[[ textProperty ]]"
+				value-property="[[ valueProperty ]]"
 				show-results-on-focus>
 			</paper-autocomplete-chips>
 		</template>


### PR DESCRIPTION
This pull request fixes the suggestions that are not correctly displayed when text property is used. Related to #179.

Tested and seems to work, 2 approves or a merge requested.