### PR TITLE
20454 - Adding item row border bottom style

### DIFF
--- a/cosmoz-omnitable-styles.html
+++ b/cosmoz-omnitable-styles.html
@@ -193,9 +193,11 @@
 			}
 
 			.itemRow {
+				border-bottom-color: #e2e2e2;
+				border-bottom-width: 1px;
+				border-bottom-style: var(--cosmoz-omnitable-item-row-border-bottom-style, solid);
 				/* set a min-height for rows so that rows with empty values are visible */
 				min-height: 24px;
-				border-bottom: solid 1px #e2e2e2;
 				padding-right: 8px;
 				@apply --layout-horizontal;
 				@apply --layout-center;


### PR DESCRIPTION
Adding item row border bottom style.

Testing: Check that item rows has the regular bottom border. Try to set the different style for the bottom bar like:

```
cosmoz-omnitable {
  --cosmoz-omnitable-item-row-border-bottom-style: none;
}
```

Requested in issue #20454.