### PR TITLE
CSS change to align paper-dropdown-menu and paper-dropdown-menu-light…

### DIFF
--- a/cosmoz-omnitable-styles.html
+++ b/cosmoz-omnitable-styles.html
@@ -211,6 +211,14 @@
 				@apply --cosmoz-omnitable-hightlighted-row;
 			}
 
+			.tableContent .itemRow-cell paper-dropdown-menu-light {
+				margin-top:-19px;
+			}
+
+			.tableContent .itemRow-cell paper-dropdown-menu {
+				margin-top:-20px;
+			}
+
 			.item-expander paper-icon-button {
 				min-height: 24px;
 				max-height: 24px;


### PR DESCRIPTION
… within omnitable cells

I thought I saw some Travis error but all I changed was a few lines of CSS-code and now a merge seems possible. Do I just ignore that? Please have a look when reviewing.

And also. I guess master is where this should be merged? Correct?