### PR TITLE
cosmoz-omnitable-column-list - Suggestions does not work with object items, fix

### DIFF
--- a/cosmoz-omnitable-column-list-data.html
+++ b/cosmoz-omnitable-column-list-data.html
@@ -10,6 +10,10 @@
 				display: block;
 			}
 
+			:host a {
+				color: var(--primary-link-color, inherit);
+			}
+
 			[hidden] {
 				display: none;
 			}

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -89,24 +89,14 @@
 					.sort();
 			},
 
-			_applySingleFilter(filterString, item) {
-				const value = this.get(this.valuePath, item);
-				if (value == null) {
-					return false;
-				}
-				return value.toString().toLowerCase() === filterString;
-			},
-
 			_applyMultiFilter(filter, item) {
-				const filterArray = filter.map(element => {
-						return element ? element.toString().toLowerCase() : null;
-					}),
+				const filterArray = filter,
 					listValue = this.get(this.valuePath, item);
 				return listValue.some(val => {
-					if (val instanceof Object && filterArray.indexOf(val[this.valueProperty].toLowerCase()) >= 0) {
+					if (val instanceof Object && filterArray.indexOf(val[this.valueProperty]) >= 0) {
 						return true;
 					}
-					if (filterArray.indexOf(val.toString().toLowerCase()) >= 0) {
+					if (filterArray.indexOf(val) >= 0) {
 						return true;
 					}
 					return false;
@@ -116,15 +106,21 @@
 			_autocompleteSelectedItemsChanged() {
 				const filter = this.filter,
 					items = this.autocompleteSelectedItems;
-				if (Array.isArray(filter) && items.length === this.filter.length && items.every((item, i) => item instanceof Object && item[this.valueProperty] === filter[i] || item === filter[i])) {
+				if (Array.isArray(filter)
+					&& items.length === this.filter.length
+					&& items.every((item, i) =>
+						item instanceof Object && item[this.valueProperty] === filter[i] || item === filter[i])) {
 					return;
 				}
-				this.filter = this.autocompleteSelectedItems.map(item => item instanceof Object && item[this.valueProperty] || item);
+				this.filter = this.autocompleteSelectedItems.map(item => item instanceof Object ? item[this.valueProperty] : item);
 			},
 
 			_filterChanged(filter, autoItems) {
 				const items = this.autocompleteSelectedItems;
-				if (!Array.isArray(autoItems) || Array.isArray(items) && items.length === this.filter.length && filter.every((f, i) => items[i] && f === items[i].value)) {
+				if (!Array.isArray(autoItems)
+					|| Array.isArray(items)
+						&& items.length === this.filter.length
+						&& filter.every((f, i) => items[i] instanceof Object && f === items[i][this.valueProperty] || items[i] === f)) {
 					return;
 				}
 				this.autocompleteSelectedItems = this.filter.map(f => {

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -120,7 +120,7 @@
 					return;
 				}
 				this.autocompleteSelectedItems = this.filter.map(f => {
-					return autoItems.find(a => a.value === f);
+					return autoItems.find(a => a[this.valueProperty] === f);
 				});
 			}
 		});

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -101,7 +101,7 @@
 					}),
 					listValue = this.get(this.valuePath, item);
 				return listValue.some(val =>
-					filterArray.indexOf(val.toString().toLowerCase()) >= 0
+					filterArray.indexOf(val[this.valueProperty].toLowerCase()) >= 0
 				);
 			},
 

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -78,8 +78,10 @@
 					.filter((value, index, array) => {
 						let arrayIndexMatching = -1;
 						array.forEach((arrayCurrentValue, arrayIndex) => {
-							if (arrayIndexMatching === -1 && arrayCurrentValue[this.valueProperty] === value[this.valueProperty]) {
-								arrayIndexMatching = arrayIndex;
+							if (arrayIndexMatching === -1) {
+								if (arrayCurrentValue instanceof Object && arrayCurrentValue[this.valueProperty] === value[this.valueProperty] || arrayCurrentValue === value) {
+									arrayIndexMatching = arrayIndex;
+								}
 							}
 						});
 						return arrayIndexMatching === index;
@@ -100,18 +102,24 @@
 						return element ? element.toString().toLowerCase() : null;
 					}),
 					listValue = this.get(this.valuePath, item);
-				return listValue.some(val =>
-					filterArray.indexOf(val[this.valueProperty].toLowerCase()) >= 0
-				);
+				return listValue.some(val => {
+					if (val instanceof Object && filterArray.indexOf(val[this.valueProperty].toLowerCase()) >= 0) {
+						return true;
+					}
+					if (filterArray.indexOf(val.toString().toLowerCase()) >= 0) {
+						return true;
+					}
+					return false;
+				});
 			},
 
 			_autocompleteSelectedItemsChanged() {
 				const filter = this.filter,
 					items = this.autocompleteSelectedItems;
-				if (Array.isArray(filter) && items.length === this.filter.length &&  items.every((item, i) => item[this.valueProperty] === filter[i])) {
+				if (Array.isArray(filter) && items.length === this.filter.length && items.every((item, i) => item instanceof Object && item[this.valueProperty] === filter[i] || item === filter[i])) {
 					return;
 				}
-				this.filter = this.autocompleteSelectedItems.map(item => item[this.valueProperty]);
+				this.filter = this.autocompleteSelectedItems.map(item => item instanceof Object && item[this.valueProperty] || item);
 			},
 
 			_filterChanged(filter, autoItems) {
@@ -120,7 +128,7 @@
 					return;
 				}
 				this.autocompleteSelectedItems = this.filter.map(f => {
-					return autoItems.find(a => a[this.valueProperty] === f);
+					return autoItems.find(a => a instanceof Object && a[this.valueProperty] === f || a === f);
 				});
 			}
 		});

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -64,6 +64,14 @@
 						return this._getDefaultFilter();
 					}
 				},
