### PR TITLE
Repopulate values for a column when external-values gets disabled

### DIFF
--- a/cosmoz-omnitable-column-behavior.html
+++ b/cosmoz-omnitable-column-behavior.html
@@ -42,7 +42,8 @@
 			 */
 			externalValues: {
 				type: Boolean,
-				value: false
+				value: false,
+				observer: '_externalValuesChanged'
 			},
 
 			filter: {
@@ -260,6 +261,19 @@
 			if (cellTemplate !== undefined && cellTemplate !== null) {
 				this._cellTemplatizer = this._createTemplatizer(cellTemplate);
 			}
+		},
+
+		_externalValuesChanged(newExternalValuesValue) {
+			if (newExternalValuesValue) {
+				return;
+			}
+			this.dispatchEvent(new CustomEvent('cosmoz-column-values-update', {
+				bubbles: true,
+				composed: true,
+				detail: {
+					column: this
+				}
+			}));
 		},
 
 		get editableTemplatizer() {

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -255,7 +255,7 @@
 			'cosmoz-column-title-changed': '_onColumnTitleChanged',
 			'cosmoz-column-filter-changed': '_filterChanged',
 			'cosmoz-column-editable-changed': '_onColumnEditableChanged',
-
+			'cosmoz-column-values-update': '_onColumnValuesUpdate'
 		},
 
 		attached() {
@@ -497,6 +497,13 @@
 			});
 
 			return columnsMissingNameAttribute.length === 0;
+		},
+
+		_onColumnValuesUpdate(event, detail) {
+			if (detail == null || detail.column == null) {
+				return;
+			}
+			this._setColumnValues([detail.column]);
 		},
 		// TODO: provides a mean to avoid setting the values for a column
 		// TODO: should process (distinct, sort, min, max) the values at the column level depending on the column type


### PR DESCRIPTION
When a column is configured for external values, the list of local
values are not updated. Also when the column is "unconfigured" for
external values, it doesn't repopulate the local values.

This PR enables columns to send an event, requesting a new list of
values from the Omnitable "mother", hopefully making the user
experience nicer.

This seemed to be triggered in ways also where omnitable initially is
configured for externalValues but updated to reflect that it, in fact,
should not be after BE response. Causing columns to have no values at all.

There might be a significant performance impact of this if views are
flipping between externalValues and not for all columns, multiple times
in a short timeframe or there a significant amount of rows loaded when
flipping it to false. But it should be fine.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>