### PR TITLE
Component, replacing translation behavior with mixin, upgrading cosmoz-i18next component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
 		"paper-listbox": "PolymerElements/paper-listbox#^2.1.1",
 		"paper-spinner": "PolymerElements/paper-spinner#^2.1.0",
 		"cosmoz-grouped-list": "Neovici/cosmoz-grouped-list#^2.0.4",
-		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.0",
+		"cosmoz-i18next": "Neovici/cosmoz-i18next#^2.0.1",
 		"cosmoz-bottom-bar": "neovici/cosmoz-bottom-bar#^2.2.1",
 		"cosmoz-behaviors": "neovici/cosmoz-behaviors#^2.0.0",
 		"cosmoz-page-router": "Neovici/cosmoz-page-router#^2.1.1",

--- a/cosmoz-omnitable-column-amount.html
+++ b/cosmoz-omnitable-column-amount.html
@@ -49,9 +49,11 @@
 		 * @appliesMixin Cosmoz.RangeColumnMixin
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
-		class OmnitableColumnAmount extends Cosmoz.RangeColumnMixin(Cosmoz.OmnitableColumnMixin(
-			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
-		)) {
+		class OmnitableColumnAmount extends Cosmoz.RangeColumnMixin(
+			Cosmoz.OmnitableColumnMixin(
+				Cosmoz.Mixins.translatable(Polymer.Element)
+			)
+		) {
 			static get is() {
 				return 'cosmoz-omnitable-column-amount';
 			}

--- a/cosmoz-omnitable-column-date.html
+++ b/cosmoz-omnitable-column-date.html
@@ -52,7 +52,7 @@
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
 		class OmnitableColumnDate extends Cosmoz.DateColumnMixin(Cosmoz.OmnitableColumnMixin(
-			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
+			Cosmoz.Mixins.translatable(Polymer.Element)
 		)) {
 			static get is() {
 				return 'cosmoz-omnitable-column-date';

--- a/cosmoz-omnitable-column-datetime.html
+++ b/cosmoz-omnitable-column-datetime.html
@@ -50,9 +50,11 @@
 		 * @appliesMixin Cosmoz.DateColumnMixin
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
-		class OmnitableColumnDatetime extends Cosmoz.DateColumnMixin(Cosmoz.OmnitableColumnMixin(
-			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
-		)) {
+		class OmnitableColumnDatetime extends Cosmoz.DateColumnMixin(
+			Cosmoz.OmnitableColumnMixin(
+				Cosmoz.Mixins.translatable(Polymer.Element)
+			)
+		) {
 			static get is() {
 				return 'cosmoz-omnitable-column-datetime';
 			}

--- a/cosmoz-omnitable-column-list-data.html
+++ b/cosmoz-omnitable-column-list-data.html
@@ -79,6 +79,11 @@
 				};
 			}
 
+			isEmpty() {
+				// FIXME: remove this when TemplateHelperBehavior is a 2.x mixin
+				return Cosmoz.TemplateHelperBehavior.isEmpty.apply(this, arguments);
+			}
+
 			_firstItem(items) {
 				if (items !== undefined && items !== null && items.length > 0) {
 					return items[0];

--- a/cosmoz-omnitable-column-list-data.html
+++ b/cosmoz-omnitable-column-list-data.html
@@ -46,12 +46,8 @@
 	<script>
 		window.Cosmoz = window.Cosmoz || {};
 
-		class OmnitableColumnListData extends Polymer.mixinBehaviors(
-			[
-				Cosmoz.TemplateHelperBehavior,
-				Cosmoz.TranslatableBehavior
-			],
-			Polymer.Element
+		class OmnitableColumnListData extends Cosmoz.Mixins.translatable(
+			Polymer.mixinBehaviors([Cosmoz.TemplateHelperBehavior], Polymer.Element)
 		) {
 			static get is() {
 				return 'cosmoz-omnitable-column-list-data';
@@ -81,16 +77,6 @@
 						}
 					}
 				};
-			}
-
-			isEmpty() {
-				// FIXME: remove this when TemplateHelperBehavior is a 2.x mixin
-				return Cosmoz.TemplateHelperBehavior.isEmpty.apply(this, arguments);
-			}
-
-			_() {
-				// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-				return Cosmoz.TranslatableBehavior._.apply(this, arguments);
 			}
 
 			_firstItem(items) {

--- a/cosmoz-omnitable-column-list-horizontal.html
+++ b/cosmoz-omnitable-column-list-horizontal.html
@@ -56,9 +56,13 @@
 		 * @appliesMixin Cosmoz.ListColumnMixin
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
-		class OmnitableColumnListHorizontal extends	Cosmoz.ListColumnMixin(Cosmoz.OmnitableColumnMixin(
-			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
-		)) {
+		class OmnitableColumnListHorizontal extends	Cosmoz.ListColumnMixin(
+			Cosmoz.OmnitableColumnMixin(
+				Cosmoz.Mixins.translatable(
+					Polymer.Element
+				)
+			)
+		) {
 			static get is() {
 				return 'cosmoz-omnitable-column-list-horizontal';
 			}

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -41,12 +41,9 @@
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
 		class OmnitableColumnList extends
-			Cosmoz.ListColumnMixin(Cosmoz.OmnitableColumnMixin(
-				Polymer.mixinBehaviors(
-					[Cosmoz.TranslatableBehavior],
-					Polymer.Element
-				)
-			)) {
+			Cosmoz.ListColumnMixin(Cosmoz.OmnitableColumnMixin(Cosmoz.Mixins.translatable(
+				Polymer.Element
+			))) {
 			static get is() {
 				return 'cosmoz-omnitable-column-list';
 			}

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -49,9 +49,13 @@
 		 * @appliesMixin Cosmoz.RangeColumnMixin
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
-		class OmnitableColumnNumber extends Cosmoz.RangeColumnMixin(Cosmoz.OmnitableColumnMixin(
-			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
-		)) {
+		class OmnitableColumnNumber extends Cosmoz.RangeColumnMixin(
+			Cosmoz.OmnitableColumnMixin(
+				Cosmoz.Mixins.translatable(
+					Polymer.Element
+				)
+			)
+		) {
 			static get is() {
 				return 'cosmoz-omnitable-column-number';
 			}

--- a/cosmoz-omnitable-column-time.html
+++ b/cosmoz-omnitable-column-time.html
@@ -47,9 +47,11 @@
 		 * @appliesMixin Cosmoz.DateColumnMixin
 		 * @appliesMixin Cosmoz.OmnitableColumnMixin
 		 */
-		class OmnitableColumnTime extends Cosmoz.DateColumnMixin(Cosmoz.OmnitableColumnMixin(
-			Polymer.mixinBehaviors([Cosmoz.TranslatableBehavior], Polymer.Element)
-		)) {
+		class OmnitableColumnTime extends Cosmoz.DateColumnMixin(
+			Cosmoz.OmnitableColumnMixin(
+				Cosmoz.Mixins.translatable(Polymer.Element)
+			)
+		) {
 			static get is() {
 				return 'cosmoz-omnitable-column-time';
 			}

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -14,12 +14,12 @@
 	 * @polymer
 	 * @customElement
 	 * @appliesMixin Polymer.IronResizableBehavior
-	 * @appliesMixin Cosmoz.TranslatableBehavior
 	 */
-	class Omnitable extends Polymer.mixinBehaviors([
-		Polymer.IronResizableBehavior,
-		Cosmoz.TranslatableBehavior
-	], Polymer.Element) {
+	class Omnitable extends Cosmoz.Mixins.translatable(
+		Polymer.mixinBehaviors([
+			Polymer.IronResizableBehavior
+		], Polymer.Element)
+	) {
 		static get is() {
 			return 'cosmoz-omnitable';
 		}
@@ -251,14 +251,6 @@
 			 */
 				_allSelected: {
 					type: Boolean
-				},
-
-				// FIXME: remove when TranslatableBehavior is a 2.x mixin
-				t: {
-					type: Object,
-					value() {
-						return {};
-					}
 				}
 			};
 		}
@@ -269,16 +261,6 @@
 				'_debounceSortItems(sortOn, descending, filteredGroupedItems)',
 				' _selectedItemsChanged(selectedItems.*)'
 			];
-		}
-
-		_() {
-			// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-			return Cosmoz.TranslatableBehavior._.apply(this, arguments);
-		}
-
-		ngettext() {
-			// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-			return Cosmoz.TranslatableBehavior.ngettext.apply(this, arguments);
 		}
 
 		constructor() {


### PR DESCRIPTION
Component, replacing translation behavior with mixin, upgrading cosmoz-i18next component.

Component upgrade was needed to get the mixin.

Testing, run `yarn install yarn start`, go to the demo.

Issue is https://github.com/Neovici/cosmoz-frontend/issues/815.