### PR TITLE
Number getComparableValue with maximumFractionDigits tests, fix.

### DIFF
--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -113,8 +113,9 @@
 					return;
 				}
 
-				const decimals = this.minimumFractionDigits;
+				const decimals = this.maximumFractionDigits;
 				if (decimals !== null) {
+					// truncate value to maximum decimals; https://github.com/Neovici/cosmoz-omnitable/issues/176
 					const d = Math.pow(10, decimals),
 						temp = parseInt(value * d, 10) / d;
 					return temp.toFixed(decimals);

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -115,10 +115,7 @@
 
 				const decimals = this.maximumFractionDigits;
 				if (decimals !== null) {
-					// truncate value to maximum decimals; https://github.com/Neovici/cosmoz-omnitable/issues/176
-					const d = Math.pow(10, decimals),
-						temp = parseInt(value * d, 10) / d;
-					return temp.toFixed(decimals);
+					return value.toFixed(decimals);
 				}
 				return value;
 			},

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -93,6 +93,35 @@
 				return new Intl.NumberFormat(locale || undefined, options);
 			},
 
+			/**
+			 *   Get the comparable value of an item.
+			 *
+			 * @param  {Object} item       Item to be processed
+			 * @param  {String} valuePath  Property path
+			 * @returns {Number|void}      Valid value or void
+			 */
+			getComparableValue(item, valuePath) {
+				if (item == null) {
+					return;
+				}
+				let value = item;
+				if (valuePath != null) {
+					value = this.get(valuePath, item);
+				}
+				value = this.toValue(value);
+				if (value == null) {
+					return;
+				}
+
+				const decimals = this.minimumFractionDigits;
+				if (decimals !== null) {
+					const d = Math.pow(10, decimals),
+						temp = parseInt(value * d, 10) / d;
+					return temp.toFixed(decimals);
+				}
+				return value;
+			},
+
 			renderValue(value, formatter = this.formatter) {
 				const number = this.toNumber(value);
 				if (number == null) {

--- a/test/range.html
+++ b/test/range.html
@@ -48,39 +48,6 @@
 	<script>
 	(function () {
 		'use strict';
-		const data = [
-			{
-				age: 17,
-				amount: { amount: '12.4', currency: 'USD' },
-			},
-			{
-				amount: { amount: 2 }
-			},
-			{
-				age: -11,
-				amount: { amount: 678, currency: 'AUD' }
-			},
-			{
-				age: 9,
-				amount: { amount: -8, currency: 'EUR' }
-			},
-			{
-				age: 5,
-				amount: { amount: '3450', currency: 'DKK' }
-			},
-			{
-				amount: { amount: 2015, currency: 'EUR' }
-			},
-			{
-				age: 46.7511, // 46,75xx
-				amount: { amount: 347, currency: 'USD' }
-			},
-			{
-				age: 46.768, // needed in maximumFractionDigits test
-				amount: { amount: 2581, currency: 'EUR' }
-			}
-		];
-
 		const domType = getDomType(),
 			data = [
 				{
@@ -106,9 +73,11 @@
 					amount: { amount: 2015, currency: 'EUR' }
 				},
 				{
+					age: 46.7511, // 46,75xx
 					amount: { amount: 347, currency: 'USD' }
 				},
 				{
+					age: 46.768, // needed in maximumFractionDigits test
 					amount: { amount: 2581, currency: 'EUR' }
 				}
 			];

--- a/test/range.html
+++ b/test/range.html
@@ -20,7 +20,7 @@
 	<test-fixture id="range">
 		<template>
 			<cosmoz-omnitable id="omnitable" class="flex">
-				<cosmoz-omnitable-column-number title="Age" name="age" value-path="age" minimum-fraction-digits=2>
+				<cosmoz-omnitable-column-number title="Age" name="age" value-path="age" maximum-fraction-digits=2>
 				</cosmoz-omnitable-column-number>
 				<cosmoz-omnitable-column-amount title="Amount" name="amount" value-path="amount">
 				</cosmoz-omnitable-column-amount>
@@ -75,7 +75,7 @@
 				amount: { amount: 347, currency: 'USD' }
 			},
 			{
-				age: 46.768, // needed in minimumFractionDigits test
+				age: 46.768, // needed in maximumFractionDigits test
 				amount: { amount: 2581, currency: 'EUR' }
 			}
 		];
@@ -219,7 +219,7 @@
 				column._filterInput =  {min: -11, max: 17};
 			});
 
-			test('filter comparision uses minimumFractionDigits', done => {
+			test('filter comparision uses maximumFractionDigits', done => {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
 

--- a/test/range.html
+++ b/test/range.html
@@ -225,14 +225,12 @@
 
 				const handler = () => {
 					const items  = omnitable.sortedFilteredGroupedItems;
-					assert.equal(items.length, 4, 'Expected item coresponding to the age: 46.768 to be in the filtered items.');
-					assert.equal(items[3].amount.amount, 2581); // item coresponding to the age: 46.768 is present on the filtered items.
-
+					assert.equal(items.filter(item => item.age && item.age === 46.768).length, 0,  'Expected item coresponding to the age: 46.768 not to be in the filtered items, because it is outside the range.');
 					omnitable.removeEventListener('sorted-filtered-grouped-items-changed', handler);
 					done();
 				};
 				omnitable.addEventListener('sorted-filtered-grouped-items-changed', handler);
-				column._filterInput =  {min: 46.76, max: 46.76};
+				column._filterInput =  {min: 46.75, max: 46.76};
 			});
 		});
 

