### PR TITLE
saving csv created faulty content with horizontal list columns

### DIFF
--- a/cosmoz-omnitable-column-list-horizontal.html
+++ b/cosmoz-omnitable-column-list-horizontal.html
@@ -158,6 +158,18 @@
 
 				return value.join(', ');
 			}
+
+			toXlsxValue(item, valuePath = this.valuePath) {
+				const textProp = this.textProperty,
+					value = super.getString.apply(this, arguments);
+				if (!valuePath || !Array.isArray(value) || value.length === 0) {
+					return '';
+				}
+				if (textProp != null) {
+					return value.map(val => this.get(textProp, val)).filter(Boolean).join(', ');
+				}
+				return this.getString(item, valuePath);
+			}
 		}
 
 		customElements.define(

--- a/cosmoz-omnitable-column-list-horizontal.html
+++ b/cosmoz-omnitable-column-list-horizontal.html
@@ -56,7 +56,7 @@
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 * @appliesMixin Cosmoz.ListColumnMixin
 		 */
-		class OmnitableColumnListHorizontal extends	Cosmoz.OmnitableColumnMixin(Cosmoz.ListColumnMixin(
+		class OmnitableColumnListHorizontal extends	Cosmoz.ListColumnMixin(Cosmoz.OmnitableColumnMixin(
 			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
 		)) {
 			static get is() {
@@ -145,29 +145,7 @@
 				return [];
 			}
 
-			getString() {
-				const textProp = this.textProperty,
-					value = super.getString.apply(this, arguments);
-				if (!Array.isArray(value) || value.length === 0) {
-					return '';
-				}
-
-				if (textProp !== null) {
-					return value.map(val => this.get(textProp, val)).filter(Boolean).join(', ');
-				}
-
-				return value.join(', ');
-			}
-
 			toXlsxValue(item, valuePath = this.valuePath) {
-				const textProp = this.textProperty,
-					value = super.getString.apply(this, arguments);
-				if (!valuePath || !Array.isArray(value) || value.length === 0) {
-					return '';
-				}
-				if (textProp != null) {
-					return value.map(val => this.get(textProp, val)).filter(Boolean).join(', ');
-				}
 				return this.getString(item, valuePath);
 			}
 		}

--- a/cosmoz-omnitable-column-list-horizontal.html
+++ b/cosmoz-omnitable-column-list-horizontal.html
@@ -146,9 +146,14 @@
 			}
 
 			getString() {
-				const value = super.getString.apply(this, arguments);
+				const textProp = this.textProperty,
+					value = super.getString.apply(this, arguments);
 				if (!Array.isArray(value) || value.length === 0) {
 					return '';
+				}
+
+				if (textProp !== null) {
+					return value.map(val => this.get(textProp, val)).filter(Boolean).join(', ');
 				}
 
 				return value.join(', ');

--- a/cosmoz-omnitable-column-list-mixin.html
+++ b/cosmoz-omnitable-column-list-mixin.html
@@ -33,6 +33,7 @@
 			return values
 				.map(value => this.textProperty ? this.get(this.textProperty, value) : value)
 				.filter((value, index, array) => array.indexOf(value) === index)
+				.filter(Boolean)
 				.join(', ');
 		}
 	});


### PR DESCRIPTION
Checks for set textProperty in horizontal list column. If so, uses that value instead for csv string. 

Possible test candidate is order 22679_30_7365563740132_F , saving orderrows as csv. should be the text values instead of "Object Object" .

refs RM #21223

*edit*
Did the same for "save as xlsx". 