### PR TITLE
Fixed extend order and moved toXlsvValue to Mixin both extends from

### DIFF
--- a/cosmoz-omnitable-column-list-horizontal.html
+++ b/cosmoz-omnitable-column-list-horizontal.html
@@ -53,8 +53,8 @@
 		/**
 		 * @polymer
 		 * @customElement
-		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 * @appliesMixin Cosmoz.ListColumnMixin
+		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
 		class OmnitableColumnListHorizontal extends	Cosmoz.ListColumnMixin(Cosmoz.OmnitableColumnMixin(
 			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
@@ -143,10 +143,6 @@
 
 			_getDefaultFilter() {
 				return [];
-			}
-
-			toXlsxValue(item, valuePath = this.valuePath) {
-				return this.getString(item, valuePath);
 			}
 		}
 

--- a/cosmoz-omnitable-column-list-mixin.html
+++ b/cosmoz-omnitable-column-list-mixin.html
@@ -36,5 +36,10 @@
 				.filter(Boolean)
 				.join(', ');
 		}
+
+		toXlsxValue(item, valuePath = this.valuePath) {
+			return this.getString(item, valuePath);
+		}
+
 	});
 </script>

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -37,11 +37,11 @@
 		/**
 		 * @polymer
 		 * @customElement
-		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 * @appliesMixin Cosmoz.ListColumnMixin
+		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
 		class OmnitableColumnList extends
-			Cosmoz.OmnitableColumnMixin(Cosmoz.ListColumnMixin(
+			Cosmoz.ListColumnMixin(Cosmoz.OmnitableColumnMixin(
 				Polymer.mixinBehaviors(
 					[Cosmoz.TranslatableBehavior],
 					Polymer.Element


### PR DESCRIPTION
Should fix save as csv and xlsv in cosmoz-omnitable-column-list as well and not only cosmoz-omnitable-column-list-horizontal.

While trying more thoroughly testing in the many views, I discovered errors that needed to be fixed inside the views.
Created Pr https://github.com/Neovici/cosmoz-frontend/pull/1149 for this