### PR TITLE
removing negative margin for paper-dropdown-menu-light. Changing beca…

### DIFF
--- a/cosmoz-omnitable-styles.html
+++ b/cosmoz-omnitable-styles.html
@@ -211,10 +211,6 @@
 				@apply --cosmoz-omnitable-hightlighted-row;
 			}
 
-			.tableContent .itemRow-cell paper-dropdown-menu-light {
-				margin-top:-19px;
-			}
-
 			.tableContent .itemRow-cell paper-dropdown-menu {
 				margin-top:-20px;
 			}


### PR DESCRIPTION
…use we can manage omnitable inline alignment by hiding label on a view level instead.