### PR TITLE
list column - refactor data flow

### DIFF
--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -7,7 +7,7 @@
 <dom-module id="cosmoz-omnitable-column-list">
 	<template>
 		<template class="cell">
-			<cosmoz-omnitable-column-list-data items="[[ get(valuePath, item) ]]">
+			<cosmoz-omnitable-column-list-data items="[[ getTexts(valuePath, item, textProperty) ]]">
 			</cosmoz-omnitable-column-list-data>
 		</template>
 
@@ -19,7 +19,7 @@
 			<paper-autocomplete-chips
 				source="[[ autocompleteItems ]]"
 				label="[[ title ]]"
-				selected-items="{{ autocompleteSelectedItems }}"
+				selected-items="{{ filter }}"
 				text-property="[[ textProperty ]]"
 				value-property="[[ valueProperty ]]"
 				show-results-on-focus>
@@ -41,11 +41,7 @@
 				autocompleteItems: {
 					type: Array,
 					notify: true,
-					computed: '_computeAutocompleteItems(values.length)'
-				},
-
-				autocompleteSelectedItems: {
-					type: Array
+					computed: '_computeAutocompleteItems(valueProperty, values.length)'
 				},
 
 				/**
@@ -63,70 +59,67 @@
 					value() {
 						return this._getDefaultFilter();
 					}
+				},
+
+				textProperty: {
+					type: String,
+					value: ''
+				},
+
+				valueProperty: {
+					type: String,
+					value: ''
 				}
 			},
 
-			observers: [
-				'_autocompleteSelectedItemsChanged(autocompleteSelectedItems.length)',
-				'_filterChanged(filter, autocompleteItems)'
-			],
+			getTexts(valuePath, item, textProperty) {
+				let values = this.get(valuePath, item);
+				if (textProperty) {
+					values = values.map(value => this.get(textProperty, value));
+				}
+				return values;
+			},
 
-			_computeAutocompleteItems() {
+			_computeAutocompleteItems(valueProperty) {
+				if (!Array.isArray(this.values)) {
+					return;
+				}
+				const used = [];
 				return this.values
+					// flatten two-dimensional arrays to one
 					.reduce((acc, val) => acc.concat(val), [])
 					// Make the item list unique
-					.filter((value, index, array) => {
-						let arrayIndexMatching = -1;
-						array.forEach((arrayCurrentValue, arrayIndex) => {
-							if (arrayIndexMatching === -1) {
-								if (arrayCurrentValue instanceof Object && arrayCurrentValue[this.valueProperty] === value[this.valueProperty] || arrayCurrentValue === value) {
-									arrayIndexMatching = arrayIndex;
-								}
+					.filter((item, index, array) => {
+						if (array.indexOf(item) !== index) {
+							return false;
+						}
+						if (valueProperty) {
+							let value = this.get(valueProperty, item);
+							if (used.indexOf(value) !== -1) {
+								return false;
 							}
-						});
-						return arrayIndexMatching === index;
+							used.push(value);
+						}
+						return true;
 					})
 					.sort();
 			},
 
-			_applyMultiFilter(filter, item) {
-				const filterArray = filter,
-					listValue = this.get(this.valuePath, item);
-				return listValue.some(val => {
-					if (val instanceof Object && filterArray.indexOf(val[this.valueProperty]) >= 0) {
-						return true;
-					}
-					if (filterArray.indexOf(val) >= 0) {
-						return true;
-					}
-					return false;
-				});
-			},
-
-			_autocompleteSelectedItemsChanged() {
-				const filter = this.filter,
-					items = this.autocompleteSelectedItems;
-				if (Array.isArray(filter)
-					&& items.length === this.filter.length
-					&& items.every((item, i) =>
-						item instanceof Object && item[this.valueProperty] === filter[i] || item === filter[i])) {
-					return;
+			_applyMultiFilter(filters, item) {
+				let itemValues = this.get(this.valuePath, item);
+				if (!Array.isArray(itemValues)) {
+					itemValues = [itemValues];
 				}
-				this.filter = this.autocompleteSelectedItems.map(item => item instanceof Object ? item[this.valueProperty] : item);
-			},
-
-			_filterChanged(filter, autoItems) {
-				const items = this.autocompleteSelectedItems;
-				if (!Array.isArray(filter)
-					|| !Array.isArray(autoItems)
-					|| Array.isArray(items)
-						&& items.length === this.filter.length
-						&& filter.every((f, i) => items[i] instanceof Object && f === items[i][this.valueProperty] || items[i] === f)) {
-					return;
+				if (!this.valueProperty) {
+					return filters.some(filter => itemValues.indexOf(filter) > -1);
 				}
-				this.autocompleteSelectedItems = this.filter.map(f => {
-					return autoItems.find(a => a instanceof Object && a[this.valueProperty] === f || a === f);
-				});
+				return filters
+					.map(filter => filter[this.valueProperty])
+					.some(filterValue =>
+						itemValues
+							.map(itemValue => itemValue[this.valueProperty])
+							.some(itemValue => itemValue === filterValue)
+					);
 			}
 		});
 	</script>

--- a/test/list.html
+++ b/test/list.html
@@ -82,12 +82,6 @@
 			test('_applyMultiFilter works', () => {
 				assert.isTrue(column._applyMultiFilter([123, 456], { list: [123, 345, 678]}));
 			});
-
-			test('_filterChanged updates autocompleteSelectedItems', () => {
-				column.autocompleteSelectedItems = [123, 456];
-				assert.deepEqual(column._filterChanged([123, 456], [123, 456]));
-			});
-
 		});
 		suite('horizontal' + domType, () => {
 			let omnitable,


### PR DESCRIPTION
- drop unnecessary transformation through selected items vs filter
-- makes filterChanged handler unnecessary
--- makes filterChanged test unnecessary
-- improves data flow (shorter, one-way, keeps original objects)
- reuse unique array filtering logic from autocomplete
-- avoids inner loop

Prepares list to be aligned with autocomplete.

Testing made easier after merging #250 250

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>