+
+				textProperty: {
+					type: String
+				},
+
+				valueProperty: {
+					type: String
+				}
 			},
 
 			observers: [
@@ -75,21 +83,16 @@
 				return this.values
 					.reduce((acc, val) => acc.concat(val), [])
 					// Make the item list unique
-					.filter((value, index, array) => array.indexOf(value) === index)
-					.sort()
-					.map(value => {
-						return {
-							value: value,
-							label: this._getLabelForValue(value)
-						};
-					});
-			},
-
-			_getLabelForValue(value) {
-				if (value == null) {
-					return null;
-				}
-				return value.toString();
+					.filter((value, index, array) => {
+						let arrayIndexMatching = -1;
+						array.forEach((arrayCurrentValue, arrayIndex) => {
+							if (arrayIndexMatching === -1 && arrayCurrentValue[this.valueProperty] === value[this.valueProperty]) {
+								arrayIndexMatching = arrayIndex;
+							}
+						});
+						return arrayIndexMatching === index;
+					})
+					.sort();
 			},
 
 			_applySingleFilter(filterString, item) {
@@ -114,7 +117,7 @@
 			_autocompleteSelectedItemsChanged() {
 				const filter = this.filter,
 					items = this.autocompleteSelectedItems;
-				if (Array.isArray(filter) && items.length === this.filter.length &&  items.every((item, i) => item.value === filter[i])) {
+				if (Array.isArray(filter) && items.length === this.filter.length &&  items.every((item, i) => item[this.valueProperty] === filter[i])) {
 					return;
 				}
 				this.filter = this.autocompleteSelectedItems.map(item => item.value);

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -111,7 +111,7 @@
 				if (Array.isArray(filter) && items.length === this.filter.length &&  items.every((item, i) => item[this.valueProperty] === filter[i])) {
 					return;
 				}
-				this.filter = this.autocompleteSelectedItems.map(item => item.value);
+				this.filter = this.autocompleteSelectedItems.map(item => item[this.valueProperty]);
 			},
 
 			_filterChanged(filter, autoItems) {

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -63,14 +63,6 @@
 					value() {
 						return this._getDefaultFilter();
 					}
-				},
-
-				textProperty: {
-					type: String
-				},
-
-				valueProperty: {
-					type: String
 				}
 			},
 
@@ -108,7 +100,6 @@
 						return element ? element.toString().toLowerCase() : null;
 					}),
 					listValue = this.get(this.valuePath, item);
-
 				return listValue.some(val =>
 					filterArray.indexOf(val.toString().toLowerCase()) >= 0
 				);

--- a/test/list.html
+++ b/test/list.html
@@ -84,12 +84,12 @@
 			});
 
 			test('_applyMultiFilter works', () => {
-				assert.isTrue(column._applyMultiFilter([123, 456], { list: ['123', '345', '678']}));
+				assert.isTrue(column._applyMultiFilter([123, 456], { list: [123, 345, 678]}));
 			});
 
 			test('_filterChanged updates autocompleteSelectedItems', () => {
-				column.autocompleteSelectedItems = ['123', '456'];
-				assert.deepEqual(column._filterChanged([123, 456], ['123', '456']));
+				column.autocompleteSelectedItems = [123, 456];
+				assert.deepEqual(column._filterChanged([123, 456], [123, 456]));
 			});
 
 		});

--- a/test/list.html
+++ b/test/list.html
@@ -71,12 +71,6 @@
 				assert.equal(column._getDefaultFilter().length, 0);
 			});
 
-			test('_getLabelForValue returns value to String', () => {
-				assert.isNull(column._getLabelForValue());
-				assert.equal(column._getLabelForValue(123), '123');
-				assert.equal(column._getLabelForValue([1, 2, 3]), '1,2,3');
-			});
-
 			test('_applySingleFilter returns true if filterString is equal to value', () => {
 				assert.isTrue(column._applySingleFilter('abc', {list: 'abc', some: 'data'}));
 			});
@@ -130,12 +124,6 @@
 				assert.equal(column.filter.length, 0);
 				assert.isTrue(Array.isArray(column._getDefaultFilter()));
 				assert.equal(column._getDefaultFilter().length, 0);
-			});
-
-			test('_getLabelForValue returns value to String', () => {
-				assert.isNull(column._getLabelForValue());
-				assert.equal(column._getLabelForValue(123), '123');
-				assert.equal(column._getLabelForValue([1, 2, 3]), '1,2,3');
 			});
 
 			test('_applySingleFilter returns true if filterString is equal to value', () => {


### PR DESCRIPTION
This pull request fixes the column suggestions for cosmoz-omnitable-column-list when this column is used with data arrays containing objects instead of strings as requested in #182.

Tested both in administration of roles with regular strings and list prioritized suppliers with objects, seems to work as it should with both.

2 approves or a merge requested.