### PR TITLE
Components, UI-helpers, adding mixin definitions, converting UI-helpers to class-style

### DIFF
--- a/cosmoz-omnitable-column-amount.html
+++ b/cosmoz-omnitable-column-amount.html
@@ -43,6 +43,8 @@
 	<script type="text/javascript">
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		/**
 		 * @polymer
 		 * @customElement

--- a/cosmoz-omnitable-column-date.html
+++ b/cosmoz-omnitable-column-date.html
@@ -45,6 +45,8 @@
 	<script>
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		/**
 		 * @polymer
 		 * @customElement

--- a/cosmoz-omnitable-column-datetime.html
+++ b/cosmoz-omnitable-column-datetime.html
@@ -44,6 +44,8 @@
 	<script>
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		/**
 		 * @polymer
 		 * @customElement

--- a/cosmoz-omnitable-column-list-data.html
+++ b/cosmoz-omnitable-column-list-data.html
@@ -46,6 +46,8 @@
 	<script>
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		class OmnitableColumnListData extends Cosmoz.Mixins.translatable(
 			Polymer.mixinBehaviors([Cosmoz.TemplateHelperBehavior], Polymer.Element)
 		) {

--- a/cosmoz-omnitable-column-list-horizontal.html
+++ b/cosmoz-omnitable-column-list-horizontal.html
@@ -50,6 +50,8 @@
 	<script type="text/javascript">
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		/**
 		 * @polymer
 		 * @customElement

--- a/cosmoz-omnitable-column-list.html
+++ b/cosmoz-omnitable-column-list.html
@@ -34,6 +34,8 @@
 	<script type="text/javascript">
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		/**
 		 * @polymer
 		 * @customElement

--- a/cosmoz-omnitable-column-number.html
+++ b/cosmoz-omnitable-column-number.html
@@ -43,6 +43,8 @@
 	<script>
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		/**
 		 * @polymer
 		 * @customElement

--- a/cosmoz-omnitable-column-time.html
+++ b/cosmoz-omnitable-column-time.html
@@ -41,6 +41,8 @@
 	<script>
 		window.Cosmoz = window.Cosmoz || {};
 
+		Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 		/**
 		 * @polymer
 		 * @customElement

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -3,6 +3,10 @@
 
 	'use strict';
 
+	window.Cosmoz = window.Cosmoz || {};
+
+	Cosmoz.Mixins = Cosmoz.Mixins || {};
+
 	const PROPERTY_HASH_PARAMS = ['sortOn', 'groupOn', 'descending', 'groupOnDescending'];
 	const {
 		FlattenedNodesObserver,

--- a/ui-helpers/cosmoz-clear-button.html
+++ b/ui-helpers/cosmoz-clear-button.html
@@ -39,21 +39,27 @@
 		<iron-icon icon="clear"></iron-icon>
 	</template>
 	<script type="text/javascript">
-		Polymer({
-			is: 'cosmoz-clear-button',
-			properties: {
-				visible: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
-				},
+		/*global Polymer*/
 
-				light: {
-					type: Boolean,
-					reflectToAttribute: true,
-					value: false
-				}
+		class CosmozClearButton extends Polymer.Element {
+			static get is() {
+				return 'cosmoz-clear-button';
 			}
-		});
+			static get properties() {
+				return {
+					light: {
+						reflectToAttribute: true,
+						type: Boolean,
+						value: false
+					},
+					visible: {
+						reflectToAttribute: true,
+						type: Boolean,
+						value: false
+					}
+				};
+			}
+		}
+		customElements.define(CosmozClearButton.is, CosmozClearButton);
 	</script>
 </dom-module>


### PR DESCRIPTION
Components, UI-helpers, adding mixin definitions, converting UI-helpers to class-style.

Testing: 'yarn install; yarn start`, add `demo/` to the address, use a demo with a date column or any other column that uses round clear buttons, enter a value in the column filter, then use the clear button.

Issue is https://github.com/Neovici/cosmoz-frontend/issues/815.