### PR TITLE
[REVERT ME] Disable Firefox testing

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -2,7 +2,7 @@
 	"testTimeout": 900000,
 	"plugins": {
 		"local": {
-			"browsers": ["chrome", "firefox"]
+			"browsers": ["chrome"]
 		},
 		"istanbul": {
 			"dir": "./coverage",


### PR DESCRIPTION
[REVERT ME] Disable Firefox testing.

Disabling Firefox since selenium-standalone uses an outdated geckodriver which breaks tests.

As requested by @nomego.