--- a/test/range.html
+++ b/test/range.html
@@ -20,7 +20,7 @@
 	<test-fixture id="range">
 		<template>
 			<cosmoz-omnitable id="omnitable" class="flex">
-				<cosmoz-omnitable-column-number title="Age" name="age" value-path="age">
+				<cosmoz-omnitable-column-number title="Age" name="age" value-path="age" minimum-fraction-digits=2>
 				</cosmoz-omnitable-column-number>
 				<cosmoz-omnitable-column-amount title="Amount" name="amount" value-path="amount">
 				</cosmoz-omnitable-column-amount>
@@ -48,6 +48,37 @@
 	<script>
 	(function () {
 		'use strict';
+		const data = [
+			{
+				age: 17,
+				amount: { amount: '12.4', currency: 'USD' },
+			},
+			{
+				amount: { amount: 2 }
+			},
+			{
+				age: -11,
+				amount: { amount: 678, currency: 'AUD' }
+			},
+			{
+				age: 9,
+				amount: { amount: -8, currency: 'EUR' }
+			},
+			{
+				age: 5,
+				amount: { amount: '3450', currency: 'DKK' }
+			},
+			{
+				amount: { amount: 2015, currency: 'EUR' }
+			},
+			{
+				amount: { amount: 347, currency: 'USD' }
+			},
+			{
+				age: 46.768, // needed in minimumFractionDigits test
+				amount: { amount: 2581, currency: 'EUR' }
+			}
+		];
 
 		const domType = getDomType(),
 			data = [
@@ -120,7 +151,7 @@
 			test('computes range from values', function (done) {
 				assert.isObject(column._range);
 				assert.equal(column._range.min, -11);
-				assert.equal(column._range.max, 17);
+				assert.equal(column._range.max, 46.768);
 				done();
 			});
 
@@ -186,6 +217,22 @@
 					});
 				});
 				column._filterInput =  {min: -11, max: 17};
+			});
+
+			test('filter comparision uses minimumFractionDigits', done => {
+				assert.isNull(column._filterInput.min);
+				assert.isNull(column._filterInput.max);
+
+				const handler = () => {
+					const items  = omnitable.sortedFilteredGroupedItems;
+					assert.equal(items.length, 4, 'Expected item coresponding to the age: 46.768 to be in the filtered items.');
+					assert.equal(items[3].amount.amount, 2581); // item coresponding to the age: 46.768 is present on the filtered items.
+
+					omnitable.removeEventListener('sorted-filtered-grouped-items-changed', handler);
+					done();
+				};
+				omnitable.addEventListener('sorted-filtered-grouped-items-changed', handler);
+				column._filterInput =  {min: 46.76, max: 46.76};
 			});
 		});
 

--- a/test/range.html
+++ b/test/range.html
@@ -72,6 +72,7 @@
 				amount: { amount: 2015, currency: 'EUR' }
 			},
 			{
+				age: 46.7511, // 46,75xx
 				amount: { amount: 347, currency: 'USD' }
 			},
 			{
@@ -219,13 +220,24 @@
 				column._filterInput =  {min: -11, max: 17};
 			});
 
-			test('filter comparision uses maximumFractionDigits', done => {
+			test('filter comparision uses maximumFractionDigits; item age outside the range', done => {
 				assert.isNull(column._filterInput.min);
 				assert.isNull(column._filterInput.max);
 
 				const handler = () => {
 					const items  = omnitable.sortedFilteredGroupedItems;
 					assert.equal(items.filter(item => item.age && item.age === 46.768).length, 0,  'Expected item coresponding to the age: 46.768 not to be in the filtered items, because it is outside the range.');
+					omnitable.removeEventListener('sorted-filtered-grouped-items-changed', handler);
+					done();
+				};
+				omnitable.addEventListener('sorted-filtered-grouped-items-changed', handler);
+				column._filterInput =  {min: 46.75, max: 46.76};
+			});
+
+			test('filter comparision uses maximumFractionDigits, item age inside range', done => {
+				const handler = () => {
+					const items  = omnitable.sortedFilteredGroupedItems;
+					assert.equal(items.filter(item => item.age && item.age === 46.7511).length, 1,  'Expected item coresponding to the age: 46.7511 to be in the filtered items.');
 					omnitable.removeEventListener('sorted-filtered-grouped-items-changed', handler);
 					done();
 				};

--- a/test/range.html
+++ b/test/range.html
@@ -244,6 +244,11 @@
 				omnitable.addEventListener('sorted-filtered-grouped-items-changed', handler);
 				column._filterInput =  {min: 46.75, max: 46.76};
 			});
+
+			test('getString displays 46.768 as 46.77', done => {
+				assert.equal(column.getString({age: 46.768}), 46.77);
+				done();
+			});
 		});
 
 		suite('amount', () => {


### PR DESCRIPTION
fixes: #176

1. Implemented Test: item with age: 46.768 and amount: 2581 should be in the filtered items when filtering from 46.76 to 46.76  Done.
2. In cosmoz-omnitable-column-number.html added getComparableValue and added the check for minimumFractionDigits. Value is truncated to the specified decimals (2 in the test). Done.
3. Rebased on latest changes from master. Done.
4. Replaced minimumFractionDigits with maximumFractionDigits in column and range test. Done.

5. Implement Test: If we filter out values between 46,75 - 46,76, we shouldn't show a value with 46,768 since it's outside the range. Done.

6. restore toFixed to round up instead of truncate to n digits. Done.
7. Implement test: But we should show 46,75xx. Done.
8. Verify if: However, if 46,768 is displayed as 46,76 then that's the error, it should be 46,77. Done.
