### PR TITLE
Fix so given label is shown instead of booleans when saving to xlsx. 

### DIFF
--- a/cosmoz-omnitable-column-boolean.html
+++ b/cosmoz-omnitable-column-boolean.html
@@ -163,7 +163,15 @@
 			_deserializeFilter(obj) {
 				const value = this.deserialize(obj, String);
 				return value === 'true' ? true : value === 'false' ? false : null;
+			},
+
+			toXlsxValue(item, valuePath = this.valuePath) {
+				if (!valuePath) {
+					return '';
+				}
+				return this.get(valuePath, item) ? this.trueLabel : this.falseLabel;
 			}
+
 		});
 
 	</script>


### PR DESCRIPTION
Overrides toXlsxValue in column boolean, so it returns trueLabel/falseLabel instead of true/false.

See RM 19713