### PR TITLE
Components, Demo, converting to class-style

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -4,2878 +4,41 @@
     {
       "description": "",
       "summary": "",
-      "path": "ui-helpers/cosmoz-clear-button.html",
-      "properties": [
-        {
-          "name": "__dataClientsReady",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1148,
-              "column": 8
-            },
-            "end": {
-              "line": 1148,
-              "column": 32
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataPendingClients",
-          "type": "Array",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1150,
-              "column": 8
-            },
-            "end": {
-              "line": 1150,
-              "column": 34
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataToNotify",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1152,
-              "column": 8
-            },
-            "end": {
-              "line": 1152,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataLinkedPaths",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1154,
-              "column": 8
-            },
-            "end": {
-              "line": 1154,
-              "column": 31
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataHasPaths",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1156,
-              "column": 8
-            },
-            "end": {
-              "line": 1156,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataCompoundStorage",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1158,
-              "column": 8
-            },
-            "end": {
-              "line": 1158,
-              "column": 35
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataHost",
-          "type": "Polymer_PropertyEffects",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1160,
-              "column": 8
-            },
-            "end": {
-              "line": 1160,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataTemp",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1162,
-              "column": 8
-            },
-            "end": {
-              "line": 1162,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataClientsInitialized",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1164,
-              "column": 8
-            },
-            "end": {
-              "line": 1164,
-              "column": 38
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__data",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1166,
-              "column": 8
-            },
-            "end": {
-              "line": 1166,
-              "column": 20
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataPending",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1168,
-              "column": 8
-            },
-            "end": {
-              "line": 1168,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataOld",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1170,
-              "column": 8
-            },
-            "end": {
-              "line": 1170,
-              "column": 23
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__computeEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1172,
-              "column": 8
-            },
-            "end": {
-              "line": 1172,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__reflectEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1174,
-              "column": 8
-            },
-            "end": {
-              "line": 1174,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__notifyEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1176,
-              "column": 8
-            },
-            "end": {
-              "line": 1176,
-              "column": 29
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__propagateEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1178,
-              "column": 8
-            },
-            "end": {
-              "line": 1178,
-              "column": 32
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__observeEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1180,
-              "column": 8
-            },
-            "end": {
-              "line": 1180,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__readOnly",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1182,
-              "column": 8
-            },
-            "end": {
-              "line": 1182,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__templateInfo",
-          "type": "!TemplateInfo",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1184,
-              "column": 8
-            },
-            "end": {
-              "line": 1184,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "PROPERTY_EFFECT_TYPES",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1187,
-              "column": 6
-            },
-            "end": {
-              "line": 1189,
-              "column": 7
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_template",
-          "type": "HTMLTemplateElement",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 435,
-              "column": 8
-            },
-            "end": {
-              "line": 435,
-              "column": 23
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_importPath",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 437,
-              "column": 8
-            },
-            "end": {
-              "line": 437,
-              "column": 25
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "rootPath",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 439,
-              "column": 8
-            },
-            "end": {
-              "line": 439,
-              "column": 22
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "importPath",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 441,
-              "column": 8
-            },
-            "end": {
-              "line": 441,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "root",
-          "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 443,
-              "column": 8
-            },
-            "end": {
-              "line": 443,
-              "column": 18
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "$",
-          "type": "!Object.<string, !Element>",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 445,
-              "column": 8
-            },
-            "end": {
-              "line": 445,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "light",
-          "type": "boolean | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 49,
-              "column": 5
-            },
-            "end": {
-              "line": 53,
-              "column": 6
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Boolean"
-            }
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "visible",
-          "type": "boolean | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 54,
-              "column": 5
-            },
-            "end": {
-              "line": 58,
-              "column": 6
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Boolean"
-            }
-          },
-          "defaultValue": "false"
-        }
-      ],
+      "path": "cosmoz-omnitable-templatizer.html",
+      "properties": [],
       "methods": [
         {
-          "name": "_stampTemplate",
-          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2424,
-              "column": 6
-            },
-            "end": {
-              "line": 2449,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template to stamp"
-            }
-          ],
-          "return": {
-            "type": "!StampedTemplate",
-            "desc": "Cloned template content"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_addMethodEventListenerToNode",
-          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 452,
-              "column": 6
-            },
-            "end": {
-              "line": 457,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "!Node",
-              "description": "Node to add listener on"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "methodName",
-              "type": "string",
-              "description": "Name of method"
-            },
-            {
-              "name": "context",
-              "type": "*=",
-              "description": "Context the method will be called on (defaults\n  to `node`)"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "Generated handler function"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_addEventListenerToNode",
-          "description": "Override point for adding custom or simulated event handling.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 467,
-              "column": 6
-            },
-            "end": {
-              "line": 469,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "!Node",
-              "description": "Node to add event listener to"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "handler",
-              "type": "function (!Event): void",
-              "description": "Listener function to add"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_removeEventListenerFromNode",
-          "description": "Override point for adding custom or simulated event handling.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 479,
-              "column": 6
-            },
-            "end": {
-              "line": 481,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "!Node",
-              "description": "Node to remove event listener from"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "handler",
-              "type": "function (!Event): void",
-              "description": "Listener function to remove"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_createPropertyAccessor",
-          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 106,
-              "column": 8
-            },
-            "end": {
-              "line": 115,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "readOnly",
-              "type": "boolean=",
-              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_addPropertyToAttributeMap",
-          "description": "Adds the given `property` to a map matching attribute names\nto property names, using `attributeNameForProperty`. This map is\nused when deserializing attribute values to properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 124,
-              "column": 8
-            },
-            "end": {
-              "line": 132,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_definePropertyAccessor",
-          "description": "Defines a property accessor for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 140,
-              "column": 9
-            },
-            "end": {
-              "line": 153,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "readOnly",
-              "type": "boolean=",
-              "description": "When true, no setter is created"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
           "name": "ready",
-          "description": "Stamps the element template.",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 553,
-              "column": 6
+              "line": 16,
+              "column": 2
             },
             "end": {
-              "line": 559,
-              "column": 7
+              "line": 23,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
+          }
         },
         {
-          "name": "_initializeProperties",
-          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 460,
-              "column": 6
-            },
-            "end": {
-              "line": 493,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_initializeInstanceProperties",
-          "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 222,
-              "column": 8
-            },
-            "end": {
-              "line": 224,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of property values that were overwritten\n  when creating property accessors."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_setProperty",
-          "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 235,
-              "column": 8
-            },
-            "end": {
-              "line": 239,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_getProperty",
-          "description": "Returns the value for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 247,
-              "column": 8
-            },
-            "end": {
-              "line": 249,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of property"
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Value for the given property"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_setPendingProperty",
-          "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 264,
-              "column": 8
-            },
-            "end": {
-              "line": 280,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set"
-            },
-            {
-              "name": "ext",
-              "type": "boolean=",
-              "description": "Not used here; affordance for closure"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Returns true if the property changed"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_invalidateProperties",
-          "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 290,
-              "column": 8
-            },
-            "end": {
-              "line": 300,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_enableProperties",
-          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 313,
-              "column": 8
-            },
-            "end": {
-              "line": 322,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_flushProperties",
-          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 333,
-              "column": 8
-            },
-            "end": {
-              "line": 342,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_shouldPropertiesChange",
-          "description": "Called in `_flushProperties` to determine if `_propertiesChanged`\nshould be called. The default implementation returns true if\nproperties are pending. Override to customize when\n`_propertiesChanged` is called.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 356,
-              "column": 8
-            },
-            "end": {
-              "line": 358,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "currentProps",
-              "type": "!Object",
-              "description": "Bag of all current accessor values"
-            },
-            {
-              "name": "changedProps",
-              "type": "!Object",
-              "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
-            },
-            {
-              "name": "oldProps",
-              "type": "!Object",
-              "description": "Bag of previous values for each property\n  in `changedProps`"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "true if changedProps is truthy"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_propertiesChanged",
-          "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 372,
-              "column": 8
-            },
-            "end": {
-              "line": 373,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "currentProps",
-              "type": "!Object",
-              "description": "Bag of all current accessor values"
-            },
-            {
-              "name": "changedProps",
-              "type": "!Object",
-              "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
-            },
-            {
-              "name": "oldProps",
-              "type": "!Object",
-              "description": "Bag of previous values for each property\n  in `changedProps`"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_shouldPropertyChange",
-          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 393,
-              "column": 8
-            },
-            "end": {
-              "line": 400,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "New property value"
-            },
-            {
-              "name": "old",
-              "type": "*",
-              "description": "Previous property value"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "attributeChangedCallback",
-          "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+          "name": "init",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
             "start": {
-              "line": 413,
-              "column": 8
+              "line": 25,
+              "column": 2
             },
             "end": {
-              "line": 420,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of attribute that changed"
-            },
-            {
-              "name": "old",
-              "type": "?string",
-              "description": "Old attribute value"
-            },
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "New attribute value"
-            },
-            {
-              "name": "namespace",
-              "type": "?string",
-              "description": "Attribute namespace."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_attributeToProperty",
-          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 434,
-              "column": 8
-            },
-            "end": {
-              "line": 441,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Name of attribute to deserialize."
-            },
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "of the attribute."
-            },
-            {
-              "name": "type",
-              "type": "*=",
-              "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_propertyToAttribute",
-          "description": "Serializes a property to its associated attribute.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 453,
-              "column": 8
-            },
-            "end": {
-              "line": 459,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name to reflect."
-            },
-            {
-              "name": "attribute",
-              "type": "string=",
-              "description": "Attribute name to reflect to."
-            },
-            {
-              "name": "value",
-              "type": "*=",
-              "description": "Property value to refect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_valueToNodeAttribute",
-          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 474,
-              "column": 8
-            },
-            "end": {
-              "line": 481,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Element to set attribute to."
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to serialize."
-            },
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Attribute name to serialize to."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_serializeValue",
-          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 494,
-              "column": 8
-            },
-            "end": {
-              "line": 501,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Property value to serialize."
-            }
-          ],
-          "return": {
-            "type": "(string | undefined)",
-            "desc": "String serialized from the provided\nproperty  value."
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_deserializeValue",
-          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
-            "start": {
-              "line": 515,
-              "column": 8
-            },
-            "end": {
-              "line": 524,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "Value to deserialize."
-            },
-            {
-              "name": "type",
-              "type": "*=",
-              "description": "Type to deserialize the string to."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Typed value deserialized from the provided string."
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
-        },
-        {
-          "name": "_initializeProtoProperties",
-          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1218,
-              "column": 6
-            },
-            "end": {
-              "line": 1222,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Properties to initialize on the prototype"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_ensureAttribute",
-          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 193,
-              "column": 6
-            },
-            "end": {
-              "line": 198,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Name of attribute to ensure is set."
-            },
-            {
-              "name": "value",
-              "type": "string",
-              "description": "of the attribute."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_hasAccessor",
-          "description": "Returns true if this library created an accessor for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 300,
-              "column": 6
-            },
-            "end": {
-              "line": 302,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if an accessor was created"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_isPropertyPending",
-          "description": "Returns true if the specified property has a pending change.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 311,
-              "column": 6
-            },
-            "end": {
-              "line": 313,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if property has a pending change"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_addPropertyEffect",
-          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1256,
-              "column": 6
-            },
-            "end": {
-              "line": 1264,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_removePropertyEffect",
-          "description": "Removes the given property effect.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1274,
-              "column": 6
-            },
-            "end": {
-              "line": 1280,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property the effect was associated with"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object to remove"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasPropertyEffect",
-          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1291,
-              "column": 6
-            },
-            "end": {
-              "line": 1294,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "type",
-              "type": "string=",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasReadOnlyEffect",
-          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1304,
-              "column": 6
-            },
-            "end": {
-              "line": 1306,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasNotifyEffect",
-          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1316,
-              "column": 6
-            },
-            "end": {
-              "line": 1318,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasReflectEffect",
-          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1328,
-              "column": 6
-            },
-            "end": {
-              "line": 1330,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasComputedEffect",
-          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1340,
-              "column": 6
-            },
-            "end": {
-              "line": 1342,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setPendingPropertyOrPath",
-          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1374,
-              "column": 6
-            },
-            "end": {
-              "line": 1406,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(number | string)>)",
-              "description": "Path to set"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set"
-            },
-            {
-              "name": "shouldNotify",
-              "type": "boolean=",
-              "description": "Set to true if this change should\n cause a property notification event dispatch"
-            },
-            {
-              "name": "isPathNotification",
-              "type": "boolean=",
-              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setUnmanagedPropertyToNode",
-          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1429,
-              "column": 6
-            },
-            "end": {
-              "line": 1437,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "!Node",
-              "description": "The node to set a property on"
-            },
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "The property to set"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "The value to set"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_enqueueClient",
-          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1544,
-              "column": 6
-            },
-            "end": {
-              "line": 1549,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "client",
-              "type": "Object",
-              "description": "PropertyEffects client to enqueue"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_flushClients",
-          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1570,
-              "column": 6
-            },
-            "end": {
-              "line": 1581,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__enableOrFlushClients",
-          "description": "(c) the stamped dom enables.",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1595,
-              "column": 6
-            },
-            "end": {
-              "line": 1608,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_readyClients",
-          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 571,
-              "column": 6
-            },
-            "end": {
-              "line": 580,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "setProperties",
-          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1637,
-              "column": 6
-            },
-            "end": {
-              "line": 1648,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
-            },
-            {
-              "name": "setReadOnly",
-              "type": "boolean=",
-              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_propagatePropertyChanges",
-          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1735,
-              "column": 6
-            },
-            "end": {
-              "line": 1745,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changedProps",
-              "type": "Object",
-              "description": "Bag of changed properties"
-            },
-            {
-              "name": "oldProps",
-              "type": "Object",
-              "description": "Bag of previous values for changed properties"
-            },
-            {
-              "name": "hasPaths",
-              "type": "boolean",
-              "description": "True with `props` contains one or more paths"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "linkPaths",
-          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1756,
-              "column": 6
-            },
-            "end": {
-              "line": 1761,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "to",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Target path to link."
-            },
-            {
-              "name": "from",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Source path to link."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "unlinkPaths",
-          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1773,
-              "column": 6
-            },
-            "end": {
-              "line": 1778,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Target path to unlink."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "notifySplices",
-          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1810,
-              "column": 6
-            },
-            "end": {
-              "line": 1814,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Path that should be notified."
-            },
-            {
-              "name": "splices",
-              "type": "Array",
-              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "get",
-          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1835,
-              "column": 6
-            },
-            "end": {
-              "line": 1837,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
-            },
-            {
-              "name": "root",
-              "type": "Object=",
-              "description": "Root object from which the path is evaluated."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "set",
-          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1860,
-              "column": 6
-            },
-            "end": {
-              "line": 1870,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set at the specified path."
-            },
-            {
-              "name": "root",
-              "type": "Object=",
-              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "push",
-          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1886,
-              "column": 6
-            },
-            "end": {
-              "line": 1895,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to push onto array"
-            }
-          ],
-          "return": {
-            "type": "number",
-            "desc": "New length of the array."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "pop",
-          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1910,
-              "column": 6
-            },
-            "end": {
-              "line": 1919,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Path to array."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Item that was removed."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "splice",
-          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1938,
-              "column": 6
-            },
-            "end": {
-              "line": 1975,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "start",
-              "type": "number",
-              "description": "Index from which to start removing/inserting."
-            },
-            {
-              "name": "deleteCount",
-              "type": "number",
-              "description": "Number of items to remove."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to insert into array."
-            }
-          ],
-          "return": {
-            "type": "Array",
-            "desc": "Array of removed items."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "shift",
-          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1990,
-              "column": 6
-            },
-            "end": {
-              "line": 1999,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Path to array."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Item that was removed."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "unshift",
-          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2015,
-              "column": 6
-            },
-            "end": {
-              "line": 2023,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string | !Array.<(string | number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to insert info array"
-            }
-          ],
-          "return": {
-            "type": "number",
-            "desc": "New length of the array."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "notifyPath",
-          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2038,
-              "column": 6
-            },
-            "end": {
-              "line": 2055,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Path that should be notified."
-            },
-            {
-              "name": "value",
-              "type": "*=",
-              "description": "Value at the path (optional)."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createReadOnlyProperty",
-          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2068,
-              "column": 6
-            },
-            "end": {
-              "line": 2075,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "protectedSetter",
-              "type": "boolean=",
-              "description": "Creates a custom protected setter\n  when `true`."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createPropertyObserver",
-          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2089,
-              "column": 6
-            },
-            "end": {
-              "line": 2099,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "method",
-              "type": "(string | function (*, *))",
-              "description": "Function or name of observer method to call"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "boolean=",
-              "description": "Whether the method name should be included as\n  a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createMethodObserver",
-          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2112,
-              "column": 6
-            },
-            "end": {
-              "line": 2118,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean | Object)=",
-              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createNotifyingProperty",
-          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2129,
-              "column": 6
-            },
-            "end": {
-              "line": 2137,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createReflectedProperty",
-          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2148,
-              "column": 6
-            },
-            "end": {
-              "line": 2161,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createComputedProperty",
-          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2175,
-              "column": 6
-            },
-            "end": {
-              "line": 2181,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of computed property to set"
-            },
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean | Object)=",
-              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_bindTemplate",
-          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2358,
-              "column": 6
-            },
-            "end": {
-              "line": 2381,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template containing binding\n  bindings"
-            },
-            {
-              "name": "instanceBinding",
-              "type": "boolean=",
-              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
-            }
-          ],
-          "return": {
-            "type": "!TemplateInfo",
-            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_removeBoundDom",
-          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2460,
-              "column": 6
-            },
-            "end": {
-              "line": 2481,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "dom",
-              "type": "!StampedTemplate",
-              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "connectedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 540,
-              "column": 6
-            },
-            "end": {
-              "line": 545,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Called when the element is removed from a document",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-mixin.html",
-            "start": {
-              "line": 216,
-              "column": 6
-            },
-            "end": {
-              "line": 220,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesMixin"
-        },
-        {
-          "name": "_attachDom",
-          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 594,
-              "column": 6
-            },
-            "end": {
-              "line": 610,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "dom",
-              "type": "StampedTemplate",
-              "description": "to attach to the element."
-            }
-          ],
-          "return": {
-            "type": "ShadowRoot",
-            "desc": "node to which the dom has been attached."
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "updateStyles",
-          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.\n\nNote: This function does not support updating CSS mixins.\nYou can not dynamically change the value of an `@apply`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 633,
-              "column": 6
-            },
-            "end": {
-              "line": 637,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "properties",
-              "type": "Object=",
-              "description": "Bag of custom property key/values to\n  apply to this element."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "resolveUrl",
-          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.\n\nNote that this function performs no resolution for URLs that start\nwith `/` (absolute URLs) or `#` (hash identifiers).  For general purpose\nURL resolution, use `window.URL`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 654,
-              "column": 6
-            },
-            "end": {
-              "line": 659,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "url",
-              "type": "string",
-              "description": "URL to resolve."
-            },
-            {
-              "name": "base",
-              "type": "string=",
-              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
-            }
-          ],
-          "return": {
-            "type": "string",
-            "desc": "Rewritten URL relative to base"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        }
-      ],
-      "staticMethods": [
-        {
-          "name": "_parseTemplate",
-          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 197,
-              "column": 6
-            },
-            "end": {
-              "line": 208,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template to parse"
-            },
-            {
-              "name": "outerTemplateInfo",
-              "type": "TemplateInfo=",
-              "description": "Template metadata from the outer\n  template, for parsing nested templates"
-            }
-          ],
-          "return": {
-            "type": "!TemplateInfo",
-            "desc": "Parsed template metadata"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateContent",
-          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 670,
-              "column": 6
-            },
-            "end": {
-              "line": 673,
-              "column": 7
+              "line": 30,
+              "column": 3
             }
           },
           "metadata": {},
@@ -2884,928 +47,377 @@
               "name": "template"
             },
             {
-              "name": "templateInfo"
-            },
-            {
-              "name": "nodeInfo"
-            }
-          ],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_parseTemplateNode",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2500,
-              "column": 6
-            },
-            "end": {
-              "line": 2514,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseTemplateChildNodes",
-          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 258,
-              "column": 6
-            },
-            "end": {
-              "line": 295,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "root",
-              "type": "Node",
-              "description": "Root node whose `childNodes` will be parsed"
-            },
-            {
-              "name": "templateInfo",
-              "type": "!TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "!NodeInfo",
-              "description": "Node metadata for current template."
+              "name": "host"
             }
           ],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
+          }
         },
         {
-          "name": "_parseTemplateNestedTemplate",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+          "name": "_getRootDataHost",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2592,
-              "column": 6
+              "line": 32,
+              "column": 2
             },
             "end": {
-              "line": 2602,
-              "column": 7
+              "line": 34,
+              "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to parse"
+          "params": []
+        },
+        {
+          "name": "_ensureTemplatized",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 36,
+              "column": 2
             },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
+            "end": {
+              "line": 40,
+              "column": 3
             }
-          ],
+          },
+          "metadata": {},
+          "params": [],
           "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
+            "type": "void"
+          }
         },
         {
-          "name": "_parseTemplateNodeAttributes",
-          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+          "name": "_forwardParentProp",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 333,
-              "column": 6
+              "line": 42,
+              "column": 2
             },
             "end": {
-              "line": 342,
-              "column": 7
+              "line": 48,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "node",
-              "type": "Element",
-              "description": "Node to parse"
+              "name": "prop"
             },
             {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template."
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateNodeAttribute",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2535,
-              "column": 6
-            },
-            "end": {
-              "line": 2576,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Attribute name"
-            },
-            {
-              "name": "value",
-              "type": "string",
-              "description": "Attribute value"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_contentForTemplate",
-          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 388,
-              "column": 6
-            },
-            "end": {
-              "line": 391,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "HTMLTemplateElement",
-              "description": "Template to retrieve `content` for"
-            }
-          ],
-          "return": {
-            "type": "DocumentFragment",
-            "desc": "Content fragment"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "createProperties",
-          "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 326,
-              "column": 7
-            },
-            "end": {
-              "line": 330,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props"
+              "name": "value"
             }
           ],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
+          }
         },
         {
-          "name": "attributeNameForProperty",
-          "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+          "name": "_forwardParentPath",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-changed.html",
             "start": {
-              "line": 77,
-              "column": 8
+              "line": 50,
+              "column": 2
+            },
+            "end": {
+              "line": 56,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_forwardHostPropV2",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 58,
+              "column": 2
+            },
+            "end": {
+              "line": 64,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop"
+            },
+            {
+              "name": "value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "getInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 66,
+              "column": 2
             },
             "end": {
               "line": 79,
-              "column": 9
+              "column": 3
             }
           },
           "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property to convert"
-            }
-          ],
-          "return": {
-            "type": "string",
-            "desc": "Attribute name corresponding to the given property."
-          },
-          "inheritedFrom": "Polymer.PropertiesChanged"
+          "params": []
         },
         {
-          "name": "typeForProperty",
-          "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-mixin.html",
-            "start": {
-              "line": 181,
-              "column": 6
-            },
-            "end": {
-              "line": 184,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of property"
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Type to which to deserialize attribute"
-          },
-          "inheritedFrom": "Polymer.PropertiesMixin"
-        },
-        {
-          "name": "createPropertiesForAttributes",
-          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+          "name": "detachInstance",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-accessors.html",
             "start": {
-              "line": 129,
-              "column": 6
+              "line": 81,
+              "column": 2
             },
             "end": {
-              "line": 134,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "addPropertyEffect",
-          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2221,
-              "column": 6
-            },
-            "end": {
-              "line": 2223,
-              "column": 7
+              "line": 84,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "property",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
+              "name": "instance"
             }
           ],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
+          }
         },
         {
-          "name": "createPropertyObserver",
-          "description": "Creates a single-property observer for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2235,
-              "column": 6
-            },
-            "end": {
-              "line": 2237,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "method",
-              "type": "(string | function (*, *))",
-              "description": "Function or name of observer method to call"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "boolean=",
-              "description": "Whether the method name should be included as\n  a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createMethodObserver",
-          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2252,
-              "column": 6
-            },
-            "end": {
-              "line": 2254,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean | Object)=",
-              "description": "Boolean or object map indicating"
-            }
-          ],
-          "return": {
-            "type": "void",
-            "desc": "whether method names should be included as a dependency to the effect."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createNotifyingProperty",
-          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2264,
-              "column": 6
-            },
-            "end": {
-              "line": 2266,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createReadOnlyProperty",
-          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2284,
-              "column": 6
-            },
-            "end": {
-              "line": 2286,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "protectedSetter",
-              "type": "boolean=",
-              "description": "Creates a custom protected setter\n  when `true`."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createReflectedProperty",
-          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2296,
-              "column": 6
-            },
-            "end": {
-              "line": 2298,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createComputedProperty",
-          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2314,
-              "column": 6
-            },
-            "end": {
-              "line": 2316,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of computed property to set"
-            },
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean | Object)=",
-              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "bindTemplate",
-          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2330,
-              "column": 6
-            },
-            "end": {
-              "line": 2332,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template containing binding\n  bindings"
-            }
-          ],
-          "return": {
-            "type": "!TemplateInfo",
-            "desc": "Template metadata object"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_addTemplatePropertyEffect",
-          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2396,
-              "column": 6
-            },
-            "end": {
-              "line": 2402,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateInfo",
-              "type": "Object",
-              "description": "Template metadata to add effect to"
-            },
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseBindings",
-          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2648,
-              "column": 6
-            },
-            "end": {
-              "line": 2713,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "text",
-              "type": "string",
-              "description": "Text to parse from attribute or textContent"
-            },
-            {
-              "name": "templateInfo",
-              "type": "Object",
-              "description": "Current template metadata"
-            }
-          ],
-          "return": {
-            "type": "Array.<!BindingPart>",
-            "desc": "Array of binding part metadata"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_evaluateBinding",
-          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2729,
-              "column": 6
-            },
-            "end": {
-              "line": 2746,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "inst",
-              "type": "this",
-              "description": "Element that should be used as scope for\n  binding dependencies"
-            },
-            {
-              "name": "part",
-              "type": "BindingPart",
-              "description": "Binding part metadata"
-            },
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Property/path that triggered this effect"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of current property changes"
-            },
-            {
-              "name": "oldProps",
-              "type": "Object",
-              "description": "Bag of previous values for changed properties"
-            },
-            {
-              "name": "hasPaths",
-              "type": "boolean",
-              "description": "True with `props` contains one or more paths"
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Value the binding part evaluated to"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "finalize",
-          "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+          "name": "releaseInstance",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 129,
-              "column": 6
+              "line": 86,
+              "column": 2
             },
             "end": {
-              "line": 138,
-              "column": 7
+              "line": 93,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 95,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertiesMixin"
+          }
         },
         {
-          "name": "_finalizeClass",
-          "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
-          "privacy": "protected",
+          "name": "releaseInstances",
+          "description": "",
+          "privacy": "public",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 294,
-              "column": 5
+              "line": 101,
+              "column": 2
             },
             "end": {
-              "line": 317,
-              "column": 7
+              "line": 104,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
+          }
         },
         {
-          "name": "createObservers",
-          "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+          "name": "_performInstanceDetach",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 343,
-              "column": 6
+              "line": 106,
+              "column": 2
             },
             "end": {
-              "line": 348,
-              "column": 7
+              "line": 119,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "observers",
-              "type": "Object",
-              "description": "Array of observer descriptors for\n  this class"
-            },
-            {
-              "name": "dynamicFns",
-              "type": "Object",
-              "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+              "name": "instance"
             }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_processStyleText",
-          "description": "Gather style text for a style element in the template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 503,
-              "column": 6
-            },
-            "end": {
-              "line": 505,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cssText",
-              "type": "string",
-              "description": "Text containing styling to process"
-            },
-            {
-              "name": "baseURI",
-              "type": "string",
-              "description": "Base URI to rebase CSS paths against"
-            }
-          ],
-          "return": {
-            "type": "string",
-            "desc": "The processed CSS text"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_finalizeTemplate",
-          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 516,
-              "column": 6
-            },
-            "end": {
-              "line": 527,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "is",
-              "type": "string",
-              "description": "Tag name (or type extension name) for this element"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
+          ]
         }
       ],
+      "staticMethods": [],
       "demos": [],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 43,
-          "column": 2
+          "line": 4,
+          "column": 1
         },
         "end": {
-          "line": 61,
+          "line": 120,
+          "column": 2
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "name": "OmnitableTemplatizer",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "cosmoz-omnitable-templatizer"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "ui-helpers/cosmoz-clear-button.html",
+      "properties": [
+        {
+          "name": "visible",
+          "type": "boolean | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 44,
+              "column": 4
+            },
+            "end": {
+              "line": 48,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Boolean"
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "light",
+          "type": "boolean | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 50,
+              "column": 4
+            },
+            "end": {
+              "line": 54,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Boolean"
+            }
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 41,
+          "column": 10
+        },
+        "end": {
+          "line": 56,
           "column": 3
         }
       },
       "privacy": "public",
-      "superclass": "Polymer.Element",
-      "name": "CosmozClearButton",
+      "superclass": "HTMLElement",
       "attributes": [
         {
-          "name": "light",
+          "name": "visible",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 49,
-              "column": 5
+              "line": 44,
+              "column": 4
             },
             "end": {
-              "line": 53,
-              "column": 6
+              "line": 48,
+              "column": 5
             }
           },
           "metadata": {},
           "type": "boolean | null | undefined"
         },
         {
-          "name": "visible",
+          "name": "light",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 54,
-              "column": 5
+              "line": 50,
+              "column": 4
             },
             "end": {
-              "line": 58,
-              "column": 6
+              "line": 54,
+              "column": 5
             }
           },
           "metadata": {},
@@ -3826,6 +438,98 @@
       "path": "cosmoz-omnitable-column.html",
       "properties": [
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -3833,11 +537,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -3857,11 +561,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -3880,11 +584,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -3905,11 +609,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -3929,11 +633,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -3954,11 +658,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -3978,11 +682,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -4003,11 +707,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -4027,11 +731,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -4052,11 +756,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -4075,11 +779,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -4098,11 +802,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -4122,11 +826,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -4146,11 +850,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -4171,11 +875,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -4195,11 +899,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -4218,11 +922,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 37,
               "column": 5
             },
             "end": {
-              "line": 43,
+              "line": 40,
               "column": 6
             }
           },
@@ -4240,11 +944,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 42,
               "column": 5
             },
             "end": {
-              "line": 48,
+              "line": 45,
               "column": 6
             }
           },
@@ -4263,11 +967,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -4287,11 +991,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -4311,11 +1015,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -4335,11 +1039,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -4358,11 +1062,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -4382,11 +1086,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -4396,6 +1100,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -4491,333 +1219,57 @@
             }
           },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         }
       ],
       "methods": [
-        {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 77,
-              "column": 2
-            },
-            "end": {
-              "line": 80,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
         {
           "name": "ready",
           "description": "",
@@ -4825,16 +1277,65 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -4847,11 +1348,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -4867,17 +1368,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -4896,11 +1442,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 257,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 263,
+              "line": 336,
               "column": 3
             }
           },
@@ -4923,11 +1469,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 264,
+              "line": 337,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 342,
               "column": 3
             }
           },
@@ -4950,11 +1496,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -4982,11 +1528,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 285,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 287,
+              "line": 360,
               "column": 3
             }
           },
@@ -5008,11 +1554,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -5034,11 +1580,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -5069,11 +1615,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -5087,11 +1633,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 57,
               "column": 3
             },
             "end": {
-              "line": 62,
+              "line": 59,
               "column": 4
             }
           },
@@ -5108,11 +1654,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -5137,11 +1683,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -5156,11 +1702,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -5182,11 +1728,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -5208,11 +1754,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -5230,11 +1776,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -5252,11 +1798,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -5274,11 +1820,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -5296,11 +1842,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -5317,11 +1863,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 49,
               "column": 3
             },
             "end": {
-              "line": 54,
+              "line": 51,
               "column": 4
             }
           },
@@ -5339,11 +1885,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 56,
+              "line": 53,
               "column": 3
             },
             "end": {
-              "line": 58,
+              "line": 55,
               "column": 4
             }
           },
@@ -5360,11 +1906,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 33,
+          "line": 30,
           "column": 2
         },
         "end": {
-          "line": 63,
+          "line": 60,
           "column": 3
         }
       },
@@ -5378,11 +1924,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -5396,11 +1942,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -5414,11 +1960,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -5432,11 +1978,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -5450,11 +1996,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -5468,11 +2014,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -5486,11 +2032,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -5504,11 +2050,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -5522,11 +2068,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -5540,11 +2086,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -5558,11 +2104,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -5576,11 +2122,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -5594,11 +2140,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -5612,11 +2158,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -5630,11 +2176,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -5648,11 +2194,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -5665,11 +2211,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 37,
               "column": 5
             },
             "end": {
-              "line": 43,
+              "line": 40,
               "column": 6
             }
           },
@@ -5681,11 +2227,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 42,
               "column": 5
             },
             "end": {
-              "line": 48,
+              "line": 45,
               "column": 6
             }
           },
@@ -5698,11 +2244,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -5716,11 +2262,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -5734,11 +2280,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -5752,11 +2298,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -5770,11 +2316,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -5788,16 +2334,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -5896,11 +2460,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 39,
               "column": 2
             },
             "end": {
-              "line": 43,
+              "line": 41,
               "column": 3
             }
           },
@@ -5917,11 +2481,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 43,
               "column": 2
             },
             "end": {
-              "line": 47,
+              "line": 45,
               "column": 3
             }
           },
@@ -5932,6 +2496,52 @@
           }
         },
         {
+          "name": "elements",
+          "type": "?",
+          "description": "Get an array of the elements generated by this repeater\n\t\t ",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 94,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "templateInstances",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 101,
+              "column": 2
+            },
+            "end": {
+              "line": 106,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -5939,11 +2549,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -5962,11 +2572,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -5981,193 +2591,16 @@
       ],
       "methods": [
         {
-          "name": "trackColumns",
-          "description": "Adds an observer to render the cells when the columns are changed.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 48,
-              "column": 2
-            },
-            "end": {
-              "line": 60,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "stopTrackingColumns",
-          "description": "Stops reacting to column changes.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 66,
-              "column": 2
-            },
-            "end": {
-              "line": 73,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "renderCells",
-          "description": "Renders all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 79,
-              "column": 2
-            },
-            "end": {
-              "line": 81,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "destroyCells",
-          "description": "Destroys all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 87,
-              "column": 2
-            },
-            "end": {
-              "line": 89,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardChange",
-          "description": "Forwards a property change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 97,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "String",
-              "description": "the property"
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "the new value"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardPathChange",
-          "description": "Forwards a path change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 106,
-              "column": 2
-            },
-            "end": {
-              "line": 110,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changeRecord",
-              "type": "Object",
-              "description": "the change record"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forEachElement",
-          "description": "Runs a callback on each element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 117,
-              "column": 2
-            },
-            "end": {
-              "line": 119,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "callback",
-              "type": "OmnitableRepeaterMixin~forEachElementCallback",
-              "description": "the callback"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 47,
               "column": 2
             },
             "end": {
-              "line": 59,
+              "line": 49,
               "column": 3
             }
           },
@@ -6179,16 +2612,46 @@
           ]
         },
         {
+          "name": "_detachTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 55,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "column"
+            },
+            {
+              "name": "element"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_configureElement",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 57,
               "column": 2
             },
             "end": {
-              "line": 69,
+              "line": 61,
               "column": 3
             }
           },
@@ -6199,7 +2662,28 @@
             },
             {
               "name": "column"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_configureTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 63,
+              "column": 2
             },
+            "end": {
+              "line": 65,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
             {
               "name": "instance"
             }
@@ -6209,17 +2693,75 @@
           }
         },
         {
+          "name": "getElementTemplateInstance",
+          "description": "Get the template instance rendered by the specified element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 113,
+              "column": 2
+            },
+            "end": {
+              "line": 115,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The instance."
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "getElementColumn",
+          "description": "Get the column that was used to rendered the specified element",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 122,
+              "column": 2
+            },
+            "end": {
+              "line": 124,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The column."
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_columnsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 171,
+              "line": 126,
               "column": 2
             },
             "end": {
-              "line": 195,
+              "line": 150,
               "column": 3
             }
           },
@@ -6241,11 +2783,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 197,
+              "line": 152,
               "column": 2
             },
             "end": {
-              "line": 206,
+              "line": 161,
               "column": 3
             }
           },
@@ -6267,11 +2809,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 208,
+              "line": 163,
               "column": 2
             },
             "end": {
-              "line": 234,
+              "line": 201,
               "column": 3
             }
           },
@@ -6296,11 +2838,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 236,
+              "line": 203,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 211,
               "column": 3
             }
           },
@@ -6325,11 +2867,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 246,
+              "line": 213,
               "column": 2
             },
             "end": {
-              "line": 262,
+              "line": 229,
               "column": 3
             }
           },
@@ -6348,17 +2890,53 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
+          "name": "_forwardProperty",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 231,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "name"
+            },
+            {
+              "name": "value"
+            },
+            {
+              "name": "flush",
+              "defaultValue": "false"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 264,
+              "line": 239,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 244,
               "column": 3
             }
           },
@@ -6372,6 +2950,10 @@
             },
             {
               "name": "value"
+            },
+            {
+              "name": "isPathNotification",
+              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -6389,11 +2971,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 36,
+          "line": 34,
           "column": 1
         },
         "end": {
-          "line": 70,
+          "line": 66,
           "column": 2
         }
       },
@@ -6407,11 +2989,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -6425,11 +3007,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -6449,11 +3031,11 @@
           "name": "header-cell",
           "range": {
             "start": {
-              "line": 24,
+              "line": 22,
               "column": 2
             },
             "end": {
-              "line": 24,
+              "line": 22,
               "column": 34
             }
           }
@@ -6476,11 +3058,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 70,
               "column": 2
             },
             "end": {
-              "line": 74,
+              "line": 72,
               "column": 3
             }
           },
@@ -6497,11 +3079,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 74,
               "column": 2
             },
             "end": {
-              "line": 78,
+              "line": 76,
               "column": 3
             }
           },
@@ -6512,6 +3094,52 @@
           }
         },
         {
+          "name": "elements",
+          "type": "?",
+          "description": "Get an array of the elements generated by this repeater\n\t\t ",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 94,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "templateInstances",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 101,
+              "column": 2
+            },
+            "end": {
+              "line": 106,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -6519,11 +3147,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -6542,11 +3170,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -6565,11 +3193,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 50,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 52,
+              "line": 50,
               "column": 5
             }
           },
@@ -6586,11 +3214,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 54,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 55,
               "column": 5
             }
           },
@@ -6608,11 +3236,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 62,
+              "line": 60,
               "column": 5
             }
           },
@@ -6626,193 +3254,16 @@
       ],
       "methods": [
         {
-          "name": "trackColumns",
-          "description": "Adds an observer to render the cells when the columns are changed.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 48,
-              "column": 2
-            },
-            "end": {
-              "line": 60,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "stopTrackingColumns",
-          "description": "Stops reacting to column changes.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 66,
-              "column": 2
-            },
-            "end": {
-              "line": 73,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "renderCells",
-          "description": "Renders all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 79,
-              "column": 2
-            },
-            "end": {
-              "line": 81,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "destroyCells",
-          "description": "Destroys all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 87,
-              "column": 2
-            },
-            "end": {
-              "line": 89,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardChange",
-          "description": "Forwards a property change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 97,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "String",
-              "description": "the property"
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "the new value"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardPathChange",
-          "description": "Forwards a path change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 106,
-              "column": 2
-            },
-            "end": {
-              "line": 110,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changeRecord",
-              "type": "Object",
-              "description": "the change record"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forEachElement",
-          "description": "Runs a callback on each element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 117,
-              "column": 2
-            },
-            "end": {
-              "line": 119,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "callback",
-              "type": "OmnitableRepeaterMixin~forEachElementCallback",
-              "description": "the callback"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 88,
+              "line": 78,
               "column": 2
             },
             "end": {
-              "line": 95,
+              "line": 80,
               "column": 3
             }
           },
@@ -6824,16 +3275,46 @@
           ]
         },
         {
+          "name": "_detachTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 82,
+              "column": 2
+            },
+            "end": {
+              "line": 84,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "column"
+            },
+            {
+              "name": "element"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_configureElement",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 86,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 92,
               "column": 3
             }
           },
@@ -6844,7 +3325,28 @@
             },
             {
               "name": "column"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_configureTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 94,
+              "column": 2
             },
+            "end": {
+              "line": 101,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
             {
               "name": "instance"
             }
@@ -6854,17 +3356,75 @@
           }
         },
         {
+          "name": "getElementTemplateInstance",
+          "description": "Get the template instance rendered by the specified element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 113,
+              "column": 2
+            },
+            "end": {
+              "line": 115,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The instance."
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "getElementColumn",
+          "description": "Get the column that was used to rendered the specified element",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 122,
+              "column": 2
+            },
+            "end": {
+              "line": 124,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The column."
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_columnsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 171,
+              "line": 126,
               "column": 2
             },
             "end": {
-              "line": 195,
+              "line": 150,
               "column": 3
             }
           },
@@ -6886,11 +3446,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 197,
+              "line": 152,
               "column": 2
             },
             "end": {
-              "line": 206,
+              "line": 161,
               "column": 3
             }
           },
@@ -6912,11 +3472,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 208,
+              "line": 163,
               "column": 2
             },
             "end": {
-              "line": 234,
+              "line": 201,
               "column": 3
             }
           },
@@ -6941,11 +3501,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 236,
+              "line": 203,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 211,
               "column": 3
             }
           },
@@ -6970,11 +3530,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 246,
+              "line": 213,
               "column": 2
             },
             "end": {
-              "line": 262,
+              "line": 229,
               "column": 3
             }
           },
@@ -6993,17 +3553,17 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
-          "name": "_forwardNotifyPath",
+          "name": "_forwardProperty",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 264,
+              "line": 231,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 237,
               "column": 3
             }
           },
@@ -7013,7 +3573,7 @@
               "name": "instance"
             },
             {
-              "name": "path"
+              "name": "name"
             },
             {
               "name": "value"
@@ -7029,6 +3589,67 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
+          "name": "_forwardNotifyPath",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 239,
+              "column": 2
+            },
+            "end": {
+              "line": 244,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "path"
+            },
+            {
+              "name": "value"
+            },
+            {
+              "name": "isPathNotification",
+              "defaultValue": "false"
+            },
+            {
+              "name": "flush",
+              "defaultValue": "false"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "_computeItemRowCellClasses",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 103,
+              "column": 2
+            },
+            "end": {
+              "line": 107,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "column"
+            }
+          ]
+        },
+        {
           "name": "_itemUpdated",
           "description": "",
           "privacy": "protected",
@@ -7038,14 +3659,14 @@
               "column": 2
             },
             "end": {
-              "line": 114,
+              "line": 120,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "changeRecord"
+              "name": "itemChange"
             }
           ],
           "return": {
@@ -7058,11 +3679,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 122,
               "column": 2
             },
             "end": {
-              "line": 118,
+              "line": 126,
               "column": 3
             }
           },
@@ -7082,11 +3703,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 120,
+              "line": 128,
               "column": 2
             },
             "end": {
-              "line": 122,
+              "line": 132,
               "column": 3
             }
           },
@@ -7106,11 +3727,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 130,
+              "line": 140,
               "column": 2
             },
             "end": {
-              "line": 132,
+              "line": 142,
               "column": 3
             }
           },
@@ -7131,27 +3752,6 @@
             "type": "string",
             "desc": "Cell title."
           }
-        },
-        {
-          "name": "_computeItemRowCellClasses",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 134,
-              "column": 2
-            },
-            "end": {
-              "line": 138,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "column"
-            }
-          ]
         }
       ],
       "staticMethods": [],
@@ -7159,11 +3759,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 41,
+          "line": 39,
           "column": 1
         },
         "end": {
-          "line": 139,
+          "line": 143,
           "column": 2
         }
       },
@@ -7177,11 +3777,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -7195,11 +3795,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -7212,11 +3812,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 50,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 52,
+              "line": 50,
               "column": 5
             }
           },
@@ -7228,11 +3828,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 54,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 55,
               "column": 5
             }
           },
@@ -7244,11 +3844,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 62,
+              "line": 60,
               "column": 5
             }
           },
@@ -7267,11 +3867,11 @@
           "name": "item-cell",
           "range": {
             "start": {
-              "line": 29,
+              "line": 27,
               "column": 2
             },
             "end": {
-              "line": 29,
+              "line": 27,
               "column": 32
             }
           }
@@ -7295,11 +3895,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1148,
+              "line": 1098,
               "column": 8
             },
             "end": {
-              "line": 1148,
+              "line": 1098,
               "column": 32
             }
           },
@@ -7318,11 +3918,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1150,
+              "line": 1100,
               "column": 8
             },
             "end": {
-              "line": 1150,
+              "line": 1100,
               "column": 34
             }
           },
@@ -7341,11 +3941,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1152,
+              "line": 1102,
               "column": 8
             },
             "end": {
-              "line": 1152,
+              "line": 1102,
               "column": 28
             }
           },
@@ -7364,11 +3964,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1154,
+              "line": 1104,
               "column": 8
             },
             "end": {
-              "line": 1154,
+              "line": 1104,
               "column": 31
             }
           },
@@ -7387,11 +3987,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1156,
+              "line": 1106,
               "column": 8
             },
             "end": {
-              "line": 1156,
+              "line": 1106,
               "column": 28
             }
           },
@@ -7410,11 +4010,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1158,
+              "line": 1108,
               "column": 8
             },
             "end": {
-              "line": 1158,
+              "line": 1108,
               "column": 35
             }
           },
@@ -7433,11 +4033,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1160,
+              "line": 1110,
               "column": 8
             },
             "end": {
-              "line": 1160,
+              "line": 1110,
               "column": 24
             }
           },
@@ -7456,11 +4056,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1162,
+              "line": 1112,
               "column": 8
             },
             "end": {
-              "line": 1162,
+              "line": 1112,
               "column": 24
             }
           },
@@ -7479,11 +4079,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1164,
+              "line": 1114,
               "column": 8
             },
             "end": {
-              "line": 1164,
+              "line": 1114,
               "column": 38
             }
           },
@@ -7502,11 +4102,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1166,
+              "line": 1116,
               "column": 8
             },
             "end": {
-              "line": 1166,
+              "line": 1116,
               "column": 20
             }
           },
@@ -7525,11 +4125,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1168,
+              "line": 1118,
               "column": 8
             },
             "end": {
-              "line": 1168,
+              "line": 1118,
               "column": 27
             }
           },
@@ -7548,11 +4148,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1170,
+              "line": 1120,
               "column": 8
             },
             "end": {
-              "line": 1170,
+              "line": 1120,
               "column": 23
             }
           },
@@ -7571,11 +4171,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1172,
+              "line": 1122,
               "column": 8
             },
             "end": {
-              "line": 1172,
+              "line": 1122,
               "column": 30
             }
           },
@@ -7594,11 +4194,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1174,
+              "line": 1124,
               "column": 8
             },
             "end": {
-              "line": 1174,
+              "line": 1124,
               "column": 30
             }
           },
@@ -7617,11 +4217,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1176,
+              "line": 1126,
               "column": 8
             },
             "end": {
-              "line": 1176,
+              "line": 1126,
               "column": 29
             }
           },
@@ -7640,11 +4240,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1178,
+              "line": 1128,
               "column": 8
             },
             "end": {
-              "line": 1178,
+              "line": 1128,
               "column": 32
             }
           },
@@ -7663,11 +4263,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1180,
+              "line": 1130,
               "column": 8
             },
             "end": {
-              "line": 1180,
+              "line": 1130,
               "column": 30
             }
           },
@@ -7686,11 +4286,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1182,
+              "line": 1132,
               "column": 8
             },
             "end": {
-              "line": 1182,
+              "line": 1132,
               "column": 24
             }
           },
@@ -7709,11 +4309,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1184,
+              "line": 1134,
               "column": 8
             },
             "end": {
-              "line": 1184,
+              "line": 1134,
               "column": 28
             }
           },
@@ -7732,11 +4332,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1187,
+              "line": 1137,
               "column": 6
             },
             "end": {
-              "line": 1189,
+              "line": 1139,
               "column": 7
             }
           },
@@ -7755,11 +4355,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 435,
+              "line": 486,
               "column": 8
             },
             "end": {
-              "line": 435,
+              "line": 486,
               "column": 23
             }
           },
@@ -7778,11 +4378,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 437,
+              "line": 488,
               "column": 8
             },
             "end": {
-              "line": 437,
+              "line": 488,
               "column": 25
             }
           },
@@ -7801,11 +4401,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 439,
+              "line": 490,
               "column": 8
             },
             "end": {
-              "line": 439,
+              "line": 490,
               "column": 22
             }
           },
@@ -7824,11 +4424,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 441,
+              "line": 492,
               "column": 8
             },
             "end": {
-              "line": 441,
+              "line": 492,
               "column": 24
             }
           },
@@ -7847,11 +4447,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 443,
+              "line": 494,
               "column": 8
             },
             "end": {
-              "line": 443,
+              "line": 494,
               "column": 18
             }
           },
@@ -7870,11 +4470,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 445,
+              "line": 496,
               "column": 8
             },
             "end": {
-              "line": 445,
+              "line": 496,
               "column": 15
             }
           },
@@ -7892,11 +4492,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 46,
               "column": 4
             },
             "end": {
-              "line": 51,
+              "line": 48,
               "column": 5
             }
           },
@@ -7944,11 +4544,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 452,
+              "line": 460,
               "column": 6
             },
             "end": {
-              "line": 457,
+              "line": 465,
               "column": 7
             }
           },
@@ -7988,11 +4588,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 467,
+              "line": 475,
               "column": 6
             },
             "end": {
-              "line": 469,
+              "line": 477,
               "column": 7
             }
           },
@@ -8026,11 +4626,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 479,
+              "line": 487,
               "column": 6
             },
             "end": {
-              "line": 481,
+              "line": 489,
               "column": 7
             }
           },
@@ -8158,11 +4758,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 553,
+              "line": 603,
               "column": 6
             },
             "end": {
-              "line": 559,
+              "line": 609,
               "column": 7
             }
           },
@@ -8180,11 +4780,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 460,
+              "line": 511,
               "column": 6
             },
             "end": {
-              "line": 493,
+              "line": 543,
               "column": 7
             }
           },
@@ -8733,11 +5333,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1218,
+              "line": 1168,
               "column": 6
             },
             "end": {
-              "line": 1222,
+              "line": 1172,
               "column": 7
             }
           },
@@ -8852,11 +5452,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1256,
+              "line": 1206,
               "column": 6
             },
             "end": {
-              "line": 1264,
+              "line": 1214,
               "column": 7
             }
           },
@@ -8890,11 +5490,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1274,
+              "line": 1224,
               "column": 6
             },
             "end": {
-              "line": 1280,
+              "line": 1230,
               "column": 7
             }
           },
@@ -8928,11 +5528,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1291,
+              "line": 1241,
               "column": 6
             },
             "end": {
-              "line": 1294,
+              "line": 1244,
               "column": 7
             }
           },
@@ -8962,11 +5562,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1304,
+              "line": 1254,
               "column": 6
             },
             "end": {
-              "line": 1306,
+              "line": 1256,
               "column": 7
             }
           },
@@ -8991,11 +5591,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1316,
+              "line": 1266,
               "column": 6
             },
             "end": {
-              "line": 1318,
+              "line": 1268,
               "column": 7
             }
           },
@@ -9020,11 +5620,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1328,
+              "line": 1278,
               "column": 6
             },
             "end": {
-              "line": 1330,
+              "line": 1280,
               "column": 7
             }
           },
@@ -9049,11 +5649,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1340,
+              "line": 1290,
               "column": 6
             },
             "end": {
-              "line": 1342,
+              "line": 1292,
               "column": 7
             }
           },
@@ -9078,11 +5678,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1374,
+              "line": 1324,
               "column": 6
             },
             "end": {
-              "line": 1406,
+              "line": 1356,
               "column": 7
             }
           },
@@ -9122,11 +5722,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1429,
+              "line": 1379,
               "column": 6
             },
             "end": {
-              "line": 1437,
+              "line": 1387,
               "column": 7
             }
           },
@@ -9160,11 +5760,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1544,
+              "line": 1494,
               "column": 6
             },
             "end": {
-              "line": 1549,
+              "line": 1499,
               "column": 7
             }
           },
@@ -9188,11 +5788,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1570,
+              "line": 1520,
               "column": 6
             },
             "end": {
-              "line": 1581,
+              "line": 1531,
               "column": 7
             }
           },
@@ -9210,11 +5810,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1595,
+              "line": 1545,
               "column": 6
             },
             "end": {
-              "line": 1608,
+              "line": 1558,
               "column": 7
             }
           },
@@ -9232,11 +5832,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 571,
+              "line": 621,
               "column": 6
             },
             "end": {
-              "line": 580,
+              "line": 630,
               "column": 7
             }
           },
@@ -9254,11 +5854,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1637,
+              "line": 1587,
               "column": 6
             },
             "end": {
-              "line": 1648,
+              "line": 1598,
               "column": 7
             }
           },
@@ -9287,11 +5887,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1735,
+              "line": 1685,
               "column": 6
             },
             "end": {
-              "line": 1745,
+              "line": 1695,
               "column": 7
             }
           },
@@ -9325,11 +5925,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1756,
+              "line": 1706,
               "column": 6
             },
             "end": {
-              "line": 1761,
+              "line": 1711,
               "column": 7
             }
           },
@@ -9358,11 +5958,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1773,
+              "line": 1723,
               "column": 6
             },
             "end": {
-              "line": 1778,
+              "line": 1728,
               "column": 7
             }
           },
@@ -9386,11 +5986,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1810,
+              "line": 1760,
               "column": 6
             },
             "end": {
-              "line": 1814,
+              "line": 1764,
               "column": 7
             }
           },
@@ -9419,11 +6019,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1835,
+              "line": 1785,
               "column": 6
             },
             "end": {
-              "line": 1837,
+              "line": 1787,
               "column": 7
             }
           },
@@ -9453,11 +6053,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1860,
+              "line": 1810,
               "column": 6
             },
             "end": {
-              "line": 1870,
+              "line": 1820,
               "column": 7
             }
           },
@@ -9491,11 +6091,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1886,
+              "line": 1836,
               "column": 6
             },
             "end": {
-              "line": 1895,
+              "line": 1845,
               "column": 7
             }
           },
@@ -9526,11 +6126,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1910,
+              "line": 1860,
               "column": 6
             },
             "end": {
-              "line": 1919,
+              "line": 1869,
               "column": 7
             }
           },
@@ -9555,11 +6155,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1938,
+              "line": 1888,
               "column": 6
             },
             "end": {
-              "line": 1975,
+              "line": 1925,
               "column": 7
             }
           },
@@ -9600,11 +6200,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1990,
+              "line": 1940,
               "column": 6
             },
             "end": {
-              "line": 1999,
+              "line": 1949,
               "column": 7
             }
           },
@@ -9629,11 +6229,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2015,
+              "line": 1965,
               "column": 6
             },
             "end": {
-              "line": 2023,
+              "line": 1973,
               "column": 7
             }
           },
@@ -9664,11 +6264,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2038,
+              "line": 1988,
               "column": 6
             },
             "end": {
-              "line": 2055,
+              "line": 2005,
               "column": 7
             }
           },
@@ -9697,11 +6297,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2068,
+              "line": 2018,
               "column": 6
             },
             "end": {
-              "line": 2075,
+              "line": 2025,
               "column": 7
             }
           },
@@ -9730,11 +6330,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2089,
+              "line": 2039,
               "column": 6
             },
             "end": {
-              "line": 2099,
+              "line": 2049,
               "column": 7
             }
           },
@@ -9768,11 +6368,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2112,
+              "line": 2062,
               "column": 6
             },
             "end": {
-              "line": 2118,
+              "line": 2068,
               "column": 7
             }
           },
@@ -9801,11 +6401,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2129,
+              "line": 2079,
               "column": 6
             },
             "end": {
-              "line": 2137,
+              "line": 2087,
               "column": 7
             }
           },
@@ -9829,11 +6429,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2148,
+              "line": 2098,
               "column": 6
             },
             "end": {
-              "line": 2161,
+              "line": 2111,
               "column": 7
             }
           },
@@ -9857,11 +6457,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2175,
+              "line": 2125,
               "column": 6
             },
             "end": {
-              "line": 2181,
+              "line": 2131,
               "column": 7
             }
           },
@@ -9885,6 +6485,45 @@
           ],
           "return": {
             "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_marshalArgs",
+          "description": "Gather the argument values for a method specified in the provided array\nof argument metadata.\n\nThe `path` and `value` arguments are used to fill in wildcard descriptor\nwhen the method is being called as a result of a path notification.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2146,
+              "column": 6
+            },
+            "end": {
+              "line": 2181,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "args",
+              "type": "!Array.<!MethodArg>",
+              "description": "Array of argument metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path name that triggered the method effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            }
+          ],
+          "return": {
+            "type": "Array.<*>",
+            "desc": "Array of argument values"
           },
           "inheritedFrom": "Polymer.PropertyEffects"
         },
@@ -9957,11 +6596,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 540,
+              "line": 590,
               "column": 6
             },
             "end": {
-              "line": 545,
+              "line": 595,
               "column": 7
             }
           },
@@ -9979,11 +6618,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 216,
+              "line": 226,
               "column": 6
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 7
             }
           },
@@ -10001,11 +6640,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 594,
+              "line": 644,
               "column": 6
             },
             "end": {
-              "line": 610,
+              "line": 660,
               "column": 7
             }
           },
@@ -10030,11 +6669,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 633,
+              "line": 683,
               "column": 6
             },
             "end": {
-              "line": 637,
+              "line": 687,
               "column": 7
             }
           },
@@ -10058,11 +6697,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 654,
+              "line": 704,
               "column": 6
             },
             "end": {
-              "line": 659,
+              "line": 709,
               "column": 7
             }
           },
@@ -10094,11 +6733,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 197,
+              "line": 201,
               "column": 6
             },
             "end": {
-              "line": 208,
+              "line": 212,
               "column": 7
             }
           },
@@ -10128,11 +6767,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 670,
+              "line": 720,
               "column": 6
             },
             "end": {
-              "line": 673,
+              "line": 723,
               "column": 7
             }
           },
@@ -10196,11 +6835,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 258,
+              "line": 263,
               "column": 6
             },
             "end": {
-              "line": 295,
+              "line": 303,
               "column": 7
             }
           },
@@ -10234,11 +6873,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2592,
+              "line": 2597,
               "column": 6
             },
             "end": {
-              "line": 2602,
+              "line": 2607,
               "column": 7
             }
           },
@@ -10273,11 +6912,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 333,
+              "line": 341,
               "column": 6
             },
             "end": {
-              "line": 342,
+              "line": 350,
               "column": 7
             }
           },
@@ -10316,7 +6955,7 @@
               "column": 6
             },
             "end": {
-              "line": 2576,
+              "line": 2581,
               "column": 7
             }
           },
@@ -10361,11 +7000,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 388,
+              "line": 396,
               "column": 6
             },
             "end": {
-              "line": 391,
+              "line": 399,
               "column": 7
             }
           },
@@ -10390,11 +7029,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 326,
-              "column": 7
+              "line": 351,
+              "column": 6
             },
             "end": {
-              "line": 330,
+              "line": 355,
               "column": 7
             }
           },
@@ -10445,11 +7084,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 181,
+              "line": 190,
               "column": 6
             },
             "end": {
-              "line": 184,
+              "line": 193,
               "column": 7
             }
           },
@@ -10800,11 +7439,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2648,
+              "line": 2653,
               "column": 6
             },
             "end": {
-              "line": 2713,
+              "line": 2718,
               "column": 7
             }
           },
@@ -10834,11 +7473,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2729,
+              "line": 2734,
               "column": 6
             },
             "end": {
-              "line": 2746,
+              "line": 2751,
               "column": 7
             }
           },
@@ -10888,11 +7527,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 129,
+              "line": 138,
               "column": 6
             },
             "end": {
-              "line": 138,
+              "line": 147,
               "column": 7
             }
           },
@@ -10910,11 +7549,33 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 294,
-              "column": 5
+              "line": 319,
+              "column": 6
             },
             "end": {
-              "line": 317,
+              "line": 326,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_prepareTemplate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 328,
+              "column": 6
+            },
+            "end": {
+              "line": 342,
               "column": 7
             }
           },
@@ -10932,11 +7593,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 343,
+              "line": 368,
               "column": 6
             },
             "end": {
-              "line": 348,
+              "line": 373,
               "column": 7
             }
           },
@@ -10965,11 +7626,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 503,
+              "line": 553,
               "column": 6
             },
             "end": {
-              "line": 505,
+              "line": 555,
               "column": 7
             }
           },
@@ -10999,11 +7660,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 516,
+              "line": 566,
               "column": 6
             },
             "end": {
-              "line": 527,
+              "line": 577,
               "column": 7
             }
           },
@@ -11025,11 +7686,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 42,
+          "line": 39,
           "column": 1
         },
         "end": {
-          "line": 54,
+          "line": 51,
           "column": 2
         }
       },
@@ -11042,11 +7703,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 46,
               "column": 4
             },
             "end": {
-              "line": 51,
+              "line": 48,
               "column": 5
             }
           },
@@ -11065,11 +7726,11 @@
           "name": "",
           "range": {
             "start": {
-              "line": 34,
+              "line": 31,
               "column": 3
             },
             "end": {
-              "line": 34,
+              "line": 31,
               "column": 16
             }
           }
@@ -11089,11 +7750,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 77,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 79,
               "column": 3
             }
           },
@@ -11110,11 +7771,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 83,
+              "line": 81,
               "column": 2
             },
             "end": {
-              "line": 85,
+              "line": 83,
               "column": 3
             }
           },
@@ -11125,6 +7786,52 @@
           }
         },
         {
+          "name": "elements",
+          "type": "?",
+          "description": "Get an array of the elements generated by this repeater\n\t\t ",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 94,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "templateInstances",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 101,
+              "column": 2
+            },
+            "end": {
+              "line": 106,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -11132,11 +7839,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -11155,11 +7862,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -11178,11 +7885,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 51,
+              "line": 49,
               "column": 5
             }
           },
@@ -11199,11 +7906,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 53,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 56,
+              "line": 54,
               "column": 5
             }
           },
@@ -11221,11 +7928,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 58,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 61,
               "column": 5
             }
           },
@@ -11244,11 +7951,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 66,
               "column": 5
             }
           },
@@ -11261,193 +7968,16 @@
       ],
       "methods": [
         {
-          "name": "trackColumns",
-          "description": "Adds an observer to render the cells when the columns are changed.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 48,
-              "column": 2
-            },
-            "end": {
-              "line": 60,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "stopTrackingColumns",
-          "description": "Stops reacting to column changes.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 66,
-              "column": 2
-            },
-            "end": {
-              "line": 73,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "renderCells",
-          "description": "Renders all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 79,
-              "column": 2
-            },
-            "end": {
-              "line": 81,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "destroyCells",
-          "description": "Destroys all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 87,
-              "column": 2
-            },
-            "end": {
-              "line": 89,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardChange",
-          "description": "Forwards a property change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 97,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "String",
-              "description": "the property"
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "the new value"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardPathChange",
-          "description": "Forwards a path change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 106,
-              "column": 2
-            },
-            "end": {
-              "line": 110,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changeRecord",
-              "type": "Object",
-              "description": "the change record"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forEachElement",
-          "description": "Runs a callback on each element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 117,
-              "column": 2
-            },
-            "end": {
-              "line": 119,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "callback",
-              "type": "OmnitableRepeaterMixin~forEachElementCallback",
-              "description": "the callback"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 85,
               "column": 2
             },
             "end": {
-              "line": 95,
+              "line": 87,
               "column": 3
             }
           },
@@ -11459,16 +7989,46 @@
           ]
         },
         {
+          "name": "_detachTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 91,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "column"
+            },
+            {
+              "name": "element"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_configureElement",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 93,
               "column": 2
             },
             "end": {
-              "line": 103,
+              "line": 95,
               "column": 3
             }
           },
@@ -11479,7 +8039,28 @@
             },
             {
               "name": "column"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_configureTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 97,
+              "column": 2
             },
+            "end": {
+              "line": 104,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
             {
               "name": "instance"
             }
@@ -11489,17 +8070,75 @@
           }
         },
         {
+          "name": "getElementTemplateInstance",
+          "description": "Get the template instance rendered by the specified element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 113,
+              "column": 2
+            },
+            "end": {
+              "line": 115,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The instance."
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "getElementColumn",
+          "description": "Get the column that was used to rendered the specified element",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 122,
+              "column": 2
+            },
+            "end": {
+              "line": 124,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The column."
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_columnsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 171,
+              "line": 126,
               "column": 2
             },
             "end": {
-              "line": 195,
+              "line": 150,
               "column": 3
             }
           },
@@ -11521,11 +8160,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 197,
+              "line": 152,
               "column": 2
             },
             "end": {
-              "line": 206,
+              "line": 161,
               "column": 3
             }
           },
@@ -11547,11 +8186,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 208,
+              "line": 163,
               "column": 2
             },
             "end": {
-              "line": 234,
+              "line": 201,
               "column": 3
             }
           },
@@ -11576,11 +8215,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 236,
+              "line": 203,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 211,
               "column": 3
             }
           },
@@ -11605,11 +8244,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 246,
+              "line": 213,
               "column": 2
             },
             "end": {
-              "line": 262,
+              "line": 229,
               "column": 3
             }
           },
@@ -11628,17 +8267,53 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
+          "name": "_forwardProperty",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 231,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "name"
+            },
+            {
+              "name": "value"
+            },
+            {
+              "name": "flush",
+              "defaultValue": "false"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 264,
+              "line": 239,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 244,
               "column": 3
             }
           },
@@ -11652,6 +8327,10 @@
             },
             {
               "name": "value"
+            },
+            {
+              "name": "isPathNotification",
+              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -11669,11 +8348,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 106,
               "column": 2
             },
             "end": {
-              "line": 114,
+              "line": 115,
               "column": 3
             }
           },
@@ -11693,18 +8372,18 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 117,
               "column": 2
             },
             "end": {
-              "line": 118,
+              "line": 127,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "changeRecord"
+              "name": "itemChange"
             }
           ],
           "return": {
@@ -11717,11 +8396,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 120,
+              "line": 129,
               "column": 2
             },
             "end": {
-              "line": 122,
+              "line": 133,
               "column": 3
             }
           },
@@ -11741,11 +8420,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 124,
+              "line": 135,
               "column": 2
             },
             "end": {
-              "line": 134,
+              "line": 139,
               "column": 3
             }
           },
@@ -11753,9 +8432,6 @@
           "params": [
             {
               "name": "expanded"
-            },
-            {
-              "name": "prevValue"
             }
           ],
           "return": {
@@ -11768,11 +8444,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 40,
+          "line": 38,
           "column": 1
         },
         "end": {
-          "line": 135,
+          "line": 140,
           "column": 2
         }
       },
@@ -11786,11 +8462,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -11804,11 +8480,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -11821,11 +8497,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 51,
+              "line": 49,
               "column": 5
             }
           },
@@ -11837,11 +8513,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 53,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 56,
+              "line": 54,
               "column": 5
             }
           },
@@ -11853,11 +8529,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 58,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 61,
               "column": 5
             }
           },
@@ -11869,11 +8545,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 66,
               "column": 5
             }
           },
@@ -11892,11 +8568,11 @@
           "name": "item-expand-line",
           "range": {
             "start": {
-              "line": 28,
+              "line": 26,
               "column": 2
             },
             "end": {
-              "line": 28,
+              "line": 26,
               "column": 39
             }
           }
@@ -11919,11 +8595,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 54,
+              "line": 52,
               "column": 3
             },
             "end": {
-              "line": 56,
+              "line": 54,
               "column": 4
             }
           },
@@ -11940,11 +8616,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 58,
+              "line": 56,
               "column": 3
             },
             "end": {
-              "line": 60,
+              "line": 58,
               "column": 4
             }
           },
@@ -11955,6 +8631,52 @@
           }
         },
         {
+          "name": "elements",
+          "type": "?",
+          "description": "Get an array of the elements generated by this repeater\n\t\t ",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 94,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "templateInstances",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 101,
+              "column": 2
+            },
+            "end": {
+              "line": 106,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -11962,11 +8684,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -11985,11 +8707,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -12008,11 +8730,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 27,
+              "line": 25,
               "column": 5
             },
             "end": {
-              "line": 30,
+              "line": 28,
               "column": 6
             }
           },
@@ -12030,11 +8752,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 32,
+              "line": 30,
               "column": 5
             },
             "end": {
-              "line": 34,
+              "line": 32,
               "column": 6
             }
           },
@@ -12051,11 +8773,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 36,
+              "line": 34,
               "column": 5
             },
             "end": {
-              "line": 39,
+              "line": 37,
               "column": 6
             }
           },
@@ -12073,11 +8795,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 39,
               "column": 5
             },
             "end": {
-              "line": 44,
+              "line": 42,
               "column": 6
             }
           },
@@ -12091,193 +8813,16 @@
       ],
       "methods": [
         {
-          "name": "trackColumns",
-          "description": "Adds an observer to render the cells when the columns are changed.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 48,
-              "column": 2
-            },
-            "end": {
-              "line": 60,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "stopTrackingColumns",
-          "description": "Stops reacting to column changes.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 66,
-              "column": 2
-            },
-            "end": {
-              "line": 73,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "renderCells",
-          "description": "Renders all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 79,
-              "column": 2
-            },
-            "end": {
-              "line": 81,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "destroyCells",
-          "description": "Destroys all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 87,
-              "column": 2
-            },
-            "end": {
-              "line": 89,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardChange",
-          "description": "Forwards a property change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 97,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "String",
-              "description": "the property"
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "the new value"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forwardPathChange",
-          "description": "Forwards a path change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 106,
-              "column": 2
-            },
-            "end": {
-              "line": 110,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changeRecord",
-              "type": "Object",
-              "description": "the change record"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "forEachElement",
-          "description": "Runs a callback on each element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 117,
-              "column": 2
-            },
-            "end": {
-              "line": 119,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "callback",
-              "type": "OmnitableRepeaterMixin~forEachElementCallback",
-              "description": "the callback"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 71,
               "column": 3
             },
             "end": {
-              "line": 86,
+              "line": 73,
               "column": 4
             }
           },
@@ -12289,17 +8834,99 @@
           ]
         },
         {
+          "name": "_detachTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 75,
+              "column": 3
+            },
+            "end": {
+              "line": 77,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "column"
+            },
+            {
+              "name": "element"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_configureElement",
-          "description": "Configure a newly created repeated element",
+          "description": "Configure a newly created repeated element\nMust be defined in implementors.",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 160,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 169,
+              "line": 79,
+              "column": 31
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "undefined"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "_configureTemplateInstance",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3
+            },
+            "end": {
+              "line": 86,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "getElementTemplateInstance",
+          "description": "Get the template instance rendered by the specified element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 113,
+              "column": 2
+            },
+            "end": {
+              "line": 115,
               "column": 3
             }
           },
@@ -12307,22 +8934,42 @@
           "params": [
             {
               "name": "element",
-              "type": "HTMLElement",
-              "description": "the root cell element"
-            },
-            {
-              "name": "column",
-              "type": "OmnitableColumnMixin",
-              "description": "the column"
-            },
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "the template instance"
+              "type": "Object",
+              "description": "The element."
             }
           ],
           "return": {
-            "type": "void"
+            "type": "Object",
+            "desc": "The instance."
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "getElementColumn",
+          "description": "Get the column that was used to rendered the specified element",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 122,
+              "column": 2
+            },
+            "end": {
+              "line": 124,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The column."
           },
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
@@ -12333,11 +8980,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 171,
+              "line": 126,
               "column": 2
             },
             "end": {
-              "line": 195,
+              "line": 150,
               "column": 3
             }
           },
@@ -12359,11 +9006,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 197,
+              "line": 152,
               "column": 2
             },
             "end": {
-              "line": 206,
+              "line": 161,
               "column": 3
             }
           },
@@ -12385,11 +9032,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 208,
+              "line": 163,
               "column": 2
             },
             "end": {
-              "line": 234,
+              "line": 201,
               "column": 3
             }
           },
@@ -12414,11 +9061,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 236,
+              "line": 203,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 211,
               "column": 3
             }
           },
@@ -12443,11 +9090,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 246,
+              "line": 213,
               "column": 2
             },
             "end": {
-              "line": 262,
+              "line": 229,
               "column": 3
             }
           },
@@ -12466,17 +9113,53 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
+          "name": "_forwardProperty",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 231,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "name"
+            },
+            {
+              "name": "value"
+            },
+            {
+              "name": "flush",
+              "defaultValue": "false"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 264,
+              "line": 239,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 244,
               "column": 3
             }
           },
@@ -12490,6 +9173,10 @@
             },
             {
               "name": "value"
+            },
+            {
+              "name": "isPathNotification",
+              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -12507,11 +9194,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 60,
               "column": 3
             },
             "end": {
-              "line": 76,
+              "line": 69,
               "column": 4
             }
           },
@@ -12535,14 +9222,14 @@
               "column": 3
             },
             "end": {
-              "line": 90,
+              "line": 98,
               "column": 4
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "changeRecord"
+              "name": "itemChange"
             }
           ],
           "return": {
@@ -12555,11 +9242,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 92,
+              "line": 100,
               "column": 3
             },
             "end": {
-              "line": 94,
+              "line": 104,
               "column": 4
             }
           },
@@ -12574,16 +9261,40 @@
           }
         },
         {
+          "name": "_expandedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 106,
+              "column": 3
+            },
+            "end": {
+              "line": 110,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expanded"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_foldedChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 112,
               "column": 3
             },
             "end": {
-              "line": 98,
+              "line": 116,
               "column": 4
             }
           },
@@ -12603,11 +9314,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 18,
+          "line": 16,
           "column": 2
         },
         "end": {
-          "line": 99,
+          "line": 117,
           "column": 3
         }
       },
@@ -12621,11 +9332,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -12639,11 +9350,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -12656,11 +9367,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 27,
+              "line": 25,
               "column": 5
             },
             "end": {
-              "line": 30,
+              "line": 28,
               "column": 6
             }
           },
@@ -12672,11 +9383,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 32,
+              "line": 30,
               "column": 5
             },
             "end": {
-              "line": 34,
+              "line": 32,
               "column": 6
             }
           },
@@ -12688,11 +9399,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 36,
+              "line": 34,
               "column": 5
             },
             "end": {
-              "line": 39,
+              "line": 37,
               "column": 6
             }
           },
@@ -12704,11 +9415,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 39,
               "column": 5
             },
             "end": {
-              "line": 44,
+              "line": 42,
               "column": 6
             }
           },
@@ -12727,11 +9438,11 @@
           "name": "group-row",
           "range": {
             "start": {
-              "line": 8,
+              "line": 6,
               "column": 2
             },
             "end": {
-              "line": 8,
+              "line": 6,
               "column": 32
             }
           }
@@ -12755,11 +9466,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1148,
+              "line": 1098,
               "column": 8
             },
             "end": {
-              "line": 1148,
+              "line": 1098,
               "column": 32
             }
           },
@@ -12778,11 +9489,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1150,
+              "line": 1100,
               "column": 8
             },
             "end": {
-              "line": 1150,
+              "line": 1100,
               "column": 34
             }
           },
@@ -12801,11 +9512,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1152,
+              "line": 1102,
               "column": 8
             },
             "end": {
-              "line": 1152,
+              "line": 1102,
               "column": 28
             }
           },
@@ -12824,11 +9535,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1154,
+              "line": 1104,
               "column": 8
             },
             "end": {
-              "line": 1154,
+              "line": 1104,
               "column": 31
             }
           },
@@ -12847,11 +9558,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1156,
+              "line": 1106,
               "column": 8
             },
             "end": {
-              "line": 1156,
+              "line": 1106,
               "column": 28
             }
           },
@@ -12870,11 +9581,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1158,
+              "line": 1108,
               "column": 8
             },
             "end": {
-              "line": 1158,
+              "line": 1108,
               "column": 35
             }
           },
@@ -12893,11 +9604,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1160,
+              "line": 1110,
               "column": 8
             },
             "end": {
-              "line": 1160,
+              "line": 1110,
               "column": 24
             }
           },
@@ -12916,11 +9627,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1162,
+              "line": 1112,
               "column": 8
             },
             "end": {
-              "line": 1162,
+              "line": 1112,
               "column": 24
             }
           },
@@ -12939,11 +9650,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1164,
+              "line": 1114,
               "column": 8
             },
             "end": {
-              "line": 1164,
+              "line": 1114,
               "column": 38
             }
           },
@@ -12962,11 +9673,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1166,
+              "line": 1116,
               "column": 8
             },
             "end": {
-              "line": 1166,
+              "line": 1116,
               "column": 20
             }
           },
@@ -12985,11 +9696,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1168,
+              "line": 1118,
               "column": 8
             },
             "end": {
-              "line": 1168,
+              "line": 1118,
               "column": 27
             }
           },
@@ -13008,11 +9719,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1170,
+              "line": 1120,
               "column": 8
             },
             "end": {
-              "line": 1170,
+              "line": 1120,
               "column": 23
             }
           },
@@ -13031,11 +9742,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1172,
+              "line": 1122,
               "column": 8
             },
             "end": {
-              "line": 1172,
+              "line": 1122,
               "column": 30
             }
           },
@@ -13054,11 +9765,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1174,
+              "line": 1124,
               "column": 8
             },
             "end": {
-              "line": 1174,
+              "line": 1124,
               "column": 30
             }
           },
@@ -13077,11 +9788,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1176,
+              "line": 1126,
               "column": 8
             },
             "end": {
-              "line": 1176,
+              "line": 1126,
               "column": 29
             }
           },
@@ -13100,11 +9811,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1178,
+              "line": 1128,
               "column": 8
             },
             "end": {
-              "line": 1178,
+              "line": 1128,
               "column": 32
             }
           },
@@ -13123,11 +9834,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1180,
+              "line": 1130,
               "column": 8
             },
             "end": {
-              "line": 1180,
+              "line": 1130,
               "column": 30
             }
           },
@@ -13146,11 +9857,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1182,
+              "line": 1132,
               "column": 8
             },
             "end": {
-              "line": 1182,
+              "line": 1132,
               "column": 24
             }
           },
@@ -13169,11 +9880,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1184,
+              "line": 1134,
               "column": 8
             },
             "end": {
-              "line": 1184,
+              "line": 1134,
               "column": 28
             }
           },
@@ -13192,11 +9903,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1187,
+              "line": 1137,
               "column": 6
             },
             "end": {
-              "line": 1189,
+              "line": 1139,
               "column": 7
             }
           },
@@ -13215,11 +9926,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 435,
+              "line": 486,
               "column": 8
             },
             "end": {
-              "line": 435,
+              "line": 486,
               "column": 23
             }
           },
@@ -13238,11 +9949,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 437,
+              "line": 488,
               "column": 8
             },
             "end": {
-              "line": 437,
+              "line": 488,
               "column": 25
             }
           },
@@ -13261,11 +9972,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 439,
+              "line": 490,
               "column": 8
             },
             "end": {
-              "line": 439,
+              "line": 490,
               "column": 22
             }
           },
@@ -13284,11 +9995,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 441,
+              "line": 492,
               "column": 8
             },
             "end": {
-              "line": 441,
+              "line": 492,
               "column": 24
             }
           },
@@ -13307,11 +10018,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 443,
+              "line": 494,
               "column": 8
             },
             "end": {
-              "line": 443,
+              "line": 494,
               "column": 18
             }
           },
@@ -13330,11 +10041,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 445,
+              "line": 496,
               "column": 8
             },
             "end": {
-              "line": 445,
+              "line": 496,
               "column": 15
             }
           },
@@ -13352,11 +10063,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 33,
+              "line": 31,
               "column": 5
             },
             "end": {
-              "line": 36,
+              "line": 34,
               "column": 6
             }
           },
@@ -13405,11 +10116,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 452,
+              "line": 460,
               "column": 6
             },
             "end": {
-              "line": 457,
+              "line": 465,
               "column": 7
             }
           },
@@ -13449,11 +10160,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 467,
+              "line": 475,
               "column": 6
             },
             "end": {
-              "line": 469,
+              "line": 477,
               "column": 7
             }
           },
@@ -13487,11 +10198,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 479,
+              "line": 487,
               "column": 6
             },
             "end": {
-              "line": 481,
+              "line": 489,
               "column": 7
             }
           },
@@ -13619,11 +10330,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 553,
+              "line": 603,
               "column": 6
             },
             "end": {
-              "line": 559,
+              "line": 609,
               "column": 7
             }
           },
@@ -13641,11 +10352,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 460,
+              "line": 511,
               "column": 6
             },
             "end": {
-              "line": 493,
+              "line": 543,
               "column": 7
             }
           },
@@ -14194,11 +10905,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1218,
+              "line": 1168,
               "column": 6
             },
             "end": {
-              "line": 1222,
+              "line": 1172,
               "column": 7
             }
           },
@@ -14313,11 +11024,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1256,
+              "line": 1206,
               "column": 6
             },
             "end": {
-              "line": 1264,
+              "line": 1214,
               "column": 7
             }
           },
@@ -14351,11 +11062,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1274,
+              "line": 1224,
               "column": 6
             },
             "end": {
-              "line": 1280,
+              "line": 1230,
               "column": 7
             }
           },
@@ -14389,11 +11100,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1291,
+              "line": 1241,
               "column": 6
             },
             "end": {
-              "line": 1294,
+              "line": 1244,
               "column": 7
             }
           },
@@ -14423,11 +11134,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1304,
+              "line": 1254,
               "column": 6
             },
             "end": {
-              "line": 1306,
+              "line": 1256,
               "column": 7
             }
           },
@@ -14452,11 +11163,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1316,
+              "line": 1266,
               "column": 6
             },
             "end": {
-              "line": 1318,
+              "line": 1268,
               "column": 7
             }
           },
@@ -14481,11 +11192,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1328,
+              "line": 1278,
               "column": 6
             },
             "end": {
-              "line": 1330,
+              "line": 1280,
               "column": 7
             }
           },
@@ -14510,11 +11221,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1340,
+              "line": 1290,
               "column": 6
             },
             "end": {
-              "line": 1342,
+              "line": 1292,
               "column": 7
             }
           },
@@ -14539,11 +11250,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1374,
+              "line": 1324,
               "column": 6
             },
             "end": {
-              "line": 1406,
+              "line": 1356,
               "column": 7
             }
           },
@@ -14583,11 +11294,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1429,
+              "line": 1379,
               "column": 6
             },
             "end": {
-              "line": 1437,
+              "line": 1387,
               "column": 7
             }
           },
@@ -14621,11 +11332,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1544,
+              "line": 1494,
               "column": 6
             },
             "end": {
-              "line": 1549,
+              "line": 1499,
               "column": 7
             }
           },
@@ -14649,11 +11360,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1570,
+              "line": 1520,
               "column": 6
             },
             "end": {
-              "line": 1581,
+              "line": 1531,
               "column": 7
             }
           },
@@ -14671,11 +11382,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1595,
+              "line": 1545,
               "column": 6
             },
             "end": {
-              "line": 1608,
+              "line": 1558,
               "column": 7
             }
           },
@@ -14693,11 +11404,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 571,
+              "line": 621,
               "column": 6
             },
             "end": {
-              "line": 580,
+              "line": 630,
               "column": 7
             }
           },
@@ -14715,11 +11426,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1637,
+              "line": 1587,
               "column": 6
             },
             "end": {
-              "line": 1648,
+              "line": 1598,
               "column": 7
             }
           },
@@ -14748,11 +11459,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1735,
+              "line": 1685,
               "column": 6
             },
             "end": {
-              "line": 1745,
+              "line": 1695,
               "column": 7
             }
           },
@@ -14786,11 +11497,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1756,
+              "line": 1706,
               "column": 6
             },
             "end": {
-              "line": 1761,
+              "line": 1711,
               "column": 7
             }
           },
@@ -14819,11 +11530,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1773,
+              "line": 1723,
               "column": 6
             },
             "end": {
-              "line": 1778,
+              "line": 1728,
               "column": 7
             }
           },
@@ -14847,11 +11558,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1810,
+              "line": 1760,
               "column": 6
             },
             "end": {
-              "line": 1814,
+              "line": 1764,
               "column": 7
             }
           },
@@ -14880,11 +11591,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1835,
+              "line": 1785,
               "column": 6
             },
             "end": {
-              "line": 1837,
+              "line": 1787,
               "column": 7
             }
           },
@@ -14914,11 +11625,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1860,
+              "line": 1810,
               "column": 6
             },
             "end": {
-              "line": 1870,
+              "line": 1820,
               "column": 7
             }
           },
@@ -14952,11 +11663,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1886,
+              "line": 1836,
               "column": 6
             },
             "end": {
-              "line": 1895,
+              "line": 1845,
               "column": 7
             }
           },
@@ -14987,11 +11698,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1910,
+              "line": 1860,
               "column": 6
             },
             "end": {
-              "line": 1919,
+              "line": 1869,
               "column": 7
             }
           },
@@ -15016,11 +11727,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1938,
+              "line": 1888,
               "column": 6
             },
             "end": {
-              "line": 1975,
+              "line": 1925,
               "column": 7
             }
           },
@@ -15061,11 +11772,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1990,
+              "line": 1940,
               "column": 6
             },
             "end": {
-              "line": 1999,
+              "line": 1949,
               "column": 7
             }
           },
@@ -15090,11 +11801,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2015,
+              "line": 1965,
               "column": 6
             },
             "end": {
-              "line": 2023,
+              "line": 1973,
               "column": 7
             }
           },
@@ -15125,11 +11836,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2038,
+              "line": 1988,
               "column": 6
             },
             "end": {
-              "line": 2055,
+              "line": 2005,
               "column": 7
             }
           },
@@ -15158,11 +11869,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2068,
+              "line": 2018,
               "column": 6
             },
             "end": {
-              "line": 2075,
+              "line": 2025,
               "column": 7
             }
           },
@@ -15191,11 +11902,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2089,
+              "line": 2039,
               "column": 6
             },
             "end": {
-              "line": 2099,
+              "line": 2049,
               "column": 7
             }
           },
@@ -15229,11 +11940,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2112,
+              "line": 2062,
               "column": 6
             },
             "end": {
-              "line": 2118,
+              "line": 2068,
               "column": 7
             }
           },
@@ -15262,11 +11973,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2129,
+              "line": 2079,
               "column": 6
             },
             "end": {
-              "line": 2137,
+              "line": 2087,
               "column": 7
             }
           },
@@ -15290,11 +12001,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2148,
+              "line": 2098,
               "column": 6
             },
             "end": {
-              "line": 2161,
+              "line": 2111,
               "column": 7
             }
           },
@@ -15318,11 +12029,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2175,
+              "line": 2125,
               "column": 6
             },
             "end": {
-              "line": 2181,
+              "line": 2131,
               "column": 7
             }
           },
@@ -15346,6 +12057,45 @@
           ],
           "return": {
             "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_marshalArgs",
+          "description": "Gather the argument values for a method specified in the provided array\nof argument metadata.\n\nThe `path` and `value` arguments are used to fill in wildcard descriptor\nwhen the method is being called as a result of a path notification.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2146,
+              "column": 6
+            },
+            "end": {
+              "line": 2181,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "args",
+              "type": "!Array.<!MethodArg>",
+              "description": "Array of argument metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path name that triggered the method effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            }
+          ],
+          "return": {
+            "type": "Array.<*>",
+            "desc": "Array of argument values"
           },
           "inheritedFrom": "Polymer.PropertyEffects"
         },
@@ -15418,11 +12168,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 540,
+              "line": 590,
               "column": 6
             },
             "end": {
-              "line": 545,
+              "line": 595,
               "column": 7
             }
           },
@@ -15440,11 +12190,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 216,
+              "line": 226,
               "column": 6
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 7
             }
           },
@@ -15462,11 +12212,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 594,
+              "line": 644,
               "column": 6
             },
             "end": {
-              "line": 610,
+              "line": 660,
               "column": 7
             }
           },
@@ -15491,11 +12241,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 633,
+              "line": 683,
               "column": 6
             },
             "end": {
-              "line": 637,
+              "line": 687,
               "column": 7
             }
           },
@@ -15519,11 +12269,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 654,
+              "line": 704,
               "column": 6
             },
             "end": {
-              "line": 659,
+              "line": 709,
               "column": 7
             }
           },
@@ -15552,11 +12302,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 42,
+              "line": 40,
               "column": 3
             },
             "end": {
-              "line": 50,
+              "line": 48,
               "column": 4
             }
           },
@@ -15575,11 +12325,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 197,
+              "line": 201,
               "column": 6
             },
             "end": {
-              "line": 208,
+              "line": 212,
               "column": 7
             }
           },
@@ -15609,11 +12359,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 670,
+              "line": 720,
               "column": 6
             },
             "end": {
-              "line": 673,
+              "line": 723,
               "column": 7
             }
           },
@@ -15677,11 +12427,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 258,
+              "line": 263,
               "column": 6
             },
             "end": {
-              "line": 295,
+              "line": 303,
               "column": 7
             }
           },
@@ -15715,11 +12465,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2592,
+              "line": 2597,
               "column": 6
             },
             "end": {
-              "line": 2602,
+              "line": 2607,
               "column": 7
             }
           },
@@ -15754,11 +12504,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 333,
+              "line": 341,
               "column": 6
             },
             "end": {
-              "line": 342,
+              "line": 350,
               "column": 7
             }
           },
@@ -15797,7 +12547,7 @@
               "column": 6
             },
             "end": {
-              "line": 2576,
+              "line": 2581,
               "column": 7
             }
           },
@@ -15842,11 +12592,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 388,
+              "line": 396,
               "column": 6
             },
             "end": {
-              "line": 391,
+              "line": 399,
               "column": 7
             }
           },
@@ -15871,11 +12621,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 326,
-              "column": 7
+              "line": 351,
+              "column": 6
             },
             "end": {
-              "line": 330,
+              "line": 355,
               "column": 7
             }
           },
@@ -15926,11 +12676,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 181,
+              "line": 190,
               "column": 6
             },
             "end": {
-              "line": 184,
+              "line": 193,
               "column": 7
             }
           },
@@ -16281,11 +13031,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2648,
+              "line": 2653,
               "column": 6
             },
             "end": {
-              "line": 2713,
+              "line": 2718,
               "column": 7
             }
           },
@@ -16315,11 +13065,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2729,
+              "line": 2734,
               "column": 6
             },
             "end": {
-              "line": 2746,
+              "line": 2751,
               "column": 7
             }
           },
@@ -16369,11 +13119,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 129,
+              "line": 138,
               "column": 6
             },
             "end": {
-              "line": 138,
+              "line": 147,
               "column": 7
             }
           },
@@ -16391,11 +13141,33 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 294,
-              "column": 5
+              "line": 319,
+              "column": 6
             },
             "end": {
-              "line": 317,
+              "line": 326,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_prepareTemplate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 328,
+              "column": 6
+            },
+            "end": {
+              "line": 342,
               "column": 7
             }
           },
@@ -16413,11 +13185,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 343,
+              "line": 368,
               "column": 6
             },
             "end": {
-              "line": 348,
+              "line": 373,
               "column": 7
             }
           },
@@ -16446,11 +13218,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 503,
+              "line": 553,
               "column": 6
             },
             "end": {
-              "line": 505,
+              "line": 555,
               "column": 7
             }
           },
@@ -16480,11 +13252,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 516,
+              "line": 566,
               "column": 6
             },
             "end": {
-              "line": 527,
+              "line": 577,
               "column": 7
             }
           },
@@ -16506,11 +13278,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 26,
+          "line": 24,
           "column": 2
         },
         "end": {
-          "line": 51,
+          "line": 49,
           "column": 3
         }
       },
@@ -16523,11 +13295,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 33,
+              "line": 31,
               "column": 5
             },
             "end": {
-              "line": 36,
+              "line": 34,
               "column": 6
             }
           },
@@ -16556,11 +13328,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -16581,11 +13353,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -16604,11 +13376,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 34,
+              "line": 30,
               "column": 4
             },
             "end": {
-              "line": 37,
+              "line": 33,
               "column": 5
             }
           },
@@ -16628,11 +13400,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 39,
+              "line": 35,
               "column": 4
             },
             "end": {
-              "line": 42,
+              "line": 38,
               "column": 5
             }
           },
@@ -16652,11 +13424,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -16676,11 +13448,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 49,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 50,
               "column": 5
             }
           },
@@ -16699,11 +13471,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 56,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 55,
               "column": 5
             }
           },
@@ -16723,11 +13495,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 61,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -16747,11 +13519,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 69,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 68,
               "column": 5
             }
           },
@@ -16764,6 +13536,98 @@
           "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -16771,11 +13635,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -16795,11 +13659,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -16818,11 +13682,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -16843,11 +13707,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -16867,11 +13731,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -16892,11 +13756,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -16916,11 +13780,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -16941,11 +13805,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -16965,11 +13829,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -16988,11 +13852,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -17012,11 +13876,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -17036,11 +13900,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -17060,11 +13924,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 85,
               "column": 5
             },
             "end": {
-              "line": 93,
+              "line": 88,
               "column": 6
             }
           },
@@ -17082,11 +13946,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 94,
+              "line": 89,
               "column": 5
             },
             "end": {
-              "line": 97,
+              "line": 92,
               "column": 6
             }
           },
@@ -17105,11 +13969,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -17129,11 +13993,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -17153,11 +14017,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -17176,11 +14040,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 99,
+              "line": 94,
               "column": 5
             },
             "end": {
-              "line": 102,
+              "line": 97,
               "column": 6
             }
           },
@@ -17198,11 +14062,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 98,
               "column": 5
             },
             "end": {
-              "line": 106,
+              "line": 101,
               "column": 6
             }
           },
@@ -17221,11 +14085,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -17244,11 +14108,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -17268,11 +14132,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -17282,6 +14146,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -17379,17 +14267,65 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "currency",
           "type": "string | null | undefined",
           "description": "Base Currency used in filters",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 73,
+              "line": 68,
               "column": 6
             }
           },
@@ -17406,11 +14342,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 81,
+              "line": 76,
               "column": 6
             }
           },
@@ -17428,11 +14364,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 87,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 89,
+              "line": 84,
               "column": 6
             }
           },
@@ -17449,11 +14385,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 107,
+              "line": 102,
               "column": 5
             },
             "end": {
-              "line": 110,
+              "line": 105,
               "column": 6
             }
           },
@@ -17468,16 +14404,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 80,
+              "line": 81,
               "column": 3
             }
           },
@@ -17486,7 +14422,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+          "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
           "name": "toNumber",
@@ -17495,11 +14431,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 95,
+              "line": 91,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 3
             }
           },
@@ -17533,11 +14469,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 193,
+              "line": 188,
               "column": 3
             },
             "end": {
-              "line": 195,
+              "line": 190,
               "column": 4
             }
           },
@@ -17550,11 +14486,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 203,
               "column": 3
             },
             "end": {
-              "line": 222,
+              "line": 217,
               "column": 4
             }
           },
@@ -17582,11 +14518,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 197,
+              "line": 192,
               "column": 3
             },
             "end": {
-              "line": 199,
+              "line": 194,
               "column": 4
             }
           },
@@ -17607,11 +14543,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 223,
+              "line": 218,
               "column": 3
             },
             "end": {
-              "line": 232,
+              "line": 227,
               "column": 4
             }
           },
@@ -17632,11 +14568,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 258,
+              "line": 253,
               "column": 3
             },
             "end": {
-              "line": 265,
+              "line": 260,
               "column": 4
             }
           },
@@ -17660,11 +14596,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 158,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 157,
               "column": 3
             }
           },
@@ -17687,11 +14623,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 169,
+              "line": 165,
               "column": 2
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 3
             }
           },
@@ -17716,11 +14652,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 2
             },
             "end": {
-              "line": 204,
+              "line": 200,
               "column": 3
             }
           },
@@ -17748,11 +14684,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -17767,11 +14703,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -17793,11 +14729,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 232,
+              "line": 228,
               "column": 2
             },
             "end": {
-              "line": 249,
+              "line": 245,
               "column": 3
             }
           },
@@ -17816,11 +14752,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 251,
+              "line": 247,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 252,
               "column": 3
             }
           },
@@ -17841,11 +14777,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 304,
+              "line": 299,
               "column": 3
             },
             "end": {
-              "line": 313,
+              "line": 308,
               "column": 4
             }
           },
@@ -17865,11 +14801,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 283,
+              "line": 278,
               "column": 3
             },
             "end": {
-              "line": 289,
+              "line": 284,
               "column": 4
             }
           },
@@ -17887,11 +14823,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -17906,11 +14842,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 283,
+              "line": 279,
               "column": 2
             },
             "end": {
-              "line": 293,
+              "line": 289,
               "column": 3
             }
           },
@@ -17934,11 +14870,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 299,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 321,
               "column": 3
             }
           },
@@ -17956,11 +14892,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 327,
+              "line": 323,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 336,
               "column": 3
             }
           },
@@ -17978,11 +14914,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 342,
+              "line": 338,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 358,
               "column": 3
             }
           },
@@ -18004,11 +14940,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -18033,11 +14969,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -18057,11 +14993,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -18079,11 +15015,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 315,
+              "line": 310,
               "column": 3
             },
             "end": {
-              "line": 320,
+              "line": 315,
               "column": 4
             }
           },
@@ -18100,11 +15036,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 322,
+              "line": 317,
               "column": 3
             },
             "end": {
-              "line": 334,
+              "line": 329,
               "column": 4
             }
           },
@@ -18116,324 +15052,71 @@
           ]
         },
         {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -18446,11 +15129,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -18466,17 +15149,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -18495,11 +15223,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -18527,11 +15255,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -18553,11 +15281,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -18588,11 +15316,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -18610,11 +15338,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -18636,11 +15364,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -18658,11 +15386,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -18680,11 +15408,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -18702,11 +15430,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -18724,11 +15452,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -18745,11 +15473,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 116,
               "column": 3
             },
             "end": {
-              "line": 146,
+              "line": 141,
               "column": 4
             }
           },
@@ -18781,11 +15509,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 151,
               "column": 3
             },
             "end": {
-              "line": 191,
+              "line": 186,
               "column": 4
             }
           },
@@ -18818,11 +15546,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 234,
+              "line": 229,
               "column": 3
             },
             "end": {
-              "line": 237,
+              "line": 232,
               "column": 4
             }
           },
@@ -18842,11 +15570,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 239,
+              "line": 234,
               "column": 3
             },
             "end": {
-              "line": 250,
+              "line": 245,
               "column": 4
             }
           },
@@ -18866,11 +15594,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 267,
+              "line": 262,
               "column": 3
             },
             "end": {
-              "line": 281,
+              "line": 276,
               "column": 4
             }
           },
@@ -18890,11 +15618,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 291,
+              "line": 286,
               "column": 3
             },
             "end": {
-              "line": 302,
+              "line": 297,
               "column": 4
             }
           },
@@ -18911,11 +15639,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 53,
+          "line": 50,
           "column": 2
         },
         "end": {
-          "line": 335,
+          "line": 330,
           "column": 3
         }
       },
@@ -18929,11 +15657,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -18947,11 +15675,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -18965,11 +15693,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 34,
+              "line": 30,
               "column": 4
             },
             "end": {
-              "line": 37,
+              "line": 33,
               "column": 5
             }
           },
@@ -18983,11 +15711,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 39,
+              "line": 35,
               "column": 4
             },
             "end": {
-              "line": 42,
+              "line": 38,
               "column": 5
             }
           },
@@ -19001,11 +15729,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -19019,11 +15747,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -19037,11 +15765,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -19055,11 +15783,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -19073,11 +15801,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -19091,11 +15819,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -19109,11 +15837,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -19127,11 +15855,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -19145,11 +15873,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -19163,11 +15891,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -19181,11 +15909,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -19199,11 +15927,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -19217,11 +15945,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -19234,11 +15962,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 85,
               "column": 5
             },
             "end": {
-              "line": 93,
+              "line": 88,
               "column": 6
             }
           },
@@ -19247,6 +15975,76 @@
         },
         {
           "name": "edit-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 5
+            },
+            "end": {
+              "line": 92,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
+          "name": "min-width",
+          "description": "The minimum width of this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 135,
+              "column": 4
+            },
+            "end": {
+              "line": 138,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "edit-min-width",
+          "description": "The minimum width of this column in edit mode.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 143,
+              "column": 4
+            },
+            "end": {
+              "line": 146,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "flex",
+          "description": "Width growing factor for this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 151,
+              "column": 4
+            },
+            "end": {
+              "line": 154,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-class",
           "description": "",
           "sourceRange": {
             "start": {
@@ -19262,85 +16060,15 @@
           "type": "string | null | undefined"
         },
         {
-          "name": "min-width",
-          "description": "The minimum width of this column.",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 139,
-              "column": 4
-            },
-            "end": {
-              "line": 142,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "edit-min-width",
-          "description": "The minimum width of this column in edit mode.",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 147,
-              "column": 4
-            },
-            "end": {
-              "line": 150,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "flex",
-          "description": "Width growing factor for this column.",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 155,
-              "column": 4
-            },
-            "end": {
-              "line": 158,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-class",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 99,
-              "column": 5
-            },
-            "end": {
-              "line": 102,
-              "column": 6
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
           "name": "header-cell-class",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 98,
               "column": 5
             },
             "end": {
-              "line": 106,
+              "line": 101,
               "column": 6
             }
           },
@@ -19353,11 +16081,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -19371,11 +16099,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -19389,16 +16117,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -19478,11 +16224,11 @@
           "description": "Base Currency used in filters",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 73,
+              "line": 68,
               "column": 6
             }
           },
@@ -19494,11 +16240,11 @@
           "description": "If this is set true then currency property will be the currency with highest occurrence in values",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 81,
+              "line": 76,
               "column": 6
             }
           },
@@ -19510,11 +16256,11 @@
           "description": "Exchange rates of currencies. Example: {\"EUR\": 1, \"USD\":0.8169982616, \"AUD\":0.6529827192, \"SEK\": 0.1019271438}'\nDefault exchange rate is 1 and it is used for every currency that is present on column values but missing from exchange rates object.",
           "sourceRange": {
             "start": {
-              "line": 87,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 89,
+              "line": 84,
               "column": 6
             }
           },
@@ -19540,6 +16286,98 @@
       "path": "cosmoz-omnitable-column-autocomplete.html",
       "properties": [
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -19547,11 +16385,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -19571,11 +16409,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -19594,11 +16432,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -19619,11 +16457,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -19643,11 +16481,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -19667,11 +16505,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 55,
+              "line": 53,
               "column": 5
             },
             "end": {
-              "line": 61,
+              "line": 59,
               "column": 6
             }
           },
@@ -19690,11 +16528,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -19715,11 +16553,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -19738,11 +16576,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 47,
               "column": 5
             },
             "end": {
-              "line": 53,
+              "line": 51,
               "column": 6
             }
           },
@@ -19762,11 +16600,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -19785,11 +16623,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -19808,11 +16646,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -19832,11 +16670,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -19856,11 +16694,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -19881,11 +16719,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -19905,11 +16743,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -19928,11 +16766,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 83,
+              "line": 81,
               "column": 5
             },
             "end": {
-              "line": 86,
+              "line": 84,
               "column": 6
             }
           },
@@ -19950,11 +16788,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 88,
+              "line": 86,
               "column": 5
             },
             "end": {
-              "line": 91,
+              "line": 89,
               "column": 6
             }
           },
@@ -19973,11 +16811,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -19997,11 +16835,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -20020,11 +16858,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 76,
               "column": 5
             },
             "end": {
-              "line": 81,
+              "line": 79,
               "column": 6
             }
           },
@@ -20043,11 +16881,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -20066,11 +16904,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -20090,11 +16928,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -20104,6 +16942,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -20201,17 +17063,65 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "query",
           "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 61,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 64,
               "column": 6
             }
           },
@@ -20229,11 +17139,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 71,
+              "line": 69,
               "column": 6
             }
           },
@@ -20251,11 +17161,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 76,
+              "line": 74,
               "column": 6
             }
           },
@@ -20269,346 +17179,71 @@
       ],
       "methods": [
         {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 77,
-              "column": 2
-            },
-            "end": {
-              "line": 80,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -20621,11 +17256,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -20641,17 +17276,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -20669,11 +17349,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 99,
+              "line": 97,
               "column": 3
             },
             "end": {
-              "line": 113,
+              "line": 111,
               "column": 4
             }
           },
@@ -20694,11 +17374,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 115,
+              "line": 113,
               "column": 3
             },
             "end": {
-              "line": 120,
+              "line": 118,
               "column": 4
             }
           },
@@ -20720,11 +17400,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -20751,11 +17431,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 95,
+              "line": 93,
               "column": 3
             },
             "end": {
-              "line": 97,
+              "line": 95,
               "column": 4
             }
           },
@@ -20777,11 +17457,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -20803,11 +17483,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -20838,11 +17518,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -20857,11 +17537,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -20879,11 +17559,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -20907,11 +17587,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 176,
+              "line": 174,
               "column": 3
             },
             "end": {
-              "line": 178,
+              "line": 176,
               "column": 4
             }
           },
@@ -20924,11 +17604,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 120,
               "column": 3
             },
             "end": {
-              "line": 125,
+              "line": 123,
               "column": 4
             }
           },
@@ -20948,11 +17628,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 127,
+              "line": 125,
               "column": 3
             },
             "end": {
-              "line": 154,
+              "line": 152,
               "column": 4
             }
           },
@@ -20973,11 +17653,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -20995,11 +17675,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -21017,11 +17697,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -21039,11 +17719,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -21061,11 +17741,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -21083,11 +17763,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -21107,11 +17787,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -21129,11 +17809,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 154,
               "column": 3
             },
             "end": {
-              "line": 174,
+              "line": 172,
               "column": 4
             }
           },
@@ -21153,11 +17833,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 40,
+          "line": 38,
           "column": 2
         },
         "end": {
-          "line": 179,
+          "line": 177,
           "column": 3
         }
       },
@@ -21171,11 +17851,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -21189,11 +17869,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -21207,11 +17887,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -21225,11 +17905,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -21243,11 +17923,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -21260,11 +17940,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 55,
+              "line": 53,
               "column": 5
             },
             "end": {
-              "line": 61,
+              "line": 59,
               "column": 6
             }
           },
@@ -21277,11 +17957,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -21295,11 +17975,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -21312,11 +17992,11 @@
           "description": "Ask for a list of values",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 47,
               "column": 5
             },
             "end": {
-              "line": 53,
+              "line": 51,
               "column": 6
             }
           },
@@ -21329,11 +18009,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -21347,11 +18027,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -21365,11 +18045,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -21383,11 +18063,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -21401,11 +18081,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -21419,11 +18099,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -21437,11 +18117,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -21454,11 +18134,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 83,
+              "line": 81,
               "column": 5
             },
             "end": {
-              "line": 86,
+              "line": 84,
               "column": 6
             }
           },
@@ -21470,11 +18150,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 88,
+              "line": 86,
               "column": 5
             },
             "end": {
-              "line": 91,
+              "line": 89,
               "column": 6
             }
           },
@@ -21487,11 +18167,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -21505,11 +18185,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -21522,11 +18202,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 76,
               "column": 5
             },
             "end": {
-              "line": 81,
+              "line": 79,
               "column": 6
             }
           },
@@ -21539,11 +18219,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -21557,11 +18237,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -21575,16 +18255,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -21664,11 +18362,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 61,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 64,
               "column": 6
             }
           },
@@ -21680,11 +18378,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 71,
+              "line": 69,
               "column": 6
             }
           },
@@ -21696,11 +18394,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 76,
+              "line": 74,
               "column": 6
             }
           },
@@ -21738,6 +18436,98 @@
       "path": "cosmoz-omnitable-column-boolean.html",
       "properties": [
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -21745,11 +18535,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -21769,11 +18559,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -21792,11 +18582,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -21817,11 +18607,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -21841,11 +18631,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -21865,11 +18655,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 50,
               "column": 5
             },
             "end": {
-              "line": 58,
+              "line": 56,
               "column": 6
             }
           },
@@ -21888,11 +18678,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -21913,11 +18703,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -21937,11 +18727,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -21962,11 +18752,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -21985,11 +18775,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -22008,11 +18798,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -22032,11 +18822,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -22056,11 +18846,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -22081,11 +18871,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -22105,11 +18895,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -22129,11 +18919,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -22153,11 +18943,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -22176,11 +18966,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 84,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 87,
+              "line": 85,
               "column": 6
             }
           },
@@ -22199,11 +18989,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -22223,11 +19013,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -22247,11 +19037,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -22270,11 +19060,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -22294,11 +19084,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -22308,6 +19098,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -22405,17 +19219,65 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "trueLabel",
           "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 58,
               "column": 5
             },
             "end": {
-              "line": 63,
+              "line": 61,
               "column": 6
             }
           },
@@ -22433,11 +19295,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 66,
               "column": 6
             }
           },
@@ -22455,11 +19317,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 68,
               "column": 5
             },
             "end": {
-              "line": 73,
+              "line": 71,
               "column": 6
             }
           },
@@ -22477,11 +19339,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 78,
+              "line": 76,
               "column": 6
             }
           },
@@ -22495,346 +19357,71 @@
       ],
       "methods": [
         {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 77,
-              "column": 2
-            },
-            "end": {
-              "line": 80,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -22847,11 +19434,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -22867,17 +19454,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -22895,11 +19527,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 119,
               "column": 3
             },
             "end": {
-              "line": 124,
+              "line": 122,
               "column": 4
             }
           },
@@ -22919,11 +19551,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 173,
+              "line": 171,
               "column": 3
             },
             "end": {
-              "line": 178,
+              "line": 176,
               "column": 4
             }
           },
@@ -22945,11 +19577,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -22977,11 +19609,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 285,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 287,
+              "line": 360,
               "column": 3
             }
           },
@@ -23002,11 +19634,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 147,
+              "line": 145,
               "column": 3
             },
             "end": {
-              "line": 159,
+              "line": 157,
               "column": 4
             }
           },
@@ -23027,11 +19659,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -23061,11 +19693,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 126,
+              "line": 124,
               "column": 3
             },
             "end": {
-              "line": 130,
+              "line": 128,
               "column": 4
             }
           },
@@ -23079,11 +19711,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -23101,11 +19733,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -23130,11 +19762,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -23148,11 +19780,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 130,
               "column": 3
             },
             "end": {
-              "line": 134,
+              "line": 132,
               "column": 4
             }
           },
@@ -23170,11 +19802,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -23196,11 +19828,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -23218,11 +19850,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -23240,11 +19872,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -23262,11 +19894,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -23284,11 +19916,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -23305,11 +19937,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 161,
+              "line": 159,
               "column": 3
             },
             "end": {
-              "line": 166,
+              "line": 164,
               "column": 4
             }
           },
@@ -23327,11 +19959,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 168,
+              "line": 166,
               "column": 3
             },
             "end": {
-              "line": 171,
+              "line": 169,
               "column": 4
             }
           },
@@ -23348,11 +19980,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 99,
+              "line": 97,
               "column": 3
             },
             "end": {
-              "line": 110,
+              "line": 108,
               "column": 4
             }
           },
@@ -23372,11 +20004,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 112,
+              "line": 110,
               "column": 3
             },
             "end": {
-              "line": 119,
+              "line": 117,
               "column": 4
             }
           },
@@ -23396,11 +20028,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 136,
+              "line": 134,
               "column": 3
             },
             "end": {
-              "line": 141,
+              "line": 139,
               "column": 4
             }
           },
@@ -23420,11 +20052,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 45,
+          "line": 43,
           "column": 2
         },
         "end": {
-          "line": 179,
+          "line": 177,
           "column": 3
         }
       },
@@ -23438,11 +20070,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -23456,11 +20088,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -23474,11 +20106,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -23492,11 +20124,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -23510,11 +20142,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -23527,11 +20159,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 50,
               "column": 5
             },
             "end": {
-              "line": 58,
+              "line": 56,
               "column": 6
             }
           },
@@ -23544,11 +20176,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -23562,11 +20194,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -23580,11 +20212,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -23598,11 +20230,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -23616,11 +20248,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -23634,11 +20266,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -23652,11 +20284,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -23670,11 +20302,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -23688,11 +20320,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -23706,11 +20338,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -23724,11 +20356,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -23742,11 +20374,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -23759,11 +20391,11 @@
           "description": "No need to grow, as the values in a boolean column should have known fixed width",
           "sourceRange": {
             "start": {
-              "line": 84,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 87,
+              "line": 85,
               "column": 6
             }
           },
@@ -23776,11 +20408,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -23794,11 +20426,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -23812,11 +20444,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -23830,11 +20462,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -23848,16 +20480,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -23937,11 +20587,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 58,
               "column": 5
             },
             "end": {
-              "line": 63,
+              "line": 61,
               "column": 6
             }
           },
@@ -23953,11 +20603,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 66,
               "column": 6
             }
           },
@@ -23969,11 +20619,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 78,
+              "line": 76,
               "column": 6
             }
           },
@@ -24012,11 +20662,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -24037,11 +20687,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -24060,12 +20710,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {
@@ -24084,12 +20734,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {
@@ -24108,11 +20758,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -24132,11 +20782,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 49,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 50,
               "column": 5
             }
           },
@@ -24155,11 +20805,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 56,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 55,
               "column": 5
             }
           },
@@ -24179,11 +20829,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 61,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -24203,11 +20853,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 69,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 68,
               "column": 5
             }
           },
@@ -24227,12 +20877,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 48,
-              "column": 5
+              "line": 30,
+              "column": 4
             },
             "end": {
-              "line": 51,
-              "column": 6
+              "line": 33,
+              "column": 5
             }
           },
           "metadata": {
@@ -24251,11 +20901,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -24275,11 +20925,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -24299,11 +20949,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -24323,12 +20973,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {
@@ -24340,6 +20990,98 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -24347,11 +21089,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -24371,11 +21113,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -24394,11 +21136,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -24419,11 +21161,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -24443,11 +21185,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -24468,11 +21210,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -24492,11 +21234,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -24517,11 +21259,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -24541,11 +21283,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -24564,11 +21306,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -24588,11 +21330,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -24612,11 +21354,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -24636,11 +21378,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 61,
               "column": 5
             },
             "end": {
-              "line": 71,
+              "line": 64,
               "column": 6
             }
           },
@@ -24658,11 +21400,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 65,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 68,
               "column": 6
             }
           },
@@ -24681,11 +21423,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -24704,11 +21446,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 57,
               "column": 5
             },
             "end": {
-              "line": 67,
+              "line": 60,
               "column": 6
             }
           },
@@ -24727,11 +21469,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -24750,11 +21492,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -24774,11 +21516,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -24788,6 +21530,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -24883,21 +21649,69 @@
             }
           },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         }
       ],
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 80,
+              "line": 81,
               "column": 3
             }
           },
@@ -24906,7 +21720,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+          "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
           "name": "toNumber",
@@ -24915,11 +21729,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 95,
+              "line": 91,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 3
             }
           },
@@ -24954,12 +21768,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 121,
-              "column": 3
+              "line": 89,
+              "column": 2
             },
             "end": {
-              "line": 123,
-              "column": 4
+              "line": 91,
+              "column": 3
             }
           },
           "metadata": {},
@@ -24973,11 +21787,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 285,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 287,
+              "line": 360,
               "column": 3
             }
           },
@@ -24998,11 +21812,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 86,
               "column": 3
             },
             "end": {
-              "line": 104,
+              "line": 97,
               "column": 4
             }
           },
@@ -25024,11 +21838,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 257,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 263,
+              "line": 336,
               "column": 3
             }
           },
@@ -25051,12 +21865,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 184,
-              "column": 3
+              "line": 127,
+              "column": 2
             },
             "end": {
-              "line": 193,
-              "column": 4
+              "line": 136,
+              "column": 3
             }
           },
           "metadata": {},
@@ -25078,11 +21892,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 158,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 157,
               "column": 3
             }
           },
@@ -25105,11 +21919,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 169,
+              "line": 165,
               "column": 2
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 3
             }
           },
@@ -25134,11 +21948,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 2
             },
             "end": {
-              "line": 204,
+              "line": 200,
               "column": 3
             }
           },
@@ -25166,11 +21980,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -25185,11 +21999,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -25211,11 +22025,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 232,
+              "line": 228,
               "column": 2
             },
             "end": {
-              "line": 249,
+              "line": 245,
               "column": 3
             }
           },
@@ -25234,11 +22048,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 251,
+              "line": 247,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 252,
               "column": 3
             }
           },
@@ -25259,11 +22073,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 72,
               "column": 3
             },
             "end": {
-              "line": 91,
+              "line": 84,
               "column": 4
             }
           },
@@ -25284,12 +22098,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 199,
-              "column": 3
+              "line": 142,
+              "column": 2
             },
             "end": {
-              "line": 205,
-              "column": 4
+              "line": 148,
+              "column": 3
             }
           },
           "metadata": {},
@@ -25307,11 +22121,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -25325,11 +22139,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 106,
+              "line": 99,
               "column": 3
             },
             "end": {
-              "line": 116,
+              "line": 109,
               "column": 4
             }
           },
@@ -25350,11 +22164,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 299,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 321,
               "column": 3
             }
           },
@@ -25372,11 +22186,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 327,
+              "line": 323,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 336,
               "column": 3
             }
           },
@@ -25394,11 +22208,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 342,
+              "line": 338,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 358,
               "column": 3
             }
           },
@@ -25420,11 +22234,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -25449,11 +22263,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -25473,11 +22287,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -25496,11 +22310,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 402,
+              "line": 398,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 404,
               "column": 3
             }
           },
@@ -25519,11 +22333,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 410,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 412,
+              "line": 408,
               "column": 3
             }
           },
@@ -25545,12 +22359,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 86,
-              "column": 3
+              "line": 68,
+              "column": 2
             },
             "end": {
-              "line": 119,
-              "column": 4
+              "line": 87,
+              "column": 3
             }
           },
           "metadata": {},
@@ -25578,76 +22392,18 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "getAbsoluteISOString",
-          "description": "Computes the local timezone and adds it to a local ISO string",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-mixin.html",
-            "start": {
-              "line": 164,
-              "column": 3
-            },
-            "end": {
-              "line": 172,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string, without timezone info"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "an ISO date string, with timezone info"
-          },
-          "inheritedFrom": "Cosmoz.DateColumnMixin"
-        },
-        {
-          "name": "_getTimezoneString",
-          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-mixin.html",
-            "start": {
-              "line": 179,
-              "column": 3
-            },
-            "end": {
-              "line": 182,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "the ISO timezone"
-          },
-          "inheritedFrom": "Cosmoz.DateColumnMixin"
-        },
-        {
           "name": "_computeFormatter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 195,
-              "column": 3
+              "line": 138,
+              "column": 2
             },
             "end": {
-              "line": 197,
-              "column": 4
+              "line": 140,
+              "column": 3
             }
           },
           "metadata": {},
@@ -25665,12 +22421,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 207,
-              "column": 3
+              "line": 150,
+              "column": 2
             },
             "end": {
-              "line": 218,
-              "column": 4
+              "line": 161,
+              "column": 3
             }
           },
           "metadata": {},
@@ -25691,12 +22447,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 220,
-              "column": 3
+              "line": 163,
+              "column": 2
             },
             "end": {
-              "line": 222,
-              "column": 4
+              "line": 175,
+              "column": 3
             }
           },
           "metadata": {},
@@ -25708,324 +22464,71 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -26038,11 +22541,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -26058,17 +22561,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -26087,11 +22635,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -26119,11 +22667,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -26145,11 +22693,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -26180,11 +22728,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -26202,11 +22750,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -26228,11 +22776,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -26250,11 +22798,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -26272,11 +22820,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -26294,11 +22842,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -26316,11 +22864,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -26337,11 +22885,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 55,
+          "line": 48,
           "column": 2
         },
         "end": {
-          "line": 117,
+          "line": 110,
           "column": 3
         }
       },
@@ -26355,11 +22903,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -26373,11 +22921,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -26391,12 +22939,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {},
@@ -26409,12 +22957,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {},
@@ -26427,11 +22975,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -26445,11 +22993,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -26463,11 +23011,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -26481,11 +23029,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -26499,12 +23047,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {},
@@ -26517,11 +23065,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -26535,11 +23083,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -26553,11 +23101,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -26571,11 +23119,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -26589,11 +23137,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -26607,11 +23155,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -26625,11 +23173,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -26643,11 +23191,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -26661,11 +23209,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -26679,11 +23227,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -26697,11 +23245,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -26715,11 +23263,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -26732,11 +23280,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 61,
               "column": 5
             },
             "end": {
-              "line": 71,
+              "line": 64,
               "column": 6
             }
           },
@@ -26748,11 +23296,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 65,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 68,
               "column": 6
             }
           },
@@ -26765,11 +23313,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -26782,11 +23330,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 57,
               "column": 5
             },
             "end": {
-              "line": 67,
+              "line": 60,
               "column": 6
             }
           },
@@ -26799,11 +23347,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -26817,11 +23365,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -26835,16 +23383,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -27001,6 +23567,27 @@
               "attributeType": "Number"
             }
           }
+        },
+        {
+          "name": "t",
+          "type": "Object | null | undefined",
+          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 74,
+              "column": 5
+            },
+            "end": {
+              "line": 79,
+              "column": 6
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          }
         }
       ],
       "methods": [
@@ -27010,11 +23597,28 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 83,
               "column": 3
             },
             "end": {
-              "line": 78,
+              "line": 86,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 88,
+              "column": 3
+            },
+            "end": {
+              "line": 91,
               "column": 4
             }
           },
@@ -27027,11 +23631,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 93,
               "column": 3
             },
             "end": {
-              "line": 84,
+              "line": 97,
               "column": 4
             }
           },
@@ -27048,11 +23652,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 99,
               "column": 3
             },
             "end": {
-              "line": 91,
+              "line": 104,
               "column": 4
             }
           },
@@ -27072,11 +23676,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 106,
               "column": 3
             },
             "end": {
-              "line": 98,
+              "line": 111,
               "column": 4
             }
           },
@@ -27096,11 +23700,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 113,
               "column": 3
             },
             "end": {
-              "line": 106,
+              "line": 119,
               "column": 4
             }
           },
@@ -27120,11 +23724,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 108,
+              "line": 121,
               "column": 3
             },
             "end": {
-              "line": 112,
+              "line": 125,
               "column": 4
             }
           },
@@ -27141,11 +23745,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 127,
               "column": 3
             },
             "end": {
-              "line": 119,
+              "line": 132,
               "column": 4
             }
           },
@@ -27165,11 +23769,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 50,
+          "line": 46,
           "column": 2
         },
         "end": {
-          "line": 120,
+          "line": 133,
           "column": 3
         }
       },
@@ -27192,6 +23796,22 @@
           },
           "metadata": {},
           "type": "Array | null | undefined"
+        },
+        {
+          "name": "t",
+          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
+          "sourceRange": {
+            "start": {
+              "line": 74,
+              "column": 5
+            },
+            "end": {
+              "line": 79,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined"
         }
       ],
       "events": [],
@@ -27208,48 +23828,96 @@
       "path": "cosmoz-omnitable-column-list.html",
       "properties": [
         {
-          "name": "textProperty",
-          "type": "string | null | undefined",
+          "name": "editableTemplatizer",
+          "type": "?",
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 77,
-              "column": 5
+              "line": 293,
+              "column": 2
             },
             "end": {
-              "line": 80,
-              "column": 6
+              "line": 296,
+              "column": 3
             }
           },
           "metadata": {
             "polymer": {
-              "attributeType": "String"
+              "readOnly": true
             }
           },
-          "defaultValue": "\"\""
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "valueProperty",
-          "type": "string | null | undefined",
+          "name": "cellTemplatizer",
+          "type": "?",
           "description": "",
           "privacy": "public",
           "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 82,
-              "column": 5
+              "line": 297,
+              "column": 2
             },
             "end": {
-              "line": 85,
-              "column": 6
+              "line": 300,
+              "column": 3
             }
           },
           "metadata": {
             "polymer": {
-              "attributeType": "String"
+              "readOnly": true
             }
           },
-          "defaultValue": "\"\""
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
           "name": "title",
@@ -27259,11 +23927,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -27283,11 +23951,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -27306,11 +23974,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -27331,11 +23999,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -27355,11 +24023,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -27379,11 +24047,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 72,
               "column": 6
             }
           },
@@ -27402,11 +24070,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -27427,11 +24095,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -27450,11 +24118,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 60,
               "column": 5
             },
             "end": {
-              "line": 67,
+              "line": 64,
               "column": 6
             }
           },
@@ -27474,11 +24142,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -27497,11 +24165,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -27520,11 +24188,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -27544,11 +24212,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -27568,11 +24236,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -27593,11 +24261,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -27617,11 +24285,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -27641,11 +24309,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -27665,11 +24333,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -27689,11 +24357,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -27713,11 +24381,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -27737,11 +24405,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -27761,11 +24429,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -27784,11 +24452,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -27808,11 +24476,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -27822,6 +24490,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -27919,17 +24611,109 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "textProperty",
+          "type": "string | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 74,
+              "column": 5
+            },
+            "end": {
+              "line": 77,
+              "column": 6
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "String"
+            }
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "valueProperty",
+          "type": "string | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5
+            },
+            "end": {
+              "line": 82,
+              "column": 6
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "String"
+            }
+          },
+          "defaultValue": "\"\""
+        },
+        {
           "name": "autocompleteItems",
           "type": "Array | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 54,
+              "line": 51,
               "column": 5
             },
             "end": {
-              "line": 58,
+              "line": 55,
               "column": 6
             }
           },
@@ -27944,400 +24728,71 @@
       ],
       "methods": [
         {
-          "name": "getString",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 257,
-              "column": 2
-            },
-            "end": {
-              "line": 263,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath",
-              "defaultValue": "this.valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "toXlsxValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 264,
-              "column": 2
-            },
-            "end": {
-              "line": 269,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath",
-              "defaultValue": "this.valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 77,
-              "column": 2
-            },
-            "end": {
-              "line": 80,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -28350,11 +24805,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -28370,17 +24825,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -28393,17 +24893,71 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getString",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "start": {
+              "line": 22,
+              "column": 2
+            },
+            "end": {
+              "line": 33,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath",
+              "defaultValue": "this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
+        },
+        {
+          "name": "toXlsxValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 337,
+              "column": 2
+            },
+            "end": {
+              "line": 342,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath",
+              "defaultValue": "this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_pathsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -28431,11 +24985,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 285,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 287,
+              "line": 360,
               "column": 3
             }
           },
@@ -28457,11 +25011,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -28483,11 +25037,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -28518,11 +25072,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -28537,11 +25091,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -28559,11 +25113,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -28587,11 +25141,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 139,
+              "line": 136,
               "column": 3
             },
             "end": {
-              "line": 141,
+              "line": 138,
               "column": 4
             }
           },
@@ -28605,11 +25159,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -28630,11 +25184,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 119,
               "column": 3
             },
             "end": {
-              "line": 137,
+              "line": 134,
               "column": 4
             }
           },
@@ -28655,11 +25209,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -28677,11 +25231,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -28699,11 +25253,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -28721,11 +25275,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -28743,11 +25297,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -28765,11 +25319,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -28789,11 +25343,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -28811,11 +25365,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 89,
+              "line": 86,
               "column": 3
             },
             "end": {
-              "line": 95,
+              "line": 92,
               "column": 4
             }
           },
@@ -28838,11 +25392,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 97,
+              "line": 94,
               "column": 3
             },
             "end": {
-              "line": 120,
+              "line": 117,
               "column": 4
             }
           },
@@ -28859,11 +25413,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 44,
+          "line": 38,
           "column": 2
         },
         "end": {
-          "line": 142,
+          "line": 139,
           "column": 3
         }
       },
@@ -28872,48 +25426,16 @@
       "name": "OmnitableColumnList",
       "attributes": [
         {
-          "name": "text-property",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 77,
-              "column": 5
-            },
-            "end": {
-              "line": 80,
-              "column": 6
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
-          "name": "value-property",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 82,
-              "column": 5
-            },
-            "end": {
-              "line": 85,
-              "column": 6
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
           "name": "title",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -28927,11 +25449,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -28945,11 +25467,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -28963,11 +25485,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -28981,11 +25503,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -28998,11 +25520,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 72,
               "column": 6
             }
           },
@@ -29015,11 +25537,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -29033,11 +25555,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -29050,11 +25572,11 @@
           "description": "Ask for a list of values",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 60,
               "column": 5
             },
             "end": {
-              "line": 67,
+              "line": 64,
               "column": 6
             }
           },
@@ -29067,11 +25589,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -29085,11 +25607,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -29103,11 +25625,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -29121,11 +25643,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -29139,11 +25661,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -29157,11 +25679,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -29175,11 +25697,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -29193,11 +25715,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -29211,11 +25733,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -29229,11 +25751,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -29247,11 +25769,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -29265,11 +25787,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -29283,11 +25805,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -29301,11 +25823,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -29319,16 +25841,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -29404,15 +25944,47 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "text-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 74,
+              "column": 5
+            },
+            "end": {
+              "line": 77,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
+          "name": "value-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5
+            },
+            "end": {
+              "line": 82,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
           "name": "autocomplete-items",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 54,
+              "line": 51,
               "column": 5
             },
             "end": {
-              "line": 58,
+              "line": 55,
               "column": 6
             }
           },
@@ -29441,8 +26013,8 @@
       "slots": [],
       "tagname": "cosmoz-omnitable-column-list",
       "mixins": [
-        "Cosmoz.ListColumnMixin",
-        "Cosmoz.OmnitableColumnMixin"
+        "Cosmoz.OmnitableColumnMixin",
+        "Cosmoz.ListColumnMixin"
       ]
     },
     {
@@ -29451,52 +26023,96 @@
       "path": "cosmoz-omnitable-column-list-horizontal.html",
       "properties": [
         {
-          "name": "textProperty",
-          "type": "string | null | undefined",
+          "name": "editableTemplatizer",
+          "type": "?",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 13,
-              "column": 4
+              "line": 293,
+              "column": 2
             },
             "end": {
-              "line": 16,
-              "column": 5
+              "line": 296,
+              "column": 3
             }
           },
           "metadata": {
             "polymer": {
-              "attributeType": "String"
+              "readOnly": true
             }
           },
-          "defaultValue": "\"label\"",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "valueProperty",
-          "type": "string | null | undefined",
+          "name": "cellTemplatizer",
+          "type": "?",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 18,
-              "column": 4
+              "line": 297,
+              "column": 2
             },
             "end": {
-              "line": 21,
-              "column": 5
+              "line": 300,
+              "column": 3
             }
           },
           "metadata": {
             "polymer": {
-              "attributeType": "String"
+              "readOnly": true
             }
           },
-          "defaultValue": "\"value\"",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
           "name": "title",
@@ -29506,11 +26122,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -29530,11 +26146,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -29553,11 +26169,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -29578,11 +26194,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -29602,11 +26218,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -29626,11 +26242,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 77,
               "column": 5
             },
             "end": {
-              "line": 92,
+              "line": 83,
               "column": 6
             }
           },
@@ -29649,11 +26265,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -29674,11 +26290,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -29697,11 +26313,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 84,
+              "line": 75,
               "column": 6
             }
           },
@@ -29721,11 +26337,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -29744,11 +26360,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -29767,11 +26383,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -29791,11 +26407,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -29815,11 +26431,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -29840,11 +26456,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -29864,11 +26480,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -29888,11 +26504,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -29912,11 +26528,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -29936,11 +26552,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -29960,11 +26576,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -29984,11 +26600,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -30008,11 +26624,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -30031,11 +26647,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -30055,11 +26671,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -30069,6 +26685,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -30166,17 +26806,113 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "textProperty",
+          "type": "string | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "start": {
+              "line": 10,
+              "column": 4
+            },
+            "end": {
+              "line": 13,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "String"
+            }
+          },
+          "defaultValue": "\"label\"",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
+        },
+        {
+          "name": "valueProperty",
+          "type": "string | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "start": {
+              "line": 15,
+              "column": 4
+            },
+            "end": {
+              "line": 18,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "String"
+            }
+          },
+          "defaultValue": "\"value\"",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
+        },
+        {
           "name": "autocompleteSelectedItems",
           "type": "Array | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 64,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 66,
               "column": 6
             }
           },
@@ -30189,400 +26925,71 @@
       ],
       "methods": [
         {
-          "name": "getString",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 257,
-              "column": 2
-            },
-            "end": {
-              "line": 263,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath",
-              "defaultValue": "this.valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "toXlsxValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 264,
-              "column": 2
-            },
-            "end": {
-              "line": 269,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath",
-              "defaultValue": "this.valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 77,
-              "column": 2
-            },
-            "end": {
-              "line": 80,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -30595,11 +27002,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -30615,17 +27022,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -30638,17 +27090,61 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getString",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 144,
+              "column": 3
+            },
+            "end": {
+              "line": 151,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "toXlsxValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 337,
+              "column": 2
+            },
+            "end": {
+              "line": 342,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath",
+              "defaultValue": "this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_pathsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -30676,11 +27172,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 285,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 287,
+              "line": 360,
               "column": 3
             }
           },
@@ -30702,11 +27198,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -30728,11 +27224,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -30763,11 +27259,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -30782,11 +27278,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -30804,11 +27300,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -30832,11 +27328,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 149,
+              "line": 140,
               "column": 3
             },
             "end": {
-              "line": 151,
+              "line": 142,
               "column": 4
             }
           },
@@ -30849,11 +27345,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 124,
+              "line": 115,
               "column": 3
             },
             "end": {
-              "line": 130,
+              "line": 121,
               "column": 4
             }
           },
@@ -30873,11 +27369,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 123,
               "column": 3
             },
             "end": {
-              "line": 147,
+              "line": 138,
               "column": 4
             }
           },
@@ -30898,11 +27394,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -30920,11 +27416,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -30942,11 +27438,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -30964,11 +27460,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -30986,11 +27482,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -31008,11 +27504,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -31032,11 +27528,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -31054,11 +27550,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 87,
               "column": 3
             },
             "end": {
-              "line": 115,
+              "line": 106,
               "column": 4
             }
           },
@@ -31076,11 +27572,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 117,
+              "line": 108,
               "column": 3
             },
             "end": {
-              "line": 122,
+              "line": 113,
               "column": 4
             }
           },
@@ -31097,7 +27593,7 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 60,
+          "line": 55,
           "column": 2
         },
         "end": {
@@ -31110,52 +27606,16 @@
       "name": "OmnitableColumnListHorizontal",
       "attributes": [
         {
-          "name": "text-property",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
-            "start": {
-              "line": 13,
-              "column": 4
-            },
-            "end": {
-              "line": 16,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
-        },
-        {
-          "name": "value-property",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
-            "start": {
-              "line": 18,
-              "column": 4
-            },
-            "end": {
-              "line": 21,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
-        },
-        {
           "name": "title",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -31169,11 +27629,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -31187,11 +27647,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -31205,11 +27665,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -31223,11 +27683,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -31240,11 +27700,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 77,
               "column": 5
             },
             "end": {
-              "line": 92,
+              "line": 83,
               "column": 6
             }
           },
@@ -31257,11 +27717,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -31275,11 +27735,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -31292,11 +27752,11 @@
           "description": "Ask for a list of values",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 84,
+              "line": 75,
               "column": 6
             }
           },
@@ -31309,11 +27769,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -31327,11 +27787,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -31345,11 +27805,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -31363,11 +27823,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -31381,11 +27841,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -31399,11 +27859,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -31417,11 +27877,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -31435,11 +27895,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -31453,11 +27913,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -31471,11 +27931,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -31489,11 +27949,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -31507,11 +27967,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -31525,11 +27985,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -31543,11 +28003,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -31561,16 +28021,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -31646,15 +28124,51 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "text-property",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "start": {
+              "line": 10,
+              "column": 4
+            },
+            "end": {
+              "line": 13,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
+        },
+        {
+          "name": "value-property",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "start": {
+              "line": 15,
+              "column": 4
+            },
+            "end": {
+              "line": 18,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
+        },
+        {
           "name": "autocomplete-selected-items",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 64,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 66,
               "column": 6
             }
           },
@@ -31677,8 +28191,8 @@
       "slots": [],
       "tagname": "cosmoz-omnitable-column-list-horizontal",
       "mixins": [
-        "Cosmoz.ListColumnMixin",
-        "Cosmoz.OmnitableColumnMixin"
+        "Cosmoz.OmnitableColumnMixin",
+        "Cosmoz.ListColumnMixin"
       ]
     },
     {
@@ -31694,11 +28208,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -31719,11 +28233,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -31742,11 +28256,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 34,
+              "line": 30,
               "column": 4
             },
             "end": {
-              "line": 37,
+              "line": 33,
               "column": 5
             }
           },
@@ -31766,11 +28280,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 39,
+              "line": 35,
               "column": 4
             },
             "end": {
-              "line": 42,
+              "line": 38,
               "column": 5
             }
           },
@@ -31790,11 +28304,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -31814,11 +28328,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 49,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 50,
               "column": 5
             }
           },
@@ -31837,11 +28351,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 56,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 55,
               "column": 5
             }
           },
@@ -31861,11 +28375,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 61,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -31885,11 +28399,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 69,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 68,
               "column": 5
             }
           },
@@ -31902,6 +28416,98 @@
           "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -31909,11 +28515,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -31933,11 +28539,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -31956,11 +28562,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -31981,11 +28587,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -32005,11 +28611,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -32030,11 +28636,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -32054,11 +28660,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -32079,11 +28685,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -32103,11 +28709,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -32126,11 +28732,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -32150,11 +28756,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -32174,11 +28780,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -32198,11 +28804,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 59,
               "column": 5
             },
             "end": {
-              "line": 73,
+              "line": 62,
               "column": 6
             }
           },
@@ -32220,11 +28826,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 74,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 77,
+              "line": 66,
               "column": 6
             }
           },
@@ -32243,11 +28849,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -32267,11 +28873,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -32291,11 +28897,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -32314,11 +28920,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 55,
               "column": 5
             },
             "end": {
-              "line": 69,
+              "line": 58,
               "column": 6
             }
           },
@@ -32336,11 +28942,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 67,
               "column": 5
             },
             "end": {
-              "line": 81,
+              "line": 70,
               "column": 6
             }
           },
@@ -32359,11 +28965,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -32382,11 +28988,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -32406,11 +29012,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -32420,6 +29026,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -32517,17 +29147,65 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "maximumFractionDigits",
           "type": "number | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 74,
               "column": 6
             }
           },
@@ -32545,11 +29223,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 75,
               "column": 5
             },
             "end": {
-              "line": 89,
+              "line": 78,
               "column": 6
             }
           },
@@ -32567,11 +29245,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 79,
               "column": 5
             },
             "end": {
-              "line": 93,
+              "line": 82,
               "column": 6
             }
           },
@@ -32589,11 +29267,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 94,
+              "line": 83,
               "column": 5
             },
             "end": {
-              "line": 97,
+              "line": 86,
               "column": 6
             }
           },
@@ -32608,16 +29286,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 80,
+              "line": 81,
               "column": 3
             }
           },
@@ -32626,7 +29304,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+          "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
           "name": "toNumber",
@@ -32635,11 +29313,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 95,
+              "line": 91,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 3
             }
           },
@@ -32674,11 +29352,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 113,
+              "line": 109,
               "column": 2
             },
             "end": {
-              "line": 115,
+              "line": 111,
               "column": 3
             }
           },
@@ -32692,11 +29370,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 141,
+              "line": 110,
               "column": 3
             },
             "end": {
-              "line": 159,
+              "line": 128,
               "column": 4
             }
           },
@@ -32725,11 +29403,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 264,
+              "line": 337,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 342,
               "column": 3
             }
           },
@@ -32752,11 +29430,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 257,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 263,
+              "line": 336,
               "column": 3
             }
           },
@@ -32778,11 +29456,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 161,
+              "line": 130,
               "column": 3
             },
             "end": {
-              "line": 167,
+              "line": 136,
               "column": 4
             }
           },
@@ -32804,11 +29482,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 158,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 157,
               "column": 3
             }
           },
@@ -32831,11 +29509,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 169,
+              "line": 165,
               "column": 2
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 3
             }
           },
@@ -32860,11 +29538,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 2
             },
             "end": {
-              "line": 204,
+              "line": 200,
               "column": 3
             }
           },
@@ -32892,11 +29570,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -32911,11 +29589,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -32937,11 +29615,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 232,
+              "line": 228,
               "column": 2
             },
             "end": {
-              "line": 249,
+              "line": 245,
               "column": 3
             }
           },
@@ -32960,11 +29638,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 251,
+              "line": 247,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 252,
               "column": 3
             }
           },
@@ -32986,11 +29664,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 258,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 256,
               "column": 3
             }
           },
@@ -33009,11 +29687,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 262,
+              "line": 258,
               "column": 2
             },
             "end": {
-              "line": 268,
+              "line": 264,
               "column": 3
             }
           },
@@ -33032,11 +29710,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -33051,11 +29729,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 283,
+              "line": 279,
               "column": 2
             },
             "end": {
-              "line": 293,
+              "line": 289,
               "column": 3
             }
           },
@@ -33079,11 +29757,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 299,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 321,
               "column": 3
             }
           },
@@ -33101,11 +29779,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 327,
+              "line": 323,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 336,
               "column": 3
             }
           },
@@ -33123,11 +29801,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 342,
+              "line": 338,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 358,
               "column": 3
             }
           },
@@ -33149,11 +29827,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -33178,11 +29856,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -33202,11 +29880,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -33225,11 +29903,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 402,
+              "line": 398,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 404,
               "column": 3
             }
           },
@@ -33248,11 +29926,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 410,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 412,
+              "line": 408,
               "column": 3
             }
           },
@@ -33268,324 +29946,71 @@
           "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -33598,11 +30023,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -33618,17 +30043,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -33647,11 +30117,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -33679,11 +30149,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -33705,11 +30175,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -33740,11 +30210,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -33762,11 +30232,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -33788,11 +30258,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -33810,11 +30280,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -33832,11 +30302,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -33854,11 +30324,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -33876,11 +30346,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -33897,11 +30367,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 101,
+              "line": 90,
               "column": 3
             },
             "end": {
-              "line": 112,
+              "line": 101,
               "column": 4
             }
           },
@@ -33917,32 +30387,6 @@
               "name": "maximumFractionDigits"
             }
           ]
-        },
-        {
-          "name": "onBadInputFloatLabel",
-          "description": "Check if label should float based on validity\n\nNumber inputs can have allowed characters that aren't numbers (-,e) and won't\ntrigger a value change and thus not float the label.\nHowever, the validity will report badInput so we can trigger a label float by\nsetting it to something truthy but still not visible.\nFixed in paper-input 3.x",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 126,
-              "column": 3
-            },
-            "end": {
-              "line": 132,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event",
-              "type": "Event",
-              "description": "KeyboardEvent"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
         }
       ],
       "staticMethods": [],
@@ -33950,11 +30394,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 53,
+          "line": 46,
           "column": 2
         },
         "end": {
-          "line": 168,
+          "line": 137,
           "column": 3
         }
       },
@@ -33968,11 +30412,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -33986,11 +30430,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -34004,11 +30448,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 34,
+              "line": 30,
               "column": 4
             },
             "end": {
-              "line": 37,
+              "line": 33,
               "column": 5
             }
           },
@@ -34022,11 +30466,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 39,
+              "line": 35,
               "column": 4
             },
             "end": {
-              "line": 42,
+              "line": 38,
               "column": 5
             }
           },
@@ -34040,11 +30484,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -34058,11 +30502,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -34076,11 +30520,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -34094,11 +30538,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -34112,11 +30556,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -34130,11 +30574,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -34148,11 +30592,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -34166,11 +30610,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -34184,11 +30628,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -34202,11 +30646,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -34220,11 +30664,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -34238,11 +30682,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -34256,11 +30700,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -34273,11 +30717,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 59,
               "column": 5
             },
             "end": {
-              "line": 73,
+              "line": 62,
               "column": 6
             }
           },
@@ -34289,11 +30733,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 74,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 77,
+              "line": 66,
               "column": 6
             }
           },
@@ -34306,11 +30750,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -34324,11 +30768,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -34342,11 +30786,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -34359,11 +30803,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 55,
               "column": 5
             },
             "end": {
-              "line": 69,
+              "line": 58,
               "column": 6
             }
           },
@@ -34375,11 +30819,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 67,
               "column": 5
             },
             "end": {
-              "line": 81,
+              "line": 70,
               "column": 6
             }
           },
@@ -34392,11 +30836,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -34410,11 +30854,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -34428,16 +30872,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -34517,11 +30979,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 74,
               "column": 6
             }
           },
@@ -34533,11 +30995,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 75,
               "column": 5
             },
             "end": {
-              "line": 89,
+              "line": 78,
               "column": 6
             }
           },
@@ -34549,11 +31011,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 79,
               "column": 5
             },
             "end": {
-              "line": 93,
+              "line": 82,
               "column": 6
             }
           },
@@ -34586,11 +31048,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -34611,11 +31073,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -34634,12 +31096,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {
@@ -34658,12 +31120,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {
@@ -34682,11 +31144,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -34706,11 +31168,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 49,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 50,
               "column": 5
             }
           },
@@ -34729,11 +31191,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 56,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 55,
               "column": 5
             }
           },
@@ -34753,11 +31215,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 61,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -34777,11 +31239,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 69,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 68,
               "column": 5
             }
           },
@@ -34801,12 +31263,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 48,
-              "column": 5
+              "line": 30,
+              "column": 4
             },
             "end": {
-              "line": 51,
-              "column": 6
+              "line": 33,
+              "column": 5
             }
           },
           "metadata": {
@@ -34825,11 +31287,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -34849,11 +31311,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -34873,11 +31335,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -34897,12 +31359,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {
@@ -34914,6 +31376,98 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -34921,11 +31475,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -34945,11 +31499,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -34968,11 +31522,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -34993,11 +31547,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -35017,11 +31571,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -35042,11 +31596,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -35066,11 +31620,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -35091,11 +31645,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -35115,11 +31669,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -35138,11 +31692,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -35162,11 +31716,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -35186,11 +31740,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -35210,11 +31764,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 69,
               "column": 5
             },
             "end": {
-              "line": 80,
+              "line": 72,
               "column": 6
             }
           },
@@ -35232,11 +31786,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 74,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 77,
               "column": 6
             }
           },
@@ -35255,11 +31809,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -35278,11 +31832,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 64,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 67,
               "column": 6
             }
           },
@@ -35301,11 +31855,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -35324,11 +31878,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -35348,11 +31902,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -35362,6 +31916,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -35459,17 +32037,65 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_fixedDate",
           "type": "?",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 89,
+              "line": 81,
               "column": 3
             },
             "end": {
-              "line": 91,
+              "line": 83,
               "column": 4
             }
           },
@@ -35486,11 +32112,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 59,
               "column": 5
             },
             "end": {
-              "line": 70,
+              "line": 62,
               "column": 6
             }
           },
@@ -35505,16 +32131,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 80,
+              "line": 81,
               "column": 3
             }
           },
@@ -35523,7 +32149,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+          "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
           "name": "toNumber",
@@ -35532,11 +32158,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 95,
+              "line": 91,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 3
             }
           },
@@ -35571,12 +32197,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 121,
-              "column": 3
+              "line": 89,
+              "column": 2
             },
             "end": {
-              "line": 123,
-              "column": 4
+              "line": 91,
+              "column": 3
             }
           },
           "metadata": {},
@@ -35589,11 +32215,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 143,
+              "line": 132,
               "column": 3
             },
             "end": {
-              "line": 156,
+              "line": 145,
               "column": 4
             }
           },
@@ -35621,11 +32247,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 158,
+              "line": 147,
               "column": 3
             },
             "end": {
-              "line": 163,
+              "line": 152,
               "column": 4
             }
           },
@@ -35647,11 +32273,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 257,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 263,
+              "line": 336,
               "column": 3
             }
           },
@@ -35674,12 +32300,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 184,
-              "column": 3
+              "line": 127,
+              "column": 2
             },
             "end": {
-              "line": 193,
-              "column": 4
+              "line": 136,
+              "column": 3
             }
           },
           "metadata": {},
@@ -35701,11 +32327,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 158,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 157,
               "column": 3
             }
           },
@@ -35728,11 +32354,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 169,
+              "line": 165,
               "column": 2
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 3
             }
           },
@@ -35757,11 +32383,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 2
             },
             "end": {
-              "line": 204,
+              "line": 200,
               "column": 3
             }
           },
@@ -35789,11 +32415,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -35808,11 +32434,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -35834,11 +32460,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 232,
+              "line": 228,
               "column": 2
             },
             "end": {
-              "line": 249,
+              "line": 245,
               "column": 3
             }
           },
@@ -35857,11 +32483,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 251,
+              "line": 247,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 252,
               "column": 3
             }
           },
@@ -35883,11 +32509,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 258,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 256,
               "column": 3
             }
           },
@@ -35905,11 +32531,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 111,
+              "line": 100,
               "column": 3
             },
             "end": {
-              "line": 117,
+              "line": 106,
               "column": 4
             }
           },
@@ -35927,11 +32553,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -35946,11 +32572,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 283,
+              "line": 279,
               "column": 2
             },
             "end": {
-              "line": 293,
+              "line": 289,
               "column": 3
             }
           },
@@ -35974,11 +32600,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 299,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 321,
               "column": 3
             }
           },
@@ -35996,11 +32622,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 327,
+              "line": 323,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 336,
               "column": 3
             }
           },
@@ -36018,11 +32644,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 342,
+              "line": 338,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 358,
               "column": 3
             }
           },
@@ -36044,11 +32670,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -36073,11 +32699,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -36097,11 +32723,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -36119,11 +32745,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 119,
+              "line": 108,
               "column": 3
             },
             "end": {
-              "line": 126,
+              "line": 115,
               "column": 4
             }
           },
@@ -36140,11 +32766,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 128,
+              "line": 117,
               "column": 3
             },
             "end": {
-              "line": 134,
+              "line": 123,
               "column": 4
             }
           },
@@ -36161,11 +32787,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 101,
+              "line": 93,
               "column": 3
             },
             "end": {
-              "line": 109,
+              "line": 98,
               "column": 4
             }
           },
@@ -36193,74 +32819,16 @@
           }
         },
         {
-          "name": "getAbsoluteISOString",
-          "description": "Computes the local timezone and adds it to a local ISO string",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-mixin.html",
-            "start": {
-              "line": 164,
-              "column": 3
-            },
-            "end": {
-              "line": 172,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string, without timezone info"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "an ISO date string, with timezone info"
-          },
-          "inheritedFrom": "Cosmoz.DateColumnMixin"
-        },
-        {
-          "name": "_getTimezoneString",
-          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-mixin.html",
-            "start": {
-              "line": 179,
-              "column": 3
-            },
-            "end": {
-              "line": 182,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "the ISO timezone"
-          },
-          "inheritedFrom": "Cosmoz.DateColumnMixin"
-        },
-        {
           "name": "_computeFormatter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 183,
+              "line": 172,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 179,
               "column": 4
             }
           },
@@ -36278,12 +32846,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 207,
-              "column": 3
+              "line": 150,
+              "column": 2
             },
             "end": {
-              "line": 218,
-              "column": 4
+              "line": 161,
+              "column": 3
             }
           },
           "metadata": {},
@@ -36304,12 +32872,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 220,
-              "column": 3
+              "line": 163,
+              "column": 2
             },
             "end": {
-              "line": 222,
-              "column": 4
+              "line": 175,
+              "column": 3
             }
           },
           "metadata": {},
@@ -36321,324 +32889,71 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -36651,11 +32966,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -36671,17 +32986,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -36700,11 +33060,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -36732,11 +33092,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -36758,11 +33118,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -36793,11 +33153,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -36815,11 +33175,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -36841,11 +33201,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -36863,11 +33223,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -36885,11 +33245,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -36907,11 +33267,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -36929,11 +33289,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -36950,11 +33310,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 154,
               "column": 3
             },
             "end": {
-              "line": 179,
+              "line": 168,
               "column": 4
             }
           },
@@ -36974,11 +33334,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 51,
+          "line": 45,
           "column": 2
         },
         "end": {
-          "line": 191,
+          "line": 180,
           "column": 3
         }
       },
@@ -36992,11 +33352,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -37010,11 +33370,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -37028,12 +33388,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {},
@@ -37046,12 +33406,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {},
@@ -37064,11 +33424,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -37082,11 +33442,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -37100,11 +33460,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -37118,11 +33478,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -37136,12 +33496,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {},
@@ -37154,11 +33514,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -37172,11 +33532,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -37190,11 +33550,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -37208,11 +33568,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -37226,11 +33586,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -37244,11 +33604,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -37262,11 +33622,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -37280,11 +33640,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -37298,11 +33658,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -37316,11 +33676,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -37334,11 +33694,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -37352,11 +33712,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -37369,11 +33729,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 69,
               "column": 5
             },
             "end": {
-              "line": 80,
+              "line": 72,
               "column": 6
             }
           },
@@ -37385,11 +33745,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 74,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 77,
               "column": 6
             }
           },
@@ -37402,11 +33762,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -37419,11 +33779,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 64,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 67,
               "column": 6
             }
           },
@@ -37436,11 +33796,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -37454,11 +33814,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -37472,16 +33832,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -37561,11 +33939,11 @@
           "description": "Specifies the value granularity of the time input's value in the filter.\n1 => full seconds\n0.1 => milliseconds",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 59,
               "column": 5
             },
             "end": {
-              "line": 70,
+              "line": 62,
               "column": 6
             }
           },
@@ -37598,11 +33976,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -37623,11 +34001,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -37646,12 +34024,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {
@@ -37670,12 +34048,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {
@@ -37694,11 +34072,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -37718,11 +34096,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 49,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 50,
               "column": 5
             }
           },
@@ -37741,11 +34119,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 56,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 55,
               "column": 5
             }
           },
@@ -37765,11 +34143,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 61,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -37789,11 +34167,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 69,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 68,
               "column": 5
             }
           },
@@ -37813,12 +34191,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 48,
-              "column": 5
+              "line": 30,
+              "column": 4
             },
             "end": {
-              "line": 51,
-              "column": 6
+              "line": 33,
+              "column": 5
             }
           },
           "metadata": {
@@ -37836,11 +34214,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 62,
               "column": 5
             },
             "end": {
-              "line": 73,
+              "line": 65,
               "column": 6
             }
           },
@@ -37858,11 +34236,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 67,
               "column": 5
             },
             "end": {
-              "line": 78,
+              "line": 70,
               "column": 6
             }
           },
@@ -37881,11 +34259,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -37905,12 +34283,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {
@@ -37922,6 +34300,98 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -37929,11 +34399,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -37953,11 +34423,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -37976,11 +34446,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -38001,11 +34471,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -38025,11 +34495,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -38050,11 +34520,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -38074,11 +34544,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -38099,11 +34569,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -38123,11 +34593,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -38146,11 +34616,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -38170,11 +34640,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -38194,11 +34664,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -38218,11 +34688,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 72,
               "column": 5
             },
             "end": {
-              "line": 83,
+              "line": 75,
               "column": 6
             }
           },
@@ -38240,11 +34710,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 77,
               "column": 5
             },
             "end": {
-              "line": 88,
+              "line": 80,
               "column": 6
             }
           },
@@ -38263,11 +34733,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -38286,11 +34756,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 93,
+              "line": 85,
               "column": 6
             }
           },
@@ -38309,11 +34779,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -38332,11 +34802,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -38356,11 +34826,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -38370,6 +34840,30 @@
             }
           },
           "defaultValue": "0",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -38467,17 +34961,65 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "filterStep",
           "type": "number | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 57,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 60,
               "column": 6
             }
           },
@@ -38492,16 +35034,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
+          "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 80,
+              "line": 81,
               "column": 3
             }
           },
@@ -38510,7 +35052,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+          "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
           "name": "toNumber",
@@ -38519,11 +35061,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 95,
+              "line": 91,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 3
             }
           },
@@ -38558,12 +35100,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 121,
-              "column": 3
+              "line": 89,
+              "column": 2
             },
             "end": {
-              "line": 123,
-              "column": 4
+              "line": 91,
+              "column": 3
             }
           },
           "metadata": {},
@@ -38577,11 +35119,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 285,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 287,
+              "line": 360,
               "column": 3
             }
           },
@@ -38602,11 +35144,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 114,
               "column": 3
             },
             "end": {
-              "line": 127,
+              "line": 119,
               "column": 4
             }
           },
@@ -38628,11 +35170,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 257,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 263,
+              "line": 336,
               "column": 3
             }
           },
@@ -38655,12 +35197,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 184,
-              "column": 3
+              "line": 127,
+              "column": 2
             },
             "end": {
-              "line": 193,
-              "column": 4
+              "line": 136,
+              "column": 3
             }
           },
           "metadata": {},
@@ -38682,11 +35224,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 158,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 157,
               "column": 3
             }
           },
@@ -38709,11 +35251,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 169,
+              "line": 165,
               "column": 2
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 3
             }
           },
@@ -38738,11 +35280,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 2
             },
             "end": {
-              "line": 204,
+              "line": 200,
               "column": 3
             }
           },
@@ -38770,11 +35312,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -38789,11 +35331,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -38815,11 +35357,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 232,
+              "line": 228,
               "column": 2
             },
             "end": {
-              "line": 249,
+              "line": 245,
               "column": 3
             }
           },
@@ -38838,11 +35380,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 251,
+              "line": 247,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 252,
               "column": 3
             }
           },
@@ -38864,11 +35406,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 258,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 256,
               "column": 3
             }
           },
@@ -38886,11 +35428,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 97,
+              "line": 89,
               "column": 3
             },
             "end": {
-              "line": 103,
+              "line": 95,
               "column": 4
             }
           },
@@ -38908,11 +35450,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -38927,11 +35469,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 283,
+              "line": 279,
               "column": 2
             },
             "end": {
-              "line": 293,
+              "line": 289,
               "column": 3
             }
           },
@@ -38955,11 +35497,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 299,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 321,
               "column": 3
             }
           },
@@ -38977,11 +35519,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 327,
+              "line": 323,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 336,
               "column": 3
             }
           },
@@ -38999,11 +35541,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 342,
+              "line": 338,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 358,
               "column": 3
             }
           },
@@ -39025,11 +35567,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -39054,11 +35596,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -39078,11 +35620,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -39100,11 +35642,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 97,
               "column": 3
             },
             "end": {
-              "line": 112,
+              "line": 104,
               "column": 4
             }
           },
@@ -39121,11 +35663,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 106,
               "column": 3
             },
             "end": {
-              "line": 120,
+              "line": 112,
               "column": 4
             }
           },
@@ -39143,12 +35685,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 86,
-              "column": 3
+              "line": 68,
+              "column": 2
             },
             "end": {
-              "line": 119,
-              "column": 4
+              "line": 87,
+              "column": 3
             }
           },
           "metadata": {},
@@ -39176,74 +35718,16 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "getAbsoluteISOString",
-          "description": "Computes the local timezone and adds it to a local ISO string",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-mixin.html",
-            "start": {
-              "line": 164,
-              "column": 3
-            },
-            "end": {
-              "line": 172,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string, without timezone info"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "an ISO date string, with timezone info"
-          },
-          "inheritedFrom": "Cosmoz.DateColumnMixin"
-        },
-        {
-          "name": "_getTimezoneString",
-          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-date-mixin.html",
-            "start": {
-              "line": 179,
-              "column": 3
-            },
-            "end": {
-              "line": 182,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "the ISO timezone"
-          },
-          "inheritedFrom": "Cosmoz.DateColumnMixin"
-        },
-        {
           "name": "_computeFormatter",
           "description": "OVERRIDES",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 130,
+              "line": 122,
               "column": 3
             },
             "end": {
-              "line": 139,
+              "line": 131,
               "column": 4
             }
           },
@@ -39261,12 +35745,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 207,
-              "column": 3
+              "line": 150,
+              "column": 2
             },
             "end": {
-              "line": 218,
-              "column": 4
+              "line": 161,
+              "column": 3
             }
           },
           "metadata": {},
@@ -39287,12 +35771,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 220,
-              "column": 3
+              "line": 163,
+              "column": 2
             },
             "end": {
-              "line": 222,
-              "column": 4
+              "line": 175,
+              "column": 3
             }
           },
           "metadata": {},
@@ -39304,324 +35788,71 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
           "return": {
             "type": "void"
           },
@@ -39634,11 +35865,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -39654,17 +35885,62 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -39683,11 +35959,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -39715,11 +35991,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -39741,11 +36017,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -39776,11 +36052,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -39798,11 +36074,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -39824,11 +36100,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -39846,11 +36122,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -39868,11 +36144,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -39890,11 +36166,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -39912,11 +36188,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -39933,11 +36209,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 54,
+          "line": 48,
           "column": 2
         },
         "end": {
-          "line": 140,
+          "line": 132,
           "column": 3
         }
       },
@@ -39951,11 +36227,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -39969,11 +36245,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -39987,12 +36263,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {},
@@ -40005,12 +36281,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {},
@@ -40023,11 +36299,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -40040,11 +36316,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 62,
               "column": 5
             },
             "end": {
-              "line": 73,
+              "line": 65,
               "column": 6
             }
           },
@@ -40056,11 +36332,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 67,
               "column": 5
             },
             "end": {
-              "line": 78,
+              "line": 70,
               "column": 6
             }
           },
@@ -40073,11 +36349,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -40091,12 +36367,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {},
@@ -40109,11 +36385,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -40127,11 +36403,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -40145,11 +36421,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -40163,11 +36439,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -40181,11 +36457,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -40199,11 +36475,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -40217,11 +36493,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -40235,11 +36511,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -40253,11 +36529,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -40271,11 +36547,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -40289,11 +36565,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -40307,11 +36583,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -40324,11 +36600,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 72,
               "column": 5
             },
             "end": {
-              "line": 83,
+              "line": 75,
               "column": 6
             }
           },
@@ -40340,11 +36616,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 77,
               "column": 5
             },
             "end": {
-              "line": 88,
+              "line": 80,
               "column": 6
             }
           },
@@ -40357,11 +36633,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -40374,11 +36650,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 93,
+              "line": 85,
               "column": 6
             }
           },
@@ -40391,11 +36667,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -40409,11 +36685,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -40427,16 +36703,34 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -40516,11 +36810,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 57,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 60,
               "column": 6
             }
           },
@@ -40552,11 +36846,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 36,
+              "line": 32,
               "column": 4
             },
             "end": {
-              "line": 39,
+              "line": 35,
               "column": 5
             }
           },
@@ -40574,11 +36868,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -40596,11 +36890,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 51,
               "column": 5
             }
           },
@@ -40618,11 +36912,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 62,
+              "line": 58,
               "column": 5
             }
           },
@@ -40639,11 +36933,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 67,
               "column": 5
             }
           },
@@ -40662,11 +36956,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 79,
+              "line": 75,
               "column": 5
             }
           },
@@ -40684,11 +36978,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 84,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 83,
               "column": 5
             }
           },
@@ -40706,11 +37000,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 92,
+              "line": 88,
               "column": 4
             },
             "end": {
-              "line": 95,
+              "line": 91,
               "column": 5
             }
           },
@@ -40728,11 +37022,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -40750,11 +37044,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 108,
+              "line": 104,
               "column": 4
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 5
             }
           },
@@ -40772,11 +37066,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 112,
               "column": 4
             },
             "end": {
-              "line": 119,
+              "line": 115,
               "column": 5
             }
           },
@@ -40794,11 +37088,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 117,
               "column": 4
             },
             "end": {
-              "line": 124,
+              "line": 120,
               "column": 5
             }
           },
@@ -40816,11 +37110,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 126,
+              "line": 122,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 126,
               "column": 5
             }
           },
@@ -40839,11 +37133,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 128,
               "column": 4
             },
             "end": {
-              "line": 136,
+              "line": 132,
               "column": 5
             }
           },
@@ -40862,11 +37156,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 138,
+              "line": 134,
               "column": 4
             },
             "end": {
-              "line": 141,
+              "line": 137,
               "column": 5
             }
           },
@@ -40884,11 +37178,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 143,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 147,
+              "line": 143,
               "column": 5
             }
           },
@@ -40907,11 +37201,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 151,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 155,
+              "line": 151,
               "column": 5
             }
           },
@@ -40930,11 +37224,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 165,
+              "line": 161,
               "column": 5
             }
           },
@@ -40954,11 +37248,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 174,
+              "line": 170,
               "column": 5
             }
           },
@@ -40977,11 +37271,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 179,
+              "line": 175,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -40998,11 +37292,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 186,
+              "line": 182,
               "column": 4
             },
             "end": {
-              "line": 189,
+              "line": 185,
               "column": 5
             }
           },
@@ -41020,11 +37314,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 194,
+              "line": 190,
               "column": 4
             },
             "end": {
-              "line": 197,
+              "line": 193,
               "column": 5
             }
           },
@@ -41042,11 +37336,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 199,
+              "line": 195,
               "column": 4
             },
             "end": {
-              "line": 202,
+              "line": 198,
               "column": 5
             }
           },
@@ -41064,11 +37358,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 207,
+              "line": 203,
               "column": 4
             },
             "end": {
-              "line": 210,
+              "line": 206,
               "column": 5
             }
           },
@@ -41086,11 +37380,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 212,
+              "line": 208,
               "column": 4
             },
             "end": {
-              "line": 218,
+              "line": 214,
               "column": 5
             }
           },
@@ -41111,11 +37405,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 223,
+              "line": 219,
               "column": 4
             },
             "end": {
-              "line": 227,
+              "line": 223,
               "column": 5
             }
           },
@@ -41134,11 +37428,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 229,
+              "line": 225,
               "column": 4
             },
             "end": {
-              "line": 232,
+              "line": 228,
               "column": 5
             }
           },
@@ -41156,11 +37450,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 234,
+              "line": 230,
               "column": 4
             },
             "end": {
-              "line": 237,
+              "line": 233,
               "column": 5
             }
           },
@@ -41178,11 +37472,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 239,
+              "line": 235,
               "column": 4
             },
             "end": {
-              "line": 241,
+              "line": 237,
               "column": 5
             }
           },
@@ -41199,11 +37493,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 243,
+              "line": 239,
               "column": 4
             },
             "end": {
-              "line": 246,
+              "line": 242,
               "column": 5
             }
           },
@@ -41220,11 +37514,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 247,
+              "line": 243,
               "column": 4
             },
             "end": {
-              "line": 250,
+              "line": 246,
               "column": 5
             }
           },
@@ -41242,11 +37536,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 255,
+              "line": 251,
               "column": 4
             },
             "end": {
-              "line": 257,
+              "line": 253,
               "column": 5
             }
           },
@@ -41255,20 +37549,75 @@
               "attributeType": "Boolean"
             }
           }
+        },
+        {
+          "name": "t",
+          "type": "Object | null | undefined",
+          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 256,
+              "column": 4
+            },
+            "end": {
+              "line": 261,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          }
         }
       ],
       "methods": [
+        {
+          "name": "_",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 273,
+              "column": 2
+            },
+            "end": {
+              "line": 276,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "ngettext",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 278,
+              "column": 2
+            },
+            "end": {
+              "line": 281,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
         {
           "name": "connectedCallback",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 282,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 312,
+              "line": 325,
               "column": 3
             }
           },
@@ -41284,11 +37633,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 314,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 332,
+              "line": 345,
               "column": 3
             }
           },
@@ -41304,11 +37653,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 334,
+              "line": 347,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 367,
               "column": 3
             }
           },
@@ -41324,11 +37673,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 358,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 377,
               "column": 3
             }
           },
@@ -41344,11 +37693,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 364,
+              "line": 381,
               "column": 2
             },
             "end": {
-              "line": 366,
+              "line": 383,
               "column": 3
             }
           },
@@ -41365,11 +37714,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 368,
+              "line": 385,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 387,
               "column": 3
             }
           },
@@ -41389,11 +37738,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 372,
+              "line": 389,
               "column": 2
             },
             "end": {
-              "line": 375,
+              "line": 392,
               "column": 3
             }
           },
@@ -41410,11 +37759,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 377,
+              "line": 394,
               "column": 2
             },
             "end": {
-              "line": 379,
+              "line": 396,
               "column": 3
             }
           },
@@ -41434,11 +37783,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 381,
+              "line": 398,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 402,
               "column": 3
             }
           },
@@ -41458,11 +37807,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 387,
+              "line": 404,
               "column": 2
             },
             "end": {
-              "line": 390,
+              "line": 407,
               "column": 3
             }
           },
@@ -41478,11 +37827,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 392,
+              "line": 409,
               "column": 2
             },
             "end": {
-              "line": 398,
+              "line": 415,
               "column": 3
             }
           },
@@ -41502,11 +37851,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 400,
+              "line": 417,
               "column": 2
             },
             "end": {
-              "line": 417,
+              "line": 434,
               "column": 3
             }
           },
@@ -41526,11 +37875,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 419,
+              "line": 436,
               "column": 2
             },
             "end": {
-              "line": 433,
+              "line": 450,
               "column": 3
             }
           },
@@ -41550,11 +37899,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 436,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 444,
+              "line": 461,
               "column": 3
             }
           },
@@ -41574,11 +37923,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 447,
+              "line": 464,
               "column": 2
             },
             "end": {
-              "line": 457,
+              "line": 474,
               "column": 3
             }
           },
@@ -41598,11 +37947,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 459,
+              "line": 476,
               "column": 2
             },
             "end": {
-              "line": 462,
+              "line": 479,
               "column": 3
             }
           },
@@ -41622,11 +37971,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 464,
+              "line": 481,
               "column": 2
             },
             "end": {
-              "line": 467,
+              "line": 484,
               "column": 3
             }
           },
@@ -41642,11 +37991,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 469,
+              "line": 486,
               "column": 2
             },
             "end": {
-              "line": 475,
+              "line": 492,
               "column": 3
             }
           },
@@ -41662,11 +38011,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 477,
+              "line": 494,
               "column": 2
             },
             "end": {
-              "line": 479,
+              "line": 496,
               "column": 3
             }
           },
@@ -41682,11 +38031,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 481,
+              "line": 498,
               "column": 2
             },
             "end": {
-              "line": 547,
+              "line": 566,
               "column": 3
             }
           },
@@ -41702,11 +38051,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 555,
+              "line": 574,
               "column": 2
             },
             "end": {
-              "line": 572,
+              "line": 591,
               "column": 3
             }
           },
@@ -41735,11 +38084,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 574,
+              "line": 593,
               "column": 2
             },
             "end": {
-              "line": 579,
+              "line": 598,
               "column": 3
             }
           },
@@ -41759,11 +38108,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 582,
+              "line": 601,
               "column": 2
             },
             "end": {
-              "line": 603,
+              "line": 622,
               "column": 3
             }
           },
@@ -41784,11 +38133,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 610,
+              "line": 629,
               "column": 2
             },
             "end": {
-              "line": 619,
+              "line": 638,
               "column": 3
             }
           },
@@ -41821,11 +38170,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 621,
+              "line": 640,
               "column": 2
             },
             "end": {
-              "line": 627,
+              "line": 646,
               "column": 3
             }
           },
@@ -41845,11 +38194,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 629,
+              "line": 648,
               "column": 2
             },
             "end": {
-              "line": 631,
+              "line": 650,
               "column": 3
             }
           },
@@ -41865,11 +38214,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 633,
+              "line": 652,
               "column": 2
             },
             "end": {
-              "line": 653,
+              "line": 672,
               "column": 3
             }
           },
@@ -41885,11 +38234,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 655,
+              "line": 674,
               "column": 2
             },
             "end": {
-              "line": 661,
+              "line": 680,
               "column": 3
             }
           },
@@ -41909,11 +38258,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 663,
+              "line": 682,
               "column": 2
             },
             "end": {
-              "line": 668,
+              "line": 687,
               "column": 3
             }
           },
@@ -41929,11 +38278,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 670,
+              "line": 689,
               "column": 2
             },
             "end": {
-              "line": 722,
+              "line": 741,
               "column": 3
             }
           },
@@ -41949,11 +38298,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 724,
+              "line": 743,
               "column": 2
             },
             "end": {
-              "line": 729,
+              "line": 748,
               "column": 3
             }
           },
@@ -41969,11 +38318,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 731,
+              "line": 750,
               "column": 2
             },
             "end": {
-              "line": 763,
+              "line": 782,
               "column": 3
             }
           },
@@ -41993,11 +38342,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 773,
+              "line": 792,
               "column": 2
             },
             "end": {
-              "line": 778,
+              "line": 797,
               "column": 3
             }
           },
@@ -42025,11 +38374,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 780,
+              "line": 799,
               "column": 2
             },
             "end": {
-              "line": 824,
+              "line": 843,
               "column": 3
             }
           },
@@ -42045,11 +38394,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 826,
+              "line": 845,
               "column": 2
             },
             "end": {
-              "line": 831,
+              "line": 850,
               "column": 3
             }
           },
@@ -42065,11 +38414,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 838,
+              "line": 857,
               "column": 2
             },
             "end": {
-              "line": 896,
+              "line": 915,
               "column": 3
             }
           },
@@ -42086,11 +38435,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 898,
+              "line": 917,
               "column": 2
             },
             "end": {
-              "line": 915,
+              "line": 934,
               "column": 3
             }
           },
@@ -42110,11 +38459,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 917,
+              "line": 936,
               "column": 2
             },
             "end": {
-              "line": 935,
+              "line": 954,
               "column": 3
             }
           },
@@ -42131,11 +38480,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 937,
+              "line": 956,
               "column": 2
             },
             "end": {
-              "line": 954,
+              "line": 973,
               "column": 3
             }
           },
@@ -42151,11 +38500,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 956,
+              "line": 975,
               "column": 2
             },
             "end": {
-              "line": 964,
+              "line": 983,
               "column": 3
             }
           },
@@ -42171,11 +38520,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 973,
+              "line": 992,
               "column": 2
             },
             "end": {
-              "line": 988,
+              "line": 1007,
               "column": 3
             }
           },
@@ -42198,11 +38547,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 990,
+              "line": 1009,
               "column": 2
             },
             "end": {
-              "line": 996,
+              "line": 1015,
               "column": 3
             }
           },
@@ -42219,11 +38568,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1001,
+              "line": 1020,
               "column": 2
             },
             "end": {
-              "line": 1020,
+              "line": 1039,
               "column": 3
             }
           },
@@ -42239,11 +38588,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1026,
+              "line": 1045,
               "column": 2
             },
             "end": {
-              "line": 1037,
+              "line": 1056,
               "column": 3
             }
           },
@@ -42260,11 +38609,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1044,
+              "line": 1063,
               "column": 2
             },
             "end": {
-              "line": 1051,
+              "line": 1070,
               "column": 3
             }
           },
@@ -42280,11 +38629,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1055,
+              "line": 1074,
               "column": 2
             },
             "end": {
-              "line": 1057,
+              "line": 1076,
               "column": 3
             }
           },
@@ -42301,11 +38650,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1058,
+              "line": 1077,
               "column": 2
             },
             "end": {
-              "line": 1060,
+              "line": 1079,
               "column": 3
             }
           },
@@ -42322,11 +38671,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1068,
+              "line": 1087,
               "column": 2
             },
             "end": {
-              "line": 1080,
+              "line": 1099,
               "column": 3
             }
           },
@@ -42348,11 +38697,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1086,
+              "line": 1105,
               "column": 2
             },
             "end": {
-              "line": 1095,
+              "line": 1114,
               "column": 3
             }
           },
@@ -42374,11 +38723,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1097,
+              "line": 1116,
               "column": 2
             },
             "end": {
-              "line": 1100,
+              "line": 1119,
               "column": 3
             }
           },
@@ -42398,11 +38747,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1107,
+              "line": 1126,
               "column": 2
             },
             "end": {
-              "line": 1117,
+              "line": 1136,
               "column": 3
             }
           },
@@ -42429,11 +38778,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1119,
+              "line": 1138,
               "column": 2
             },
             "end": {
-              "line": 1123,
+              "line": 1142,
               "column": 3
             }
           },
@@ -42453,11 +38802,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1125,
+              "line": 1144,
               "column": 2
             },
             "end": {
-              "line": 1135,
+              "line": 1154,
               "column": 3
             }
           },
@@ -42477,11 +38826,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1144,
+              "line": 1163,
               "column": 2
             },
             "end": {
-              "line": 1154,
+              "line": 1173,
               "column": 3
             }
           },
@@ -42504,11 +38853,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1160,
+              "line": 1179,
               "column": 2
             },
             "end": {
-              "line": 1165,
+              "line": 1184,
               "column": 3
             }
           },
@@ -42531,11 +38880,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1174,
+              "line": 1193,
               "column": 2
             },
             "end": {
-              "line": 1179,
+              "line": 1198,
               "column": 3
             }
           },
@@ -42567,11 +38916,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1181,
+              "line": 1200,
               "column": 2
             },
             "end": {
-              "line": 1183,
+              "line": 1202,
               "column": 3
             }
           },
@@ -42591,11 +38940,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1185,
+              "line": 1204,
               "column": 2
             },
             "end": {
-              "line": 1187,
+              "line": 1206,
               "column": 3
             }
           },
@@ -42615,11 +38964,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1189,
+              "line": 1208,
               "column": 2
             },
             "end": {
-              "line": 1191,
+              "line": 1210,
               "column": 3
             }
           },
@@ -42636,11 +38985,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1193,
+              "line": 1212,
               "column": 2
             },
             "end": {
-              "line": 1195,
+              "line": 1214,
               "column": 3
             }
           },
@@ -42657,11 +39006,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1197,
+              "line": 1216,
               "column": 2
             },
             "end": {
-              "line": 1207,
+              "line": 1226,
               "column": 3
             }
           },
@@ -42684,11 +39033,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1209,
+              "line": 1228,
               "column": 2
             },
             "end": {
-              "line": 1215,
+              "line": 1234,
               "column": 3
             }
           },
@@ -42711,11 +39060,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1217,
+              "line": 1236,
               "column": 2
             },
             "end": {
-              "line": 1239,
+              "line": 1258,
               "column": 3
             }
           },
@@ -42738,11 +39087,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1240,
+              "line": 1259,
               "column": 2
             },
             "end": {
-              "line": 1245,
+              "line": 1264,
               "column": 3
             }
           },
@@ -42759,11 +39108,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1246,
+              "line": 1265,
               "column": 2
             },
             "end": {
-              "line": 1260,
+              "line": 1279,
               "column": 3
             }
           },
@@ -42786,11 +39135,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1262,
+              "line": 1281,
               "column": 2
             },
             "end": {
-              "line": 1270,
+              "line": 1289,
               "column": 3
             }
           },
@@ -42806,11 +39155,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1272,
+              "line": 1291,
               "column": 2
             },
             "end": {
-              "line": 1286,
+              "line": 1305,
               "column": 3
             }
           },
@@ -42830,11 +39179,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1288,
+              "line": 1307,
               "column": 2
             },
             "end": {
-              "line": 1302,
+              "line": 1321,
               "column": 3
             }
           },
@@ -42854,11 +39203,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1304,
+              "line": 1323,
               "column": 2
             },
             "end": {
-              "line": 1311,
+              "line": 1330,
               "column": 3
             }
           },
@@ -42874,11 +39223,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1313,
+              "line": 1332,
               "column": 2
             },
             "end": {
-              "line": 1315,
+              "line": 1334,
               "column": 3
             }
           },
@@ -42910,11 +39259,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 21,
+          "line": 18,
           "column": 1
         },
         "end": {
-          "line": 1316,
+          "line": 1335,
           "column": 2
         }
       },
@@ -42927,11 +39276,11 @@
           "description": "Filename when saving as CSV",
           "sourceRange": {
             "start": {
-              "line": 36,
+              "line": 32,
               "column": 4
             },
             "end": {
-              "line": 39,
+              "line": 35,
               "column": 5
             }
           },
@@ -42943,11 +39292,11 @@
           "description": "Filename when saving as XLSX",
           "sourceRange": {
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -42959,11 +39308,11 @@
           "description": "Sheet name when saving as XLSX",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 48,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 51,
               "column": 5
             }
           },
@@ -42975,11 +39324,11 @@
           "description": "Array used to list items.",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 62,
+              "line": 58,
               "column": 5
             }
           },
@@ -42991,11 +39340,11 @@
           "description": "If set to true, then group a row will be displayed for groups that contain no items.",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 79,
+              "line": 75,
               "column": 5
             }
           },
@@ -43007,11 +39356,11 @@
           "description": "Specific columns to enable",
           "sourceRange": {
             "start": {
-              "line": 84,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 83,
               "column": 5
             }
           },
@@ -43023,11 +39372,11 @@
           "description": "Whether bottom-bar has actions.",
           "sourceRange": {
             "start": {
-              "line": 92,
+              "line": 88,
               "column": 4
             },
             "end": {
-              "line": 95,
+              "line": 91,
               "column": 5
             }
           },
@@ -43039,11 +39388,11 @@
           "description": "Shows a loading overlay to indicate data will be updated",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -43055,11 +39404,11 @@
           "description": "List of selected rows/items in `data`.",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 112,
               "column": 4
             },
             "end": {
-              "line": 119,
+              "line": 115,
               "column": 5
             }
           },
@@ -43071,11 +39420,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 117,
               "column": 4
             },
             "end": {
-              "line": 124,
+              "line": 120,
               "column": 5
             }
           },
@@ -43087,11 +39436,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 126,
+              "line": 122,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 126,
               "column": 5
             }
           },
@@ -43103,11 +39452,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 128,
               "column": 4
             },
             "end": {
-              "line": 136,
+              "line": 132,
               "column": 5
             }
           },
@@ -43119,11 +39468,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 138,
+              "line": 134,
               "column": 4
             },
             "end": {
-              "line": 141,
+              "line": 137,
               "column": 5
             }
           },
@@ -43135,11 +39484,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 143,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 147,
+              "line": 143,
               "column": 5
             }
           },
@@ -43151,11 +39500,11 @@
           "description": "The column name to group on.",
           "sourceRange": {
             "start": {
-              "line": 151,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 155,
+              "line": 151,
               "column": 5
             }
           },
@@ -43167,11 +39516,11 @@
           "description": "The column that matches the current `groupOn` value.",
           "sourceRange": {
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 165,
+              "line": 161,
               "column": 5
             }
           },
@@ -43183,11 +39532,11 @@
           "description": "Items matching current set filter(s)",
           "sourceRange": {
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 174,
+              "line": 170,
               "column": 5
             }
           },
@@ -43199,11 +39548,11 @@
           "description": "Grouped items structure after filtering.",
           "sourceRange": {
             "start": {
-              "line": 179,
+              "line": 175,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -43215,11 +39564,11 @@
           "description": "Sorted items structure after filtering and grouping.",
           "sourceRange": {
             "start": {
-              "line": 186,
+              "line": 182,
               "column": 4
             },
             "end": {
-              "line": 189,
+              "line": 185,
               "column": 5
             }
           },
@@ -43231,11 +39580,11 @@
           "description": "List of columns definition for this table.",
           "sourceRange": {
             "start": {
-              "line": 207,
+              "line": 203,
               "column": 4
             },
             "end": {
-              "line": 210,
+              "line": 206,
               "column": 5
             }
           },
@@ -43247,11 +39596,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 212,
+              "line": 208,
               "column": 4
             },
             "end": {
-              "line": 218,
+              "line": 214,
               "column": 5
             }
           },
@@ -43263,11 +39612,11 @@
           "description": "List of <b>visible</b> columns.",
           "sourceRange": {
             "start": {
-              "line": 223,
+              "line": 219,
               "column": 4
             },
             "end": {
-              "line": 227,
+              "line": 223,
               "column": 5
             }
           },
@@ -43279,11 +39628,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 229,
+              "line": 225,
               "column": 4
             },
             "end": {
-              "line": 232,
+              "line": 228,
               "column": 5
             }
           },
@@ -43295,16 +39644,32 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 239,
+              "line": 235,
               "column": 4
             },
             "end": {
-              "line": 241,
+              "line": 237,
               "column": 5
             }
           },
           "metadata": {},
           "type": "string | null | undefined"
+        },
+        {
+          "name": "t",
+          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
+          "sourceRange": {
+            "start": {
+              "line": 256,
+              "column": 4
+            },
+            "end": {
+              "line": 261,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined"
         }
       ],
       "events": [
@@ -43386,11 +39751,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 185,
+              "line": 181,
               "column": 5
             },
             "end": {
-              "line": 185,
+              "line": 181,
               "column": 46
             }
           }
@@ -43401,11 +39766,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 5
             },
             "end": {
-              "line": 188,
+              "line": 184,
               "column": 44
             }
           }
@@ -43416,11 +39781,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 189,
+              "line": 185,
               "column": 5
             },
             "end": {
-              "line": 189,
+              "line": 185,
               "column": 41
             }
           }
@@ -43431,11 +39796,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 218,
+              "line": 214,
               "column": 3
             },
             "end": {
-              "line": 218,
+              "line": 214,
               "column": 33
             }
           }
@@ -43443,350 +39808,101 @@
       ],
       "tagname": "cosmoz-omnitable",
       "mixins": [
-        "Polymer.IronResizableBehavior"
+        "Polymer.IronResizableBehavior",
+        "Cosmoz.TranslatableBehavior"
       ]
     }
   ],
   "mixins": [
     {
-      "description": "Prepares instances of templates and re-uses recycled instances.",
-      "summary": "",
-      "path": "cosmoz-omnitable-templatize-mixin.html",
-      "properties": [],
-      "methods": [
-        {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          }
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          }
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          }
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 77,
-              "column": 2
-            },
-            "end": {
-              "line": 80,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          }
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          }
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          }
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          }
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        }
-      ],
-      "staticMethods": [],
-      "demos": [],
-      "metadata": {},
-      "sourceRange": {
-        "start": {
-          "line": 9,
-          "column": 1
-        },
-        "end": {
-          "line": 205,
-          "column": 3
-        }
-      },
-      "privacy": "public",
-      "name": "Cosmoz.OmnitableTemplatizeMixin",
-      "attributes": [],
-      "events": [],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
-      "slots": []
-    },
-    {
       "description": "",
       "summary": "",
       "path": "cosmoz-omnitable-column-mixin.html",
       "properties": [
+        {
+          "name": "editableTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 293,
+              "column": 2
+            },
+            "end": {
+              "line": 296,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "cellTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 297,
+              "column": 2
+            },
+            "end": {
+              "line": 300,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "dataTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 302,
+              "column": 2
+            },
+            "end": {
+              "line": 304,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "headerTemplatizer",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 306,
+              "column": 2
+            },
+            "end": {
+              "line": 308,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
         {
           "name": "title",
           "type": "string | null | undefined",
@@ -43794,11 +39910,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -43816,11 +39932,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -43837,11 +39953,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -43860,11 +39976,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -43882,11 +39998,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -43905,11 +40021,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -43927,11 +40043,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -43950,11 +40066,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -43972,11 +40088,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -43995,11 +40111,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -44016,11 +40132,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -44037,11 +40153,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -44059,11 +40175,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -44081,11 +40197,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -44104,11 +40220,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -44126,11 +40242,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -44148,11 +40264,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -44170,11 +40286,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -44192,11 +40308,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -44214,11 +40330,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -44236,11 +40352,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -44258,11 +40374,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -44279,11 +40395,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -44301,11 +40417,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
@@ -44315,6 +40431,28 @@
             }
           },
           "defaultValue": "0"
+        },
+        {
+          "name": "cellTemplate",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_cellTemplateChanged\"",
+              "attributeType": "Object"
+            }
+          }
         },
         {
           "name": "cellTitleFn",
@@ -44401,344 +40539,64 @@
               "attributeType": "String"
             }
           }
+        },
+        {
+          "name": "_dataTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 223,
+              "column": 4
+            },
+            "end": {
+              "line": 226,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "_headerTemplatizer",
+          "type": "Object | null | undefined",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 228,
+              "column": 4
+            },
+            "end": {
+              "line": 231,
+              "column": 5
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Object"
+            }
+          },
+          "defaultValue": "null"
         }
       ],
       "methods": [
-        {
-          "name": "getTemplateInstance",
-          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 28,
-              "column": 2
-            },
-            "end": {
-              "line": 43,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the template instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "recycleInstance",
-          "description": "Marks an instance for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 61,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the detached instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "isRecycledInstance",
-          "description": "Tests whether the instance is marked for re-use.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 68,
-              "column": 2
-            },
-            "end": {
-              "line": 70,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            }
-          ],
-          "return": {
-            "type": "Boolean",
-            "desc": "true if instance is recycled"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Cleans up references to recycled instances when the element is detached.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 77,
-              "column": 2
-            },
-            "end": {
-              "line": 80,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_reuseInstance",
-          "description": "Reuses an already created instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 103,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "an instance"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instances properties"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_createInstance",
-          "description": "Creates a new instance of the required type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 112,
-              "column": 2
-            },
-            "end": {
-              "line": 118,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "the instance's properies"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstance",
-            "desc": "the instance"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_getTemplateCtor",
-          "description": "Searches for a template node of the required type and templatizes it.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 127,
-              "column": 2
-            },
-            "end": {
-              "line": 149,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "TemplateInstanceBase",
-            "desc": "the templatized template"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardHostProp",
-          "description": "Generates a function that forwards properties to instances of a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 157,
-              "column": 2
-            },
-            "end": {
-              "line": 173,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "type",
-              "type": "String",
-              "description": "the type of the template"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "a function that forwards props to instances"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperty",
-          "description": "Forward one property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 183,
-              "column": 2
-            },
-            "end": {
-              "line": 189,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Property name."
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "Property value."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "false",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
-        {
-          "name": "_forwardProperties",
-          "description": "Forward many properties.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-templatize-mixin.html",
-            "start": {
-              "line": 198,
-              "column": 2
-            },
-            "end": {
-              "line": 204,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "object",
-              "description": "Instance."
-            },
-            {
-              "name": "props",
-              "type": "object",
-              "defaultValue": "{}",
-              "description": "Properties to forward."
-            },
-            {
-              "name": "flush",
-              "type": "boolean",
-              "defaultValue": "true",
-              "description": "Whether to flush properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
-        },
         {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 232,
+              "line": 242,
               "column": 2
             },
             "end": {
-              "line": 235,
+              "line": 246,
               "column": 3
             }
           },
@@ -44749,16 +40607,61 @@
           }
         },
         {
+          "name": "_createTemplatizer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 248,
+              "column": 2
+            },
+            "end": {
+              "line": 272,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateElementOrSelector"
+            }
+          ]
+        },
+        {
+          "name": "_cellTemplateChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 274,
+              "column": 2
+            },
+            "end": {
+              "line": 278,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cellTemplate"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_externalValuesChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 237,
+              "line": 280,
               "column": 2
             },
             "end": {
-              "line": 248,
+              "line": 291,
               "column": 3
             }
           },
@@ -44773,16 +40676,57 @@
           }
         },
         {
+          "name": "getHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 310,
+              "column": 2
+            },
+            "end": {
+              "line": 315,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "releaseHeaderTemplateInstance",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 317,
+              "column": 2
+            },
+            "end": {
+              "line": 321,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 254,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 329,
               "column": 3
             }
           },
@@ -44799,11 +40743,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 257,
+              "line": 330,
               "column": 2
             },
             "end": {
-              "line": 263,
+              "line": 336,
               "column": 3
             }
           },
@@ -44824,11 +40768,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 264,
+              "line": 337,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 342,
               "column": 3
             }
           },
@@ -44849,11 +40793,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 271,
+              "line": 344,
               "column": 2
             },
             "end": {
-              "line": 283,
+              "line": 356,
               "column": 3
             }
           },
@@ -44879,11 +40823,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 285,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 287,
+              "line": 360,
               "column": 3
             }
           },
@@ -44903,11 +40847,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 289,
+              "line": 362,
               "column": 2
             },
             "end": {
-              "line": 297,
+              "line": 370,
               "column": 3
             }
           },
@@ -44927,11 +40871,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 299,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 309,
+              "line": 382,
               "column": 3
             }
           },
@@ -44960,11 +40904,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 311,
+              "line": 384,
               "column": 2
             },
             "end": {
-              "line": 322,
+              "line": 395,
               "column": 3
             }
           },
@@ -44977,11 +40921,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 324,
+              "line": 397,
               "column": 2
             },
             "end": {
-              "line": 326,
+              "line": 399,
               "column": 3
             }
           },
@@ -44997,11 +40941,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 333,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 350,
+              "line": 423,
               "column": 3
             }
           },
@@ -45024,11 +40968,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 352,
+              "line": 425,
               "column": 2
             },
             "end": {
-              "line": 359,
+              "line": 432,
               "column": 3
             }
           },
@@ -45041,11 +40985,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 361,
+              "line": 434,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 440,
               "column": 3
             }
           },
@@ -45065,11 +41009,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 369,
+              "line": 442,
               "column": 2
             },
             "end": {
-              "line": 374,
+              "line": 447,
               "column": 3
             }
           },
@@ -45089,11 +41033,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 376,
+              "line": 449,
               "column": 2
             },
             "end": {
-              "line": 378,
+              "line": 451,
               "column": 3
             }
           },
@@ -45109,11 +41053,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 380,
+              "line": 453,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 455,
               "column": 3
             }
           },
@@ -45129,11 +41073,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 383,
+              "line": 456,
               "column": 2
             },
             "end": {
-              "line": 385,
+              "line": 458,
               "column": 3
             }
           },
@@ -45149,11 +41093,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 387,
+              "line": 460,
               "column": 2
             },
             "end": {
-              "line": 389,
+              "line": 466,
               "column": 3
             }
           },
@@ -45169,11 +41113,11 @@
           "privacy": "private",
           "sourceRange": {
             "start": {
-              "line": 391,
+              "line": 468,
               "column": 2
             },
             "end": {
-              "line": 393,
+              "line": 470,
               "column": 3
             }
           },
@@ -45189,11 +41133,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 395,
+              "line": 472,
               "column": 2
             },
             "end": {
-              "line": 413,
+              "line": 490,
               "column": 3
             }
           },
@@ -45211,11 +41155,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 415,
+              "line": 492,
               "column": 2
             },
             "end": {
-              "line": 425,
+              "line": 502,
               "column": 3
             }
           },
@@ -45232,11 +41176,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 13,
+          "line": 9,
           "column": 1
         },
         "end": {
-          "line": 426,
+          "line": 503,
           "column": 3
         }
       },
@@ -45248,11 +41192,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 16,
+              "line": 12,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 15,
               "column": 5
             }
           },
@@ -45264,11 +41208,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 23,
+              "line": 19,
               "column": 5
             }
           },
@@ -45280,11 +41224,11 @@
           "description": "If the column should be disabled until enabled with enabledColumns",
           "sourceRange": {
             "start": {
-              "line": 28,
+              "line": 24,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -45296,11 +41240,11 @@
           "description": "If true, the column will be editable by using an input element for rendering.",
           "sourceRange": {
             "start": {
-              "line": 37,
+              "line": 33,
               "column": 4
             },
             "end": {
-              "line": 40,
+              "line": 36,
               "column": 5
             }
           },
@@ -45312,11 +41256,11 @@
           "description": "Values to filter this column will be managed outside of omnitable",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 41,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 45,
               "column": 5
             }
           },
@@ -45328,11 +41272,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 47,
               "column": 4
             },
             "end": {
-              "line": 57,
+              "line": 53,
               "column": 5
             }
           },
@@ -45344,11 +41288,11 @@
           "description": "Indicates whether the user has engaged with the\nheader/filter component of the column",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -45360,11 +41304,11 @@
           "description": "Indicate that the column is loading/performing work",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 68,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 71,
               "column": 5
             }
           },
@@ -45376,11 +41320,11 @@
           "description": "Whether the column wants a list of all distinct values for the column in `values`",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 84,
+              "line": 80,
               "column": 5
             }
           },
@@ -45392,11 +41336,11 @@
           "description": "Column name for use with enabledColumns",
           "sourceRange": {
             "start": {
-              "line": 89,
+              "line": 85,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 87,
               "column": 5
             }
           },
@@ -45408,11 +41352,11 @@
           "description": "All values for this column.",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 98,
+              "line": 94,
               "column": 5
             }
           },
@@ -45424,11 +41368,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 103,
+              "line": 99,
               "column": 5
             }
           },
@@ -45440,11 +41384,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 101,
               "column": 4
             },
             "end": {
-              "line": 108,
+              "line": 104,
               "column": 5
             }
           },
@@ -45456,11 +41400,11 @@
           "description": "Used to indicate that an element using this behavior is a column definition that can be used\nin cosmoz-omnitable",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 110,
               "column": 4
             },
             "end": {
-              "line": 118,
+              "line": 114,
               "column": 5
             }
           },
@@ -45472,11 +41416,11 @@
           "description": "Base width of this column.",
           "sourceRange": {
             "start": {
-              "line": 123,
+              "line": 119,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 122,
               "column": 5
             }
           },
@@ -45488,11 +41432,11 @@
           "description": "Base width of this column when in edit mode.",
           "sourceRange": {
             "start": {
-              "line": 131,
+              "line": 127,
               "column": 4
             },
             "end": {
-              "line": 134,
+              "line": 130,
               "column": 5
             }
           },
@@ -45504,11 +41448,11 @@
           "description": "The minimum width of this column.",
           "sourceRange": {
             "start": {
-              "line": 139,
+              "line": 135,
               "column": 4
             },
             "end": {
-              "line": 142,
+              "line": 138,
               "column": 5
             }
           },
@@ -45520,11 +41464,11 @@
           "description": "The minimum width of this column in edit mode.",
           "sourceRange": {
             "start": {
-              "line": 147,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 150,
+              "line": 146,
               "column": 5
             }
           },
@@ -45536,11 +41480,11 @@
           "description": "Width growing factor for this column.",
           "sourceRange": {
             "start": {
-              "line": 155,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 158,
+              "line": 154,
               "column": 5
             }
           },
@@ -45552,11 +41496,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 160,
+              "line": 156,
               "column": 4
             },
             "end": {
-              "line": 163,
+              "line": 159,
               "column": 5
             }
           },
@@ -45568,11 +41512,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 161,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 164,
               "column": 5
             }
           },
@@ -45584,11 +41528,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 170,
+              "line": 166,
               "column": 4
             },
             "end": {
-              "line": 172,
+              "line": 168,
               "column": 5
             }
           },
@@ -45600,11 +41544,11 @@
           "description": "Allow column to overflow without triggering\ncolumn folding (good for long descriptions)",
           "sourceRange": {
             "start": {
-              "line": 178,
+              "line": 174,
               "column": 4
             },
             "end": {
-              "line": 181,
+              "line": 177,
               "column": 5
             }
           },
@@ -45616,16 +41560,32 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 183,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined"
+        },
+        {
+          "name": "cell-template",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 184,
+              "column": 4
+            },
+            "end": {
+              "line": 187,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "Object | null | undefined"
         },
         {
           "name": "cell-title-fn",
@@ -45697,10 +41657,7 @@
         "cssVariables": [],
         "selectors": []
       },
-      "slots": [],
-      "mixins": [
-        "Cosmoz.OmnitableTemplatizeMixin"
-      ]
+      "slots": []
     },
     {
       "description": "",
@@ -45714,11 +41671,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 128,
+              "line": 41,
               "column": 2
             },
             "end": {
-              "line": 130,
+              "line": 43,
               "column": 3
             }
           },
@@ -45735,11 +41692,53 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 137,
+              "line": 50,
               "column": 2
             },
             "end": {
-              "line": 139,
+              "line": 52,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "elements",
+          "type": "?",
+          "description": "Get an array of the elements generated by this repeater\n\t\t ",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 94,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "templateInstances",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 101,
+              "column": 2
+            },
+            "end": {
+              "line": 106,
               "column": 3
             }
           },
@@ -45756,11 +41755,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -45777,11 +41776,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -45795,179 +41794,16 @@
       ],
       "methods": [
         {
-          "name": "trackColumns",
-          "description": "Adds an observer to render the cells when the columns are changed.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 48,
-              "column": 2
-            },
-            "end": {
-              "line": 60,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "stopTrackingColumns",
-          "description": "Stops reacting to column changes.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 66,
-              "column": 2
-            },
-            "end": {
-              "line": 73,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "renderCells",
-          "description": "Renders all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 79,
-              "column": 2
-            },
-            "end": {
-              "line": 81,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "destroyCells",
-          "description": "Destroys all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 87,
-              "column": 2
-            },
-            "end": {
-              "line": 89,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "forwardChange",
-          "description": "Forwards a property change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 97,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "String",
-              "description": "the property"
-            },
-            {
-              "name": "value",
-              "type": "any",
-              "description": "the new value"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "forwardPathChange",
-          "description": "Forwards a path change to all cells.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 106,
-              "column": 2
-            },
-            "end": {
-              "line": 110,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changeRecord",
-              "type": "Object",
-              "description": "the change record"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "forEachElement",
-          "description": "Runs a callback on each element.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 117,
-              "column": 2
-            },
-            "end": {
-              "line": 119,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "callback",
-              "type": "OmnitableRepeaterMixin~forEachElementCallback",
-              "description": "the callback"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_getTemplateInstance",
           "description": "Get a template instance for the specified column\nMust be defined in implementors.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 148,
+              "line": 60,
               "column": 2
             },
             "end": {
-              "line": 148,
+              "line": 60,
               "column": 33
             }
           },
@@ -45975,7 +41811,7 @@
           "params": [
             {
               "name": "column",
-              "type": "OmnitableColumnMixin",
+              "type": "Object",
               "description": "The column."
             }
           ],
@@ -45985,16 +41821,104 @@
           }
         },
         {
-          "name": "_configureElement",
-          "description": "Configure a newly created repeated element",
+          "name": "_detachTemplateInstance",
+          "description": "Detach and release the template instance associated with\nthe specified column and rendered in the specified element.\nMust be defined in implementors.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 160,
+              "line": 71,
               "column": 2
             },
             "end": {
-              "line": 169,
+              "line": 71,
+              "column": 55
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "Object",
+              "description": "The instance."
+            },
+            {
+              "name": "column",
+              "type": "Object",
+              "description": "The column."
+            },
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "undefined"
+          }
+        },
+        {
+          "name": "_configureElement",
+          "description": "Configure a newly created repeated element\nMust be defined in implementors.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 2
+            },
+            "end": {
+              "line": 79,
+              "column": 31
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "undefined"
+          }
+        },
+        {
+          "name": "_configureTemplateInstance",
+          "description": "Configure a newly created cell template instance\nMust be defined in implementors.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 87,
+              "column": 2
+            },
+            "end": {
+              "line": 87,
+              "column": 41
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "Object",
+              "description": "The instance."
+            }
+          ],
+          "return": {
+            "type": "undefined"
+          }
+        },
+        {
+          "name": "getElementTemplateInstance",
+          "description": "Get the template instance rendered by the specified element.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 113,
+              "column": 2
+            },
+            "end": {
+              "line": 115,
               "column": 3
             }
           },
@@ -46002,22 +41926,40 @@
           "params": [
             {
               "name": "element",
-              "type": "HTMLElement",
-              "description": "the root cell element"
-            },
-            {
-              "name": "column",
-              "type": "OmnitableColumnMixin",
-              "description": "the column"
-            },
-            {
-              "name": "instance",
-              "type": "TemplateInstance",
-              "description": "the template instance"
+              "type": "Object",
+              "description": "The element."
             }
           ],
           "return": {
-            "type": "void"
+            "type": "Object",
+            "desc": "The instance."
+          }
+        },
+        {
+          "name": "getElementColumn",
+          "description": "Get the column that was used to rendered the specified element",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 122,
+              "column": 2
+            },
+            "end": {
+              "line": 124,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "element",
+              "type": "Object",
+              "description": "The element."
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "The column."
           }
         },
         {
@@ -46026,11 +41968,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 171,
+              "line": 126,
               "column": 2
             },
             "end": {
-              "line": 195,
+              "line": 150,
               "column": 3
             }
           },
@@ -46050,11 +41992,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 197,
+              "line": 152,
               "column": 2
             },
             "end": {
-              "line": 206,
+              "line": 161,
               "column": 3
             }
           },
@@ -46074,11 +42016,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 163,
               "column": 2
             },
             "end": {
-              "line": 234,
+              "line": 201,
               "column": 3
             }
           },
@@ -46101,11 +42043,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 236,
+              "line": 203,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 211,
               "column": 3
             }
           },
@@ -46128,11 +42070,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 246,
+              "line": 213,
               "column": 2
             },
             "end": {
-              "line": 262,
+              "line": 229,
               "column": 3
             }
           },
@@ -46150,16 +42092,50 @@
           }
         },
         {
+          "name": "_forwardProperty",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 231,
+              "column": 2
+            },
+            "end": {
+              "line": 237,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance"
+            },
+            {
+              "name": "name"
+            },
+            {
+              "name": "value"
+            },
+            {
+              "name": "flush",
+              "defaultValue": "false"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 264,
+              "line": 239,
               "column": 2
             },
             "end": {
-              "line": 269,
+              "line": 244,
               "column": 3
             }
           },
@@ -46173,6 +42149,10 @@
             },
             {
               "name": "value"
+            },
+            {
+              "name": "isPathNotification",
+              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -46189,11 +42169,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 24,
+          "line": 14,
           "column": 1
         },
         "end": {
-          "line": 270,
+          "line": 245,
           "column": 3
         }
       },
@@ -46205,11 +42185,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 27,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 29,
+              "line": 19,
               "column": 5
             }
           },
@@ -46221,11 +42201,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 31,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 34,
+              "line": 24,
               "column": 5
             }
           },
@@ -46252,11 +42232,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 25,
+              "line": 21,
               "column": 5
             }
           },
@@ -46275,11 +42255,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 27,
+              "line": 23,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -46296,11 +42276,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 34,
+              "line": 30,
               "column": 4
             },
             "end": {
-              "line": 37,
+              "line": 33,
               "column": 5
             }
           },
@@ -46318,11 +42298,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 39,
+              "line": 35,
               "column": 4
             },
             "end": {
-              "line": 42,
+              "line": 38,
               "column": 5
             }
           },
@@ -46340,11 +42320,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -46362,11 +42342,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 50,
               "column": 5
             }
           },
@@ -46383,11 +42363,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 56,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 55,
               "column": 5
             }
           },
@@ -46405,11 +42385,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 61,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -46427,11 +42407,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 68,
               "column": 5
             }
           },
@@ -46450,11 +42430,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 83,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 85,
+              "line": 81,
               "column": 3
             }
           },
@@ -46470,11 +42450,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 95,
+              "line": 91,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 3
             }
           },
@@ -46507,11 +42487,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 113,
+              "line": 109,
               "column": 2
             },
             "end": {
-              "line": 115,
+              "line": 111,
               "column": 3
             }
           },
@@ -46524,11 +42504,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 124,
+              "line": 120,
               "column": 2
             },
             "end": {
-              "line": 133,
+              "line": 129,
               "column": 3
             }
           },
@@ -46556,11 +42536,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 135,
+              "line": 131,
               "column": 2
             },
             "end": {
-              "line": 141,
+              "line": 137,
               "column": 3
             }
           },
@@ -46581,11 +42561,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 143,
+              "line": 139,
               "column": 2
             },
             "end": {
-              "line": 153,
+              "line": 149,
               "column": 3
             }
           },
@@ -46606,11 +42586,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 154,
+              "line": 150,
               "column": 2
             },
             "end": {
-              "line": 156,
+              "line": 152,
               "column": 3
             }
           },
@@ -46626,11 +42606,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 158,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 157,
               "column": 3
             }
           },
@@ -46651,11 +42631,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 169,
+              "line": 165,
               "column": 2
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 3
             }
           },
@@ -46678,11 +42658,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 2
             },
             "end": {
-              "line": 204,
+              "line": 200,
               "column": 3
             }
           },
@@ -46708,11 +42688,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 206,
+              "line": 202,
               "column": 2
             },
             "end": {
-              "line": 214,
+              "line": 210,
               "column": 3
             }
           },
@@ -46725,11 +42705,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 216,
+              "line": 212,
               "column": 2
             },
             "end": {
-              "line": 230,
+              "line": 226,
               "column": 3
             }
           },
@@ -46749,11 +42729,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 232,
+              "line": 228,
               "column": 2
             },
             "end": {
-              "line": 249,
+              "line": 245,
               "column": 3
             }
           },
@@ -46770,11 +42750,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 251,
+              "line": 247,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 252,
               "column": 3
             }
           },
@@ -46794,11 +42774,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 258,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 256,
               "column": 3
             }
           },
@@ -46815,11 +42795,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 262,
+              "line": 258,
               "column": 2
             },
             "end": {
-              "line": 268,
+              "line": 264,
               "column": 3
             }
           },
@@ -46836,11 +42816,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 270,
+              "line": 266,
               "column": 2
             },
             "end": {
-              "line": 275,
+              "line": 271,
               "column": 3
             }
           },
@@ -46853,11 +42833,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 283,
+              "line": 279,
               "column": 2
             },
             "end": {
-              "line": 293,
+              "line": 289,
               "column": 3
             }
           },
@@ -46879,11 +42859,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 299,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 321,
               "column": 3
             }
           },
@@ -46899,11 +42879,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 327,
+              "line": 323,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 336,
               "column": 3
             }
           },
@@ -46919,11 +42899,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 342,
+              "line": 338,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 358,
               "column": 3
             }
           },
@@ -46943,11 +42923,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 364,
+              "line": 360,
               "column": 2
             },
             "end": {
-              "line": 371,
+              "line": 367,
               "column": 3
             }
           },
@@ -46960,11 +42940,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 373,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 380,
               "column": 3
             }
           },
@@ -46982,11 +42962,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 386,
+              "line": 382,
               "column": 2
             },
             "end": {
-              "line": 400,
+              "line": 396,
               "column": 3
             }
           },
@@ -47003,11 +42983,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 402,
+              "line": 398,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 404,
               "column": 3
             }
           },
@@ -47024,11 +43004,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 410,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 412,
+              "line": 408,
               "column": 3
             }
           },
@@ -47048,11 +43028,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 13,
+          "line": 9,
           "column": 0
         },
         "end": {
-          "line": 414,
+          "line": 410,
           "column": 1
         }
       },
@@ -47064,11 +43044,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 25,
+              "line": 21,
               "column": 5
             }
           },
@@ -47080,11 +43060,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 27,
+              "line": 23,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -47096,11 +43076,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 34,
+              "line": 30,
               "column": 4
             },
             "end": {
-              "line": 37,
+              "line": 33,
               "column": 5
             }
           },
@@ -47112,11 +43092,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 39,
+              "line": 35,
               "column": 4
             },
             "end": {
-              "line": 42,
+              "line": 38,
               "column": 5
             }
           },
@@ -47128,11 +43108,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -47160,11 +43140,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 25,
+              "line": 21,
               "column": 5
             }
           },
@@ -47185,11 +43165,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 27,
+              "line": 23,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -47207,12 +43187,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {
@@ -47229,12 +43209,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {
@@ -47252,11 +43232,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -47276,11 +43256,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 49,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 50,
               "column": 5
             }
           },
@@ -47299,11 +43279,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 56,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 59,
+              "line": 55,
               "column": 5
             }
           },
@@ -47323,11 +43303,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 61,
+              "line": 57,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 63,
               "column": 5
             }
           },
@@ -47347,11 +43327,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 69,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 72,
+              "line": 68,
               "column": 5
             }
           },
@@ -47370,12 +43350,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 48,
-              "column": 5
+              "line": 30,
+              "column": 4
             },
             "end": {
-              "line": 51,
-              "column": 6
+              "line": 33,
+              "column": 5
             }
           },
           "metadata": {
@@ -47392,12 +43372,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 53,
-              "column": 5
+              "line": 35,
+              "column": 4
             },
             "end": {
-              "line": 56,
-              "column": 6
+              "line": 38,
+              "column": 5
             }
           },
           "metadata": {
@@ -47414,12 +43394,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 58,
-              "column": 5
+              "line": 40,
+              "column": 4
             },
             "end": {
-              "line": 61,
-              "column": 6
+              "line": 43,
+              "column": 5
             }
           },
           "metadata": {
@@ -47436,12 +43416,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 67,
-              "column": 5
+              "line": 49,
+              "column": 4
             },
             "end": {
-              "line": 70,
-              "column": 6
+              "line": 52,
+              "column": 5
             }
           },
           "metadata": {
@@ -47458,12 +43438,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {
@@ -47482,11 +43462,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 83,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 85,
+              "line": 81,
               "column": 3
             }
           },
@@ -47504,11 +43484,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 95,
+              "line": 91,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 107,
               "column": 3
             }
           },
@@ -47542,12 +43522,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 121,
-              "column": 3
+              "line": 89,
+              "column": 2
             },
             "end": {
-              "line": 123,
-              "column": 4
+              "line": 91,
+              "column": 3
             }
           },
           "metadata": {},
@@ -47559,12 +43539,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 132,
-              "column": 3
+              "line": 100,
+              "column": 2
             },
             "end": {
-              "line": 138,
-              "column": 4
+              "line": 106,
+              "column": 3
             }
           },
           "metadata": {},
@@ -47592,11 +43572,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 135,
+              "line": 131,
               "column": 2
             },
             "end": {
-              "line": 141,
+              "line": 137,
               "column": 3
             }
           },
@@ -47618,12 +43598,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 148,
-              "column": 3
+              "line": 116,
+              "column": 2
             },
             "end": {
-              "line": 157,
-              "column": 4
+              "line": 125,
+              "column": 3
             }
           },
           "metadata": {},
@@ -47657,12 +43637,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 184,
-              "column": 3
+              "line": 127,
+              "column": 2
             },
             "end": {
-              "line": 193,
-              "column": 4
+              "line": 136,
+              "column": 3
             }
           },
           "metadata": {},
@@ -47683,11 +43663,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 158,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 157,
               "column": 3
             }
           },
@@ -47710,11 +43690,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 169,
+              "line": 165,
               "column": 2
             },
             "end": {
-              "line": 186,
+              "line": 182,
               "column": 3
             }
           },
@@ -47739,11 +43719,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 188,
+              "line": 184,
               "column": 2
             },
             "end": {
-              "line": 204,
+              "line": 200,
               "column": 3
             }
           },
@@ -47771,11 +43751,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 206,
+              "line": 202,
               "column": 2
             },
             "end": {
-              "line": 214,
+              "line": 210,
               "column": 3
             }
           },
@@ -47790,11 +43770,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 216,
+              "line": 212,
               "column": 2
             },
             "end": {
-              "line": 230,
+              "line": 226,
               "column": 3
             }
           },
@@ -47816,11 +43796,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 232,
+              "line": 228,
               "column": 2
             },
             "end": {
-              "line": 249,
+              "line": 245,
               "column": 3
             }
           },
@@ -47839,11 +43819,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 251,
+              "line": 247,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 252,
               "column": 3
             }
           },
@@ -47865,11 +43845,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 258,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 260,
+              "line": 256,
               "column": 3
             }
           },
@@ -47887,12 +43867,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 199,
-              "column": 3
+              "line": 142,
+              "column": 2
             },
             "end": {
-              "line": 205,
-              "column": 4
+              "line": 148,
+              "column": 3
             }
           },
           "metadata": {},
@@ -47909,11 +43889,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 270,
+              "line": 266,
               "column": 2
             },
             "end": {
-              "line": 275,
+              "line": 271,
               "column": 3
             }
           },
@@ -47928,11 +43908,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 283,
+              "line": 279,
               "column": 2
             },
             "end": {
-              "line": 293,
+              "line": 289,
               "column": 3
             }
           },
@@ -47956,11 +43936,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 299,
+              "line": 295,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 321,
               "column": 3
             }
           },
@@ -47978,11 +43958,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 327,
+              "line": 323,
               "column": 2
             },
             "end": {
-              "line": 340,
+              "line": 336,
               "column": 3
             }
           },
@@ -48000,11 +43980,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 342,
+              "line": 338,
               "column": 2
             },
             "end": {
-              "line": 362,
+              "line": 358,
               "column": 3
             }
           },
@@ -48026,11 +44006,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 364,
+              "line": 360,
               "column": 2
             },
             "end": {
-              "line": 371,
+              "line": 367,
               "column": 3
             }
           },
@@ -48045,11 +44025,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 373,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 384,
+              "line": 380,
               "column": 3
             }
           },
@@ -48069,11 +44049,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 386,
+              "line": 382,
               "column": 2
             },
             "end": {
-              "line": 400,
+              "line": 396,
               "column": 3
             }
           },
@@ -48092,11 +44072,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 402,
+              "line": 398,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 404,
               "column": 3
             }
           },
@@ -48115,11 +44095,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 410,
+              "line": 406,
               "column": 2
             },
             "end": {
-              "line": 412,
+              "line": 408,
               "column": 3
             }
           },
@@ -48140,12 +44120,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 86,
-              "column": 3
+              "line": 68,
+              "column": 2
             },
             "end": {
-              "line": 119,
-              "column": 4
+              "line": 87,
+              "column": 3
             }
           },
           "metadata": {},
@@ -48172,71 +44152,17 @@
           }
         },
         {
-          "name": "getAbsoluteISOString",
-          "description": "Computes the local timezone and adds it to a local ISO string",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 164,
-              "column": 3
-            },
-            "end": {
-              "line": 172,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string, without timezone info"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "an ISO date string, with timezone info"
-          }
-        },
-        {
-          "name": "_getTimezoneString",
-          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 179,
-              "column": 3
-            },
-            "end": {
-              "line": 182,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "localISOString",
-              "type": "String",
-              "description": "an ISO date string"
-            }
-          ],
-          "return": {
-            "type": "String",
-            "desc": "the ISO timezone"
-          }
-        },
-        {
           "name": "_computeFormatter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 195,
-              "column": 3
+              "line": 138,
+              "column": 2
             },
             "end": {
-              "line": 197,
-              "column": 4
+              "line": 140,
+              "column": 3
             }
           },
           "metadata": {},
@@ -48252,12 +44178,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 207,
-              "column": 3
+              "line": 150,
+              "column": 2
             },
             "end": {
-              "line": 218,
-              "column": 4
+              "line": 161,
+              "column": 3
             }
           },
           "metadata": {},
@@ -48276,12 +44202,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 220,
-              "column": 3
+              "line": 163,
+              "column": 2
             },
             "end": {
-              "line": 222,
-              "column": 4
+              "line": 175,
+              "column": 3
             }
           },
           "metadata": {},
@@ -48297,12 +44223,12 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 30,
-          "column": 1
+          "line": 12,
+          "column": 0
         },
         "end": {
-          "line": 224,
-          "column": 2
+          "line": 177,
+          "column": 1
         }
       },
       "privacy": "public",
@@ -48314,11 +44240,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 21,
+              "line": 17,
               "column": 4
             },
             "end": {
-              "line": 25,
+              "line": 21,
               "column": 5
             }
           },
@@ -48332,11 +44258,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 27,
+              "line": 23,
               "column": 4
             },
             "end": {
-              "line": 32,
+              "line": 28,
               "column": 5
             }
           },
@@ -48349,12 +44275,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 43,
-              "column": 5
+              "line": 25,
+              "column": 4
             },
             "end": {
-              "line": 46,
-              "column": 6
+              "line": 28,
+              "column": 5
             }
           },
           "metadata": {},
@@ -48365,12 +44291,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 38,
-              "column": 5
+              "line": 20,
+              "column": 4
             },
             "end": {
-              "line": 41,
-              "column": 6
+              "line": 23,
+              "column": 5
             }
           },
           "metadata": {},
@@ -48382,11 +44308,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 44,
+              "line": 40,
               "column": 4
             },
             "end": {
-              "line": 47,
+              "line": 43,
               "column": 5
             }
           },
@@ -48399,12 +44325,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 53,
-              "column": 5
+              "line": 35,
+              "column": 4
             },
             "end": {
-              "line": 56,
-              "column": 6
+              "line": 38,
+              "column": 5
             }
           },
           "metadata": {},
@@ -48415,12 +44341,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 58,
-              "column": 5
+              "line": 40,
+              "column": 4
             },
             "end": {
-              "line": 61,
-              "column": 6
+              "line": 43,
+              "column": 5
             }
           },
           "metadata": {},
@@ -48431,12 +44357,12 @@
           "description": "No need to grow, as the values in a date column should have known fixed width",
           "sourceRange": {
             "start": {
-              "line": 67,
-              "column": 5
+              "line": 49,
+              "column": 4
             },
             "end": {
-              "line": 70,
-              "column": 6
+              "line": 52,
+              "column": 5
             }
           },
           "metadata": {},
@@ -48447,12 +44373,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 71,
-              "column": 5
+              "line": 53,
+              "column": 4
             },
             "end": {
-              "line": 74,
-              "column": 6
+              "line": 56,
+              "column": 5
             }
           },
           "metadata": {},
@@ -48481,11 +44407,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 13,
+              "line": 10,
               "column": 4
             },
             "end": {
-              "line": 16,
+              "line": 13,
               "column": 5
             }
           },
@@ -48503,11 +44429,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 18,
+              "line": 15,
               "column": 4
             },
             "end": {
-              "line": 21,
+              "line": 18,
               "column": 5
             }
           },
@@ -48526,36 +44452,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 25,
+              "line": 22,
               "column": 2
             },
             "end": {
-              "line": 37,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath",
-              "defaultValue": "this.valuePath"
-            }
-          ]
-        },
-        {
-          "name": "toXlsxValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 39,
-              "column": 2
-            },
-            "end": {
-              "line": 41,
+              "line": 33,
               "column": 3
             }
           },
@@ -48576,11 +44477,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 10,
+          "line": 7,
           "column": 1
         },
         "end": {
-          "line": 43,
+          "line": 34,
           "column": 3
         }
       },
@@ -48592,11 +44493,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 13,
+              "line": 10,
               "column": 4
             },
             "end": {
-              "line": 16,
+              "line": 13,
               "column": 5
             }
           },
@@ -48608,11 +44509,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 18,
+              "line": 15,
               "column": 4
             },
             "end": {
-              "line": 21,
+              "line": 18,
               "column": 5
             }
           },

--- a/analysis.json
+++ b/analysis.json
@@ -4,41 +4,2878 @@
     {
       "description": "",
       "summary": "",
-      "path": "cosmoz-omnitable-templatizer.html",
-      "properties": [],
-      "methods": [
+      "path": "ui-helpers/cosmoz-clear-button.html",
+      "properties": [
         {
-          "name": "ready",
+          "name": "__dataClientsReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1148,
+              "column": 8
+            },
+            "end": {
+              "line": 1148,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPendingClients",
+          "type": "Array",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1150,
+              "column": 8
+            },
+            "end": {
+              "line": 1150,
+              "column": 34
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataToNotify",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1152,
+              "column": 8
+            },
+            "end": {
+              "line": 1152,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataLinkedPaths",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1154,
+              "column": 8
+            },
+            "end": {
+              "line": 1154,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHasPaths",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1156,
+              "column": 8
+            },
+            "end": {
+              "line": 1156,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataCompoundStorage",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1158,
+              "column": 8
+            },
+            "end": {
+              "line": 1158,
+              "column": 35
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHost",
+          "type": "Polymer_PropertyEffects",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1160,
+              "column": 8
+            },
+            "end": {
+              "line": 1160,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataTemp",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1162,
+              "column": 8
+            },
+            "end": {
+              "line": 1162,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataClientsInitialized",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1164,
+              "column": 8
+            },
+            "end": {
+              "line": 1164,
+              "column": 38
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__data",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1166,
+              "column": 8
+            },
+            "end": {
+              "line": 1166,
+              "column": 20
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPending",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1168,
+              "column": 8
+            },
+            "end": {
+              "line": 1168,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataOld",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1170,
+              "column": 8
+            },
+            "end": {
+              "line": 1170,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__computeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1172,
+              "column": 8
+            },
+            "end": {
+              "line": 1172,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__reflectEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1174,
+              "column": 8
+            },
+            "end": {
+              "line": 1174,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__notifyEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1176,
+              "column": 8
+            },
+            "end": {
+              "line": 1176,
+              "column": 29
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__propagateEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1178,
+              "column": 8
+            },
+            "end": {
+              "line": 1178,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__observeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1180,
+              "column": 8
+            },
+            "end": {
+              "line": 1180,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__readOnly",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1182,
+              "column": 8
+            },
+            "end": {
+              "line": 1182,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__templateInfo",
+          "type": "!TemplateInfo",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1184,
+              "column": 8
+            },
+            "end": {
+              "line": 1184,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "PROPERTY_EFFECT_TYPES",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1187,
+              "column": 6
+            },
+            "end": {
+              "line": 1189,
+              "column": 7
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_template",
+          "type": "HTMLTemplateElement",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 16,
-              "column": 2
+              "line": 435,
+              "column": 8
             },
             "end": {
-              "line": 23,
-              "column": 3
+              "line": 435,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 437,
+              "column": 8
+            },
+            "end": {
+              "line": 437,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "rootPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 439,
+              "column": 8
+            },
+            "end": {
+              "line": 439,
+              "column": 22
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 441,
+              "column": 8
+            },
+            "end": {
+              "line": 441,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "root",
+          "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 443,
+              "column": 8
+            },
+            "end": {
+              "line": 443,
+              "column": 18
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "$",
+          "type": "!Object.<string, !Element>",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 445,
+              "column": 8
+            },
+            "end": {
+              "line": 445,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "light",
+          "type": "boolean | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 49,
+              "column": 5
+            },
+            "end": {
+              "line": 53,
+              "column": 6
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Boolean"
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "visible",
+          "type": "boolean | null | undefined",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 5
+            },
+            "end": {
+              "line": 58,
+              "column": 6
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "attributeType": "Boolean"
+            }
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [
+        {
+          "name": "_stampTemplate",
+          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2424,
+              "column": 6
+            },
+            "end": {
+              "line": 2449,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to stamp"
+            }
+          ],
+          "return": {
+            "type": "!StampedTemplate",
+            "desc": "Cloned template content"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addMethodEventListenerToNode",
+          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 452,
+              "column": 6
+            },
+            "end": {
+              "line": 457,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to add listener on"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of method"
+            },
+            {
+              "name": "context",
+              "type": "*=",
+              "description": "Context the method will be called on (defaults\n  to `node`)"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "Generated handler function"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_addEventListenerToNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 467,
+              "column": 6
+            },
+            "end": {
+              "line": 469,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to add event listener to"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "function (!Event): void",
+              "description": "Listener function to add"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_removeEventListenerFromNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 479,
+              "column": 6
+            },
+            "end": {
+              "line": 481,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to remove event listener from"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "function (!Event): void",
+              "description": "Listener function to remove"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_createPropertyAccessor",
+          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 106,
+              "column": 8
+            },
+            "end": {
+              "line": 115,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_addPropertyToAttributeMap",
+          "description": "Adds the given `property` to a map matching attribute names\nto property names, using `attributeNameForProperty`. This map is\nused when deserializing attribute values to properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 124,
+              "column": 8
+            },
+            "end": {
+              "line": 132,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_definePropertyAccessor",
+          "description": "Defines a property accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 140,
+              "column": 9
+            },
+            "end": {
+              "line": 153,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "ready",
+          "description": "Stamps the element template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 553,
+              "column": 6
+            },
+            "end": {
+              "line": 559,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [],
           "return": {
             "type": "void"
-          }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
         },
         {
-          "name": "init",
-          "description": "",
-          "privacy": "public",
+          "name": "_initializeProperties",
+          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+          "privacy": "protected",
           "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 25,
-              "column": 2
+              "line": 460,
+              "column": 6
             },
             "end": {
-              "line": 30,
-              "column": 3
+              "line": 493,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_initializeInstanceProperties",
+          "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 222,
+              "column": 8
+            },
+            "end": {
+              "line": 224,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of property values that were overwritten\n  when creating property accessors."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_setProperty",
+          "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 235,
+              "column": 8
+            },
+            "end": {
+              "line": 239,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_getProperty",
+          "description": "Returns the value for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 247,
+              "column": 8
+            },
+            "end": {
+              "line": 249,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of property"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value for the given property"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_setPendingProperty",
+          "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 264,
+              "column": 8
+            },
+            "end": {
+              "line": 280,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "ext",
+              "type": "boolean=",
+              "description": "Not used here; affordance for closure"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property changed"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_invalidateProperties",
+          "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 290,
+              "column": 8
+            },
+            "end": {
+              "line": 300,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_enableProperties",
+          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 313,
+              "column": 8
+            },
+            "end": {
+              "line": 322,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_flushProperties",
+          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 333,
+              "column": 8
+            },
+            "end": {
+              "line": 342,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_shouldPropertiesChange",
+          "description": "Called in `_flushProperties` to determine if `_propertiesChanged`\nshould be called. The default implementation returns true if\nproperties are pending. Override to customize when\n`_propertiesChanged` is called.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 356,
+              "column": 8
+            },
+            "end": {
+              "line": 358,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "currentProps",
+              "type": "!Object",
+              "description": "Bag of all current accessor values"
+            },
+            {
+              "name": "changedProps",
+              "type": "!Object",
+              "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+            },
+            {
+              "name": "oldProps",
+              "type": "!Object",
+              "description": "Bag of previous values for each property\n  in `changedProps`"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "true if changedProps is truthy"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_propertiesChanged",
+          "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 372,
+              "column": 8
+            },
+            "end": {
+              "line": 373,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "currentProps",
+              "type": "!Object",
+              "description": "Bag of all current accessor values"
+            },
+            {
+              "name": "changedProps",
+              "type": "!Object",
+              "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+            },
+            {
+              "name": "oldProps",
+              "type": "!Object",
+              "description": "Bag of previous values for each property\n  in `changedProps`"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_shouldPropertyChange",
+          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 393,
+              "column": 8
+            },
+            "end": {
+              "line": 400,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "New property value"
+            },
+            {
+              "name": "old",
+              "type": "*",
+              "description": "Previous property value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "attributeChangedCallback",
+          "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 413,
+              "column": 8
+            },
+            "end": {
+              "line": 420,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of attribute that changed"
+            },
+            {
+              "name": "old",
+              "type": "?string",
+              "description": "Old attribute value"
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "New attribute value"
+            },
+            {
+              "name": "namespace",
+              "type": "?string",
+              "description": "Attribute namespace."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_attributeToProperty",
+          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 434,
+              "column": 8
+            },
+            "end": {
+              "line": 441,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to deserialize."
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "of the attribute."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_propertyToAttribute",
+          "description": "Serializes a property to its associated attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 453,
+              "column": 8
+            },
+            "end": {
+              "line": 459,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name to reflect."
+            },
+            {
+              "name": "attribute",
+              "type": "string=",
+              "description": "Attribute name to reflect to."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Property value to refect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_valueToNodeAttribute",
+          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 474,
+              "column": 8
+            },
+            "end": {
+              "line": 481,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Element to set attribute to."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to serialize."
+            },
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Attribute name to serialize to."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_serializeValue",
+          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 494,
+              "column": 8
+            },
+            "end": {
+              "line": 501,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Property value to serialize."
+            }
+          ],
+          "return": {
+            "type": "(string | undefined)",
+            "desc": "String serialized from the provided\nproperty  value."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_deserializeValue",
+          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 515,
+              "column": 8
+            },
+            "end": {
+              "line": 524,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "Value to deserialize."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "Type to deserialize the string to."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Typed value deserialized from the provided string."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_initializeProtoProperties",
+          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1218,
+              "column": 6
+            },
+            "end": {
+              "line": 1222,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the prototype"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_ensureAttribute",
+          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 193,
+              "column": 6
+            },
+            "end": {
+              "line": 198,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to ensure is set."
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "of the attribute."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_hasAccessor",
+          "description": "Returns true if this library created an accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 300,
+              "column": 6
+            },
+            "end": {
+              "line": 302,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if an accessor was created"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_isPropertyPending",
+          "description": "Returns true if the specified property has a pending change.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 311,
+              "column": 6
+            },
+            "end": {
+              "line": 313,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if property has a pending change"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_addPropertyEffect",
+          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1256,
+              "column": 6
+            },
+            "end": {
+              "line": 1264,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removePropertyEffect",
+          "description": "Removes the given property effect.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1274,
+              "column": 6
+            },
+            "end": {
+              "line": 1280,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property the effect was associated with"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object to remove"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasPropertyEffect",
+          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1291,
+              "column": 6
+            },
+            "end": {
+              "line": 1294,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "type",
+              "type": "string=",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReadOnlyEffect",
+          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1304,
+              "column": 6
+            },
+            "end": {
+              "line": 1306,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasNotifyEffect",
+          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1316,
+              "column": 6
+            },
+            "end": {
+              "line": 1318,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReflectEffect",
+          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1328,
+              "column": 6
+            },
+            "end": {
+              "line": 1330,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasComputedEffect",
+          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1340,
+              "column": 6
+            },
+            "end": {
+              "line": 1342,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setPendingPropertyOrPath",
+          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1374,
+              "column": 6
+            },
+            "end": {
+              "line": 1406,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(number | string)>)",
+              "description": "Path to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "Set to true if this change should\n cause a property notification event dispatch"
+            },
+            {
+              "name": "isPathNotification",
+              "type": "boolean=",
+              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setUnmanagedPropertyToNode",
+          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1429,
+              "column": 6
+            },
+            "end": {
+              "line": 1437,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "The node to set a property on"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "The property to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "The value to set"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_enqueueClient",
+          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1544,
+              "column": 6
+            },
+            "end": {
+              "line": 1549,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "client",
+              "type": "Object",
+              "description": "PropertyEffects client to enqueue"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_flushClients",
+          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1570,
+              "column": 6
+            },
+            "end": {
+              "line": 1581,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__enableOrFlushClients",
+          "description": "(c) the stamped dom enables.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1595,
+              "column": 6
+            },
+            "end": {
+              "line": 1608,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_readyClients",
+          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 571,
+              "column": 6
+            },
+            "end": {
+              "line": 580,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "setProperties",
+          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1637,
+              "column": 6
+            },
+            "end": {
+              "line": 1648,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+            },
+            {
+              "name": "setReadOnly",
+              "type": "boolean=",
+              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_propagatePropertyChanges",
+          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1735,
+              "column": 6
+            },
+            "end": {
+              "line": 1745,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changedProps",
+              "type": "Object",
+              "description": "Bag of changed properties"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "linkPaths",
+          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1756,
+              "column": 6
+            },
+            "end": {
+              "line": 1761,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "to",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Target path to link."
+            },
+            {
+              "name": "from",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Source path to link."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unlinkPaths",
+          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1773,
+              "column": 6
+            },
+            "end": {
+              "line": 1778,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Target path to unlink."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifySplices",
+          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1810,
+              "column": 6
+            },
+            "end": {
+              "line": 1814,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "splices",
+              "type": "Array",
+              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "get",
+          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1835,
+              "column": 6
+            },
+            "end": {
+              "line": 1837,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "set",
+          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1860,
+              "column": 6
+            },
+            "end": {
+              "line": 1870,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set at the specified path."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "push",
+          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1886,
+              "column": 6
+            },
+            "end": {
+              "line": 1895,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to push onto array"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "pop",
+          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1910,
+              "column": 6
+            },
+            "end": {
+              "line": 1919,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "splice",
+          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1938,
+              "column": 6
+            },
+            "end": {
+              "line": 1975,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "start",
+              "type": "number",
+              "description": "Index from which to start removing/inserting."
+            },
+            {
+              "name": "deleteCount",
+              "type": "number",
+              "description": "Number of items to remove."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to insert into array."
+            }
+          ],
+          "return": {
+            "type": "Array",
+            "desc": "Array of removed items."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "shift",
+          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1990,
+              "column": 6
+            },
+            "end": {
+              "line": 1999,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unshift",
+          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2015,
+              "column": 6
+            },
+            "end": {
+              "line": 2023,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string | !Array.<(string | number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to insert info array"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifyPath",
+          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2038,
+              "column": 6
+            },
+            "end": {
+              "line": 2055,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Value at the path (optional)."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReadOnlyProperty",
+          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2068,
+              "column": 6
+            },
+            "end": {
+              "line": 2075,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createPropertyObserver",
+          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2089,
+              "column": 6
+            },
+            "end": {
+              "line": 2099,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "method",
+              "type": "(string | function (*, *))",
+              "description": "Function or name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createMethodObserver",
+          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2112,
+              "column": 6
+            },
+            "end": {
+              "line": 2118,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createNotifyingProperty",
+          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2129,
+              "column": 6
+            },
+            "end": {
+              "line": 2137,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReflectedProperty",
+          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2148,
+              "column": 6
+            },
+            "end": {
+              "line": 2161,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createComputedProperty",
+          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2175,
+              "column": 6
+            },
+            "end": {
+              "line": 2181,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_bindTemplate",
+          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2358,
+              "column": 6
+            },
+            "end": {
+              "line": 2381,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            },
+            {
+              "name": "instanceBinding",
+              "type": "boolean=",
+              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removeBoundDom",
+          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2460,
+              "column": 6
+            },
+            "end": {
+              "line": 2481,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "!StampedTemplate",
+              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "connectedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 540,
+              "column": 6
+            },
+            "end": {
+              "line": 545,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Called when the element is removed from a document",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 216,
+              "column": 6
+            },
+            "end": {
+              "line": 220,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "_attachDom",
+          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 594,
+              "column": 6
+            },
+            "end": {
+              "line": 610,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "StampedTemplate",
+              "description": "to attach to the element."
+            }
+          ],
+          "return": {
+            "type": "ShadowRoot",
+            "desc": "node to which the dom has been attached."
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "updateStyles",
+          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.\n\nNote: This function does not support updating CSS mixins.\nYou can not dynamically change the value of an `@apply`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 633,
+              "column": 6
+            },
+            "end": {
+              "line": 637,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "properties",
+              "type": "Object=",
+              "description": "Bag of custom property key/values to\n  apply to this element."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "resolveUrl",
+          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.\n\nNote that this function performs no resolution for URLs that start\nwith `/` (absolute URLs) or `#` (hash identifiers).  For general purpose\nURL resolution, use `window.URL`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 654,
+              "column": 6
+            },
+            "end": {
+              "line": 659,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "url",
+              "type": "string",
+              "description": "URL to resolve."
+            },
+            {
+              "name": "base",
+              "type": "string=",
+              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Rewritten URL relative to base"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "staticMethods": [
+        {
+          "name": "_parseTemplate",
+          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 197,
+              "column": 6
+            },
+            "end": {
+              "line": 208,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to parse"
+            },
+            {
+              "name": "outerTemplateInfo",
+              "type": "TemplateInfo=",
+              "description": "Template metadata from the outer\n  template, for parsing nested templates"
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Parsed template metadata"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateContent",
+          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 670,
+              "column": 6
+            },
+            "end": {
+              "line": 673,
+              "column": 7
             }
           },
           "metadata": {},
@@ -47,377 +2884,928 @@
               "name": "template"
             },
             {
-              "name": "host"
+              "name": "templateInfo"
+            },
+            {
+              "name": "nodeInfo"
             }
           ],
-          "return": {
-            "type": "void"
-          }
+          "inheritedFrom": "Polymer.ElementMixin"
         },
         {
-          "name": "_getRootDataHost",
-          "description": "",
+          "name": "_parseTemplateNode",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
           "privacy": "protected",
           "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 32,
-              "column": 2
+              "line": 2500,
+              "column": 6
             },
             "end": {
-              "line": 34,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_ensureTemplatized",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 36,
-              "column": 2
-            },
-            "end": {
-              "line": 40,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "_forwardParentProp",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 42,
-              "column": 2
-            },
-            "end": {
-              "line": 48,
-              "column": 3
+              "line": 2514,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "prop"
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
             },
             {
-              "name": "value"
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
             }
           ],
           "return": {
-            "type": "void"
-          }
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
         },
         {
-          "name": "_forwardParentPath",
-          "description": "",
+          "name": "_parseTemplateChildNodes",
+          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
           "privacy": "protected",
           "sourceRange": {
+            "file": "../../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 50,
-              "column": 2
+              "line": 258,
+              "column": 6
             },
             "end": {
-              "line": 56,
-              "column": 3
+              "line": 295,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "path"
+              "name": "root",
+              "type": "Node",
+              "description": "Root node whose `childNodes` will be parsed"
             },
             {
-              "name": "value"
+              "name": "templateInfo",
+              "type": "!TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "!NodeInfo",
+              "description": "Node metadata for current template."
             }
           ],
           "return": {
             "type": "void"
-          }
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
         },
         {
-          "name": "_forwardHostPropV2",
-          "description": "",
+          "name": "_parseTemplateNestedTemplate",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
           "privacy": "protected",
           "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 58,
-              "column": 2
+              "line": 2592,
+              "column": 6
             },
             "end": {
-              "line": 64,
-              "column": 3
+              "line": 2602,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "prop"
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
             },
             {
-              "name": "value"
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateNodeAttributes",
+          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 333,
+              "column": 6
+            },
+            "end": {
+              "line": 342,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNodeAttribute",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2535,
+              "column": 6
+            },
+            "end": {
+              "line": 2576,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Attribute name"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "Attribute value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_contentForTemplate",
+          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 388,
+              "column": 6
+            },
+            "end": {
+              "line": 391,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template to retrieve `content` for"
+            }
+          ],
+          "return": {
+            "type": "DocumentFragment",
+            "desc": "Content fragment"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "createProperties",
+          "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 326,
+              "column": 7
+            },
+            "end": {
+              "line": 330,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props"
             }
           ],
           "return": {
             "type": "void"
-          }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
         },
         {
-          "name": "getInstance",
-          "description": "",
-          "privacy": "public",
+          "name": "attributeNameForProperty",
+          "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+          "privacy": "protected",
           "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-changed.html",
             "start": {
-              "line": 66,
-              "column": 2
+              "line": 77,
+              "column": 8
             },
             "end": {
               "line": 79,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "detachInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 81,
-              "column": 2
-            },
-            "end": {
-              "line": 84,
-              "column": 3
+              "column": 9
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "instance"
+              "name": "property",
+              "type": "string",
+              "description": "Property to convert"
             }
           ],
           "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "releaseInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 86,
-              "column": 2
-            },
-            "end": {
-              "line": 93,
-              "column": 3
-            }
+            "type": "string",
+            "desc": "Attribute name corresponding to the given property."
           },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
+          "inheritedFrom": "Polymer.PropertiesChanged"
         },
         {
-          "name": "disconnectedCallback",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 95,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "releaseInstances",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 101,
-              "column": 2
-            },
-            "end": {
-              "line": 104,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "_performInstanceDetach",
-          "description": "",
+          "name": "typeForProperty",
+          "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
           "privacy": "protected",
           "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 106,
-              "column": 2
+              "line": 181,
+              "column": 6
             },
             "end": {
-              "line": 119,
-              "column": 3
+              "line": 184,
+              "column": 7
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "instance"
+              "name": "name",
+              "type": "string",
+              "description": "Name of property"
             }
-          ]
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Type to which to deserialize attribute"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "createPropertiesForAttributes",
+          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 129,
+              "column": 6
+            },
+            "end": {
+              "line": 134,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "addPropertyEffect",
+          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2221,
+              "column": 6
+            },
+            "end": {
+              "line": 2223,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createPropertyObserver",
+          "description": "Creates a single-property observer for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2235,
+              "column": 6
+            },
+            "end": {
+              "line": 2237,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "method",
+              "type": "(string | function (*, *))",
+              "description": "Function or name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createMethodObserver",
+          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2252,
+              "column": 6
+            },
+            "end": {
+              "line": 2254,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating"
+            }
+          ],
+          "return": {
+            "type": "void",
+            "desc": "whether method names should be included as a dependency to the effect."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createNotifyingProperty",
+          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2264,
+              "column": 6
+            },
+            "end": {
+              "line": 2266,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReadOnlyProperty",
+          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2284,
+              "column": 6
+            },
+            "end": {
+              "line": 2286,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReflectedProperty",
+          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2296,
+              "column": 6
+            },
+            "end": {
+              "line": 2298,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createComputedProperty",
+          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2314,
+              "column": 6
+            },
+            "end": {
+              "line": 2316,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean | Object)=",
+              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "bindTemplate",
+          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2330,
+              "column": 6
+            },
+            "end": {
+              "line": 2332,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Template metadata object"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addTemplatePropertyEffect",
+          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2396,
+              "column": 6
+            },
+            "end": {
+              "line": 2402,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Template metadata to add effect to"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseBindings",
+          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`\n\nThe default implementation uses a regular expression for best\nperformance. However, the regular expression uses a white-list of\nallowed characters in a data-binding, which causes problems for\ndata-bindings that do use characters not in this white-list.\n\nInstead of updating the white-list with all allowed characters,\nthere is a StrictBindingParser (see lib/mixins/strict-binding-parser)\nthat uses a state machine instead. This state machine is able to handle\nall characters. However, it is slightly less performant, therefore we\nextracted it into a separate optional mixin.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2648,
+              "column": 6
+            },
+            "end": {
+              "line": 2713,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text",
+              "type": "string",
+              "description": "Text to parse from attribute or textContent"
+            },
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Current template metadata"
+            }
+          ],
+          "return": {
+            "type": "Array.<!BindingPart>",
+            "desc": "Array of binding part metadata"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_evaluateBinding",
+          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2729,
+              "column": 6
+            },
+            "end": {
+              "line": 2746,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "inst",
+              "type": "this",
+              "description": "Element that should be used as scope for\n  binding dependencies"
+            },
+            {
+              "name": "part",
+              "type": "BindingPart",
+              "description": "Binding part metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path that triggered this effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value the binding part evaluated to"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "finalize",
+          "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 129,
+              "column": 6
+            },
+            "end": {
+              "line": 138,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "_finalizeClass",
+          "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 294,
+              "column": 5
+            },
+            "end": {
+              "line": 317,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "createObservers",
+          "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 343,
+              "column": 6
+            },
+            "end": {
+              "line": 348,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "observers",
+              "type": "Object",
+              "description": "Array of observer descriptors for\n  this class"
+            },
+            {
+              "name": "dynamicFns",
+              "type": "Object",
+              "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_processStyleText",
+          "description": "Gather style text for a style element in the template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 503,
+              "column": 6
+            },
+            "end": {
+              "line": 505,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cssText",
+              "type": "string",
+              "description": "Text containing styling to process"
+            },
+            {
+              "name": "baseURI",
+              "type": "string",
+              "description": "Base URI to rebase CSS paths against"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "The processed CSS text"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_finalizeTemplate",
+          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../../polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 516,
+              "column": 6
+            },
+            "end": {
+              "line": 527,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name (or type extension name) for this element"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
         }
       ],
-      "staticMethods": [],
       "demos": [],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 4,
-          "column": 1
-        },
-        "end": {
-          "line": 120,
+          "line": 43,
           "column": 2
-        }
-      },
-      "privacy": "public",
-      "superclass": "HTMLElement",
-      "name": "OmnitableTemplatizer",
-      "attributes": [],
-      "events": [],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
-      "slots": [],
-      "tagname": "cosmoz-omnitable-templatizer"
-    },
-    {
-      "description": "",
-      "summary": "",
-      "path": "ui-helpers/cosmoz-clear-button.html",
-      "properties": [
-        {
-          "name": "visible",
-          "type": "boolean | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 44,
-              "column": 4
-            },
-            "end": {
-              "line": 48,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Boolean"
-            }
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "light",
-          "type": "boolean | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 50,
-              "column": 4
-            },
-            "end": {
-              "line": 54,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Boolean"
-            }
-          },
-          "defaultValue": "false"
-        }
-      ],
-      "methods": [],
-      "staticMethods": [],
-      "demos": [],
-      "metadata": {},
-      "sourceRange": {
-        "start": {
-          "line": 41,
-          "column": 10
         },
         "end": {
-          "line": 56,
+          "line": 61,
           "column": 3
         }
       },
       "privacy": "public",
-      "superclass": "HTMLElement",
+      "superclass": "Polymer.Element",
+      "name": "CosmozClearButton",
       "attributes": [
         {
-          "name": "visible",
+          "name": "light",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 44,
-              "column": 4
+              "line": 49,
+              "column": 5
             },
             "end": {
-              "line": 48,
-              "column": 5
+              "line": 53,
+              "column": 6
             }
           },
           "metadata": {},
           "type": "boolean | null | undefined"
         },
         {
-          "name": "light",
+          "name": "visible",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 50,
-              "column": 4
-            },
-            "end": {
               "line": 54,
               "column": 5
+            },
+            "end": {
+              "line": 58,
+              "column": 6
             }
           },
           "metadata": {},
@@ -438,98 +3826,6 @@
       "path": "cosmoz-omnitable-column.html",
       "properties": [
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -537,11 +3833,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -561,11 +3857,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -584,11 +3880,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -609,11 +3905,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -633,11 +3929,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -658,11 +3954,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -682,11 +3978,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -707,11 +4003,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -731,11 +4027,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -756,11 +4052,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -779,11 +4075,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -802,11 +4098,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -826,11 +4122,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -850,11 +4146,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -875,11 +4171,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -899,11 +4195,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -922,11 +4218,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 37,
+              "line": 40,
               "column": 5
             },
             "end": {
-              "line": 40,
+              "line": 43,
               "column": 6
             }
           },
@@ -944,11 +4240,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 42,
+              "line": 45,
               "column": 5
             },
             "end": {
-              "line": 45,
+              "line": 48,
               "column": 6
             }
           },
@@ -967,11 +4263,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -991,11 +4287,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -1015,11 +4311,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -1039,11 +4335,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -1062,11 +4358,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -1086,11 +4382,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -1100,30 +4396,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -1219,69 +4491,113 @@
             }
           },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         }
       ],
       "methods": [
         {
-          "name": "ready",
-          "description": "",
-          "privacy": "protected",
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 242,
+              "line": 28,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Cleans up references to recycled instances when the element is detached.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 80,
               "column": 3
             }
           },
@@ -1290,52 +4606,235 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_createTemplatizer",
-          "description": "",
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 248,
+              "line": 89,
               "column": 2
             },
             "end": {
-              "line": 272,
+              "line": 103,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "templateElementOrSelector"
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
             }
           ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_cellTemplateChanged",
-          "description": "",
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 274,
+              "line": 112,
               "column": 2
             },
             "end": {
-              "line": 278,
+              "line": 118,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "cellTemplate"
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
             }
           ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 235,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
           "return": {
             "type": "void"
           },
@@ -1348,11 +4847,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -1368,62 +4867,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -1442,11 +4896,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 330,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 263,
               "column": 3
             }
           },
@@ -1469,11 +4923,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 337,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 342,
+              "line": 269,
               "column": 3
             }
           },
@@ -1496,11 +4950,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -1528,11 +4982,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 358,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 287,
               "column": 3
             }
           },
@@ -1554,11 +5008,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -1580,11 +5034,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -1615,11 +5069,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -1633,11 +5087,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 60,
               "column": 3
             },
             "end": {
-              "line": 59,
+              "line": 62,
               "column": 4
             }
           },
@@ -1654,11 +5108,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -1683,11 +5137,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -1702,11 +5156,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -1728,11 +5182,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -1754,11 +5208,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -1776,11 +5230,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -1798,11 +5252,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -1820,11 +5274,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -1842,11 +5296,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -1863,11 +5317,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 49,
+              "line": 52,
               "column": 3
             },
             "end": {
-              "line": 51,
+              "line": 54,
               "column": 4
             }
           },
@@ -1885,11 +5339,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 53,
+              "line": 56,
               "column": 3
             },
             "end": {
-              "line": 55,
+              "line": 58,
               "column": 4
             }
           },
@@ -1906,11 +5360,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 30,
+          "line": 33,
           "column": 2
         },
         "end": {
-          "line": 60,
+          "line": 63,
           "column": 3
         }
       },
@@ -1924,11 +5378,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -1942,11 +5396,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -1960,11 +5414,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -1978,11 +5432,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -1996,11 +5450,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -2014,11 +5468,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -2032,11 +5486,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -2050,11 +5504,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -2068,11 +5522,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -2086,11 +5540,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -2104,11 +5558,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -2122,11 +5576,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -2140,11 +5594,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -2158,11 +5612,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -2176,11 +5630,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -2194,11 +5648,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -2211,11 +5665,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 37,
+              "line": 40,
               "column": 5
             },
             "end": {
-              "line": 40,
+              "line": 43,
               "column": 6
             }
           },
@@ -2227,11 +5681,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 42,
+              "line": 45,
               "column": 5
             },
             "end": {
-              "line": 45,
+              "line": 48,
               "column": 6
             }
           },
@@ -2244,11 +5698,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -2262,11 +5716,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -2280,11 +5734,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -2298,11 +5752,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -2316,11 +5770,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -2334,34 +5788,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -2460,11 +5896,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 2
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 3
             }
           },
@@ -2481,11 +5917,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 2
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 3
             }
           },
@@ -2496,52 +5932,6 @@
           }
         },
         {
-          "name": "elements",
-          "type": "?",
-          "description": "Get an array of the elements generated by this repeater\n\t\t ",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 94,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "templateInstances",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 101,
-              "column": 2
-            },
-            "end": {
-              "line": 106,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -2549,11 +5939,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -2572,11 +5962,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -2591,16 +5981,193 @@
       ],
       "methods": [
         {
+          "name": "trackColumns",
+          "description": "Adds an observer to render the cells when the columns are changed.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 48,
+              "column": 2
+            },
+            "end": {
+              "line": 60,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "stopTrackingColumns",
+          "description": "Stops reacting to column changes.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 66,
+              "column": 2
+            },
+            "end": {
+              "line": 73,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "renderCells",
+          "description": "Renders all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 79,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "destroyCells",
+          "description": "Destroys all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 87,
+              "column": 2
+            },
+            "end": {
+              "line": 89,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardChange",
+          "description": "Forwards a property change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 97,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "String",
+              "description": "the property"
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "the new value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardPathChange",
+          "description": "Forwards a path change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 106,
+              "column": 2
+            },
+            "end": {
+              "line": 110,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changeRecord",
+              "type": "Object",
+              "description": "the change record"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forEachElement",
+          "description": "Runs a callback on each element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 117,
+              "column": 2
+            },
+            "end": {
+              "line": 119,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "callback",
+              "type": "OmnitableRepeaterMixin~forEachElementCallback",
+              "description": "the callback"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 57,
               "column": 2
             },
             "end": {
-              "line": 49,
+              "line": 59,
               "column": 3
             }
           },
@@ -2612,46 +6179,16 @@
           ]
         },
         {
-          "name": "_detachTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 51,
-              "column": 2
-            },
-            "end": {
-              "line": 55,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "column"
-            },
-            {
-              "name": "element"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_configureElement",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 64,
               "column": 2
             },
             "end": {
-              "line": 61,
+              "line": 69,
               "column": 3
             }
           },
@@ -2662,28 +6199,7 @@
             },
             {
               "name": "column"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "_configureTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 63,
-              "column": 2
             },
-            "end": {
-              "line": 65,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
             {
               "name": "instance"
             }
@@ -2691,64 +6207,6 @@
           "return": {
             "type": "void"
           }
-        },
-        {
-          "name": "getElementTemplateInstance",
-          "description": "Get the template instance rendered by the specified element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 113,
-              "column": 2
-            },
-            "end": {
-              "line": 115,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The instance."
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "getElementColumn",
-          "description": "Get the column that was used to rendered the specified element",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 122,
-              "column": 2
-            },
-            "end": {
-              "line": 124,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The column."
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
           "name": "_columnsChanged",
@@ -2757,11 +6215,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 126,
+              "line": 171,
               "column": 2
             },
             "end": {
-              "line": 150,
+              "line": 195,
               "column": 3
             }
           },
@@ -2783,11 +6241,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 152,
+              "line": 197,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 206,
               "column": 3
             }
           },
@@ -2809,11 +6267,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 163,
+              "line": 208,
               "column": 2
             },
             "end": {
-              "line": 201,
+              "line": 234,
               "column": 3
             }
           },
@@ -2838,11 +6296,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 203,
+              "line": 236,
               "column": 2
             },
             "end": {
-              "line": 211,
+              "line": 244,
               "column": 3
             }
           },
@@ -2867,11 +6325,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 213,
+              "line": 246,
               "column": 2
             },
             "end": {
-              "line": 229,
+              "line": 262,
               "column": 3
             }
           },
@@ -2890,53 +6348,17 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
-          "name": "_forwardProperty",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 231,
-              "column": 2
-            },
-            "end": {
-              "line": 237,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "value"
-            },
-            {
-              "name": "flush",
-              "defaultValue": "false"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 239,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 269,
               "column": 3
             }
           },
@@ -2950,10 +6372,6 @@
             },
             {
               "name": "value"
-            },
-            {
-              "name": "isPathNotification",
-              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -2971,11 +6389,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1
         },
         "end": {
-          "line": 66,
+          "line": 70,
           "column": 2
         }
       },
@@ -2989,11 +6407,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -3007,11 +6425,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -3031,11 +6449,11 @@
           "name": "header-cell",
           "range": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 2
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 34
             }
           }
@@ -3058,11 +6476,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 2
             },
             "end": {
-              "line": 72,
+              "line": 74,
               "column": 3
             }
           },
@@ -3079,11 +6497,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 74,
+              "line": 76,
               "column": 2
             },
             "end": {
-              "line": 76,
+              "line": 78,
               "column": 3
             }
           },
@@ -3094,52 +6512,6 @@
           }
         },
         {
-          "name": "elements",
-          "type": "?",
-          "description": "Get an array of the elements generated by this repeater\n\t\t ",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 94,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "templateInstances",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 101,
-              "column": 2
-            },
-            "end": {
-              "line": 106,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -3147,11 +6519,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -3170,11 +6542,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -3193,11 +6565,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 5
             }
           },
@@ -3214,11 +6586,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 5
             }
           },
@@ -3236,11 +6608,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 60,
+              "line": 62,
               "column": 5
             }
           },
@@ -3254,16 +6626,193 @@
       ],
       "methods": [
         {
+          "name": "trackColumns",
+          "description": "Adds an observer to render the cells when the columns are changed.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 48,
+              "column": 2
+            },
+            "end": {
+              "line": 60,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "stopTrackingColumns",
+          "description": "Stops reacting to column changes.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 66,
+              "column": 2
+            },
+            "end": {
+              "line": 73,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "renderCells",
+          "description": "Renders all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 79,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "destroyCells",
+          "description": "Destroys all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 87,
+              "column": 2
+            },
+            "end": {
+              "line": 89,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardChange",
+          "description": "Forwards a property change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 97,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "String",
+              "description": "the property"
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "the new value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardPathChange",
+          "description": "Forwards a path change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 106,
+              "column": 2
+            },
+            "end": {
+              "line": 110,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changeRecord",
+              "type": "Object",
+              "description": "the change record"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forEachElement",
+          "description": "Runs a callback on each element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 117,
+              "column": 2
+            },
+            "end": {
+              "line": 119,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "callback",
+              "type": "OmnitableRepeaterMixin~forEachElementCallback",
+              "description": "the callback"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 78,
+              "line": 88,
               "column": 2
             },
             "end": {
-              "line": 80,
+              "line": 95,
               "column": 3
             }
           },
@@ -3275,46 +6824,16 @@
           ]
         },
         {
-          "name": "_detachTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 82,
-              "column": 2
-            },
-            "end": {
-              "line": 84,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "column"
-            },
-            {
-              "name": "element"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_configureElement",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 100,
               "column": 2
             },
             "end": {
-              "line": 92,
+              "line": 107,
               "column": 3
             }
           },
@@ -3325,28 +6844,7 @@
             },
             {
               "name": "column"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "_configureTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 94,
-              "column": 2
             },
-            "end": {
-              "line": 101,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
             {
               "name": "instance"
             }
@@ -3354,64 +6852,6 @@
           "return": {
             "type": "void"
           }
-        },
-        {
-          "name": "getElementTemplateInstance",
-          "description": "Get the template instance rendered by the specified element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 113,
-              "column": 2
-            },
-            "end": {
-              "line": 115,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The instance."
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "getElementColumn",
-          "description": "Get the column that was used to rendered the specified element",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 122,
-              "column": 2
-            },
-            "end": {
-              "line": 124,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The column."
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
           "name": "_columnsChanged",
@@ -3420,11 +6860,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 126,
+              "line": 171,
               "column": 2
             },
             "end": {
-              "line": 150,
+              "line": 195,
               "column": 3
             }
           },
@@ -3446,11 +6886,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 152,
+              "line": 197,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 206,
               "column": 3
             }
           },
@@ -3472,11 +6912,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 163,
+              "line": 208,
               "column": 2
             },
             "end": {
-              "line": 201,
+              "line": 234,
               "column": 3
             }
           },
@@ -3501,11 +6941,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 203,
+              "line": 236,
               "column": 2
             },
             "end": {
-              "line": 211,
+              "line": 244,
               "column": 3
             }
           },
@@ -3530,11 +6970,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 213,
+              "line": 246,
               "column": 2
             },
             "end": {
-              "line": 229,
+              "line": 262,
               "column": 3
             }
           },
@@ -3553,53 +6993,17 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
-          "name": "_forwardProperty",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 231,
-              "column": 2
-            },
-            "end": {
-              "line": 237,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "value"
-            },
-            {
-              "name": "flush",
-              "defaultValue": "false"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 239,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 269,
               "column": 3
             }
           },
@@ -3615,10 +7019,6 @@
               "name": "value"
             },
             {
-              "name": "isPathNotification",
-              "defaultValue": "false"
-            },
-            {
               "name": "flush",
               "defaultValue": "false"
             }
@@ -3627,27 +7027,6 @@
             "type": "void"
           },
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "_computeItemRowCellClasses",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 103,
-              "column": 2
-            },
-            "end": {
-              "line": 107,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "column"
-            }
-          ]
         },
         {
           "name": "_itemUpdated",
@@ -3659,14 +7038,14 @@
               "column": 2
             },
             "end": {
-              "line": 120,
+              "line": 114,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "itemChange"
+              "name": "changeRecord"
             }
           ],
           "return": {
@@ -3679,11 +7058,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 116,
               "column": 2
             },
             "end": {
-              "line": 126,
+              "line": 118,
               "column": 3
             }
           },
@@ -3703,11 +7082,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 128,
+              "line": 120,
               "column": 2
             },
             "end": {
-              "line": 132,
+              "line": 122,
               "column": 3
             }
           },
@@ -3727,11 +7106,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 140,
+              "line": 130,
               "column": 2
             },
             "end": {
-              "line": 142,
+              "line": 132,
               "column": 3
             }
           },
@@ -3752,6 +7131,27 @@
             "type": "string",
             "desc": "Cell title."
           }
+        },
+        {
+          "name": "_computeItemRowCellClasses",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 134,
+              "column": 2
+            },
+            "end": {
+              "line": 138,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "column"
+            }
+          ]
         }
       ],
       "staticMethods": [],
@@ -3759,11 +7159,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 39,
+          "line": 41,
           "column": 1
         },
         "end": {
-          "line": 143,
+          "line": 139,
           "column": 2
         }
       },
@@ -3777,11 +7177,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -3795,11 +7195,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -3812,11 +7212,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 5
             }
           },
@@ -3828,11 +7228,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 5
             }
           },
@@ -3844,11 +7244,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 4
             },
             "end": {
-              "line": 60,
+              "line": 62,
               "column": 5
             }
           },
@@ -3867,11 +7267,11 @@
           "name": "item-cell",
           "range": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 2
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 32
             }
           }
@@ -3895,11 +7295,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1098,
+              "line": 1148,
               "column": 8
             },
             "end": {
-              "line": 1098,
+              "line": 1148,
               "column": 32
             }
           },
@@ -3918,11 +7318,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1100,
+              "line": 1150,
               "column": 8
             },
             "end": {
-              "line": 1100,
+              "line": 1150,
               "column": 34
             }
           },
@@ -3941,11 +7341,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1102,
+              "line": 1152,
               "column": 8
             },
             "end": {
-              "line": 1102,
+              "line": 1152,
               "column": 28
             }
           },
@@ -3964,11 +7364,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1104,
+              "line": 1154,
               "column": 8
             },
             "end": {
-              "line": 1104,
+              "line": 1154,
               "column": 31
             }
           },
@@ -3987,11 +7387,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1106,
+              "line": 1156,
               "column": 8
             },
             "end": {
-              "line": 1106,
+              "line": 1156,
               "column": 28
             }
           },
@@ -4010,11 +7410,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1108,
+              "line": 1158,
               "column": 8
             },
             "end": {
-              "line": 1108,
+              "line": 1158,
               "column": 35
             }
           },
@@ -4033,11 +7433,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1110,
+              "line": 1160,
               "column": 8
             },
             "end": {
-              "line": 1110,
+              "line": 1160,
               "column": 24
             }
           },
@@ -4056,11 +7456,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1112,
+              "line": 1162,
               "column": 8
             },
             "end": {
-              "line": 1112,
+              "line": 1162,
               "column": 24
             }
           },
@@ -4079,11 +7479,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1114,
+              "line": 1164,
               "column": 8
             },
             "end": {
-              "line": 1114,
+              "line": 1164,
               "column": 38
             }
           },
@@ -4102,11 +7502,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1116,
+              "line": 1166,
               "column": 8
             },
             "end": {
-              "line": 1116,
+              "line": 1166,
               "column": 20
             }
           },
@@ -4125,11 +7525,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1118,
+              "line": 1168,
               "column": 8
             },
             "end": {
-              "line": 1118,
+              "line": 1168,
               "column": 27
             }
           },
@@ -4148,11 +7548,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1120,
+              "line": 1170,
               "column": 8
             },
             "end": {
-              "line": 1120,
+              "line": 1170,
               "column": 23
             }
           },
@@ -4171,11 +7571,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1122,
+              "line": 1172,
               "column": 8
             },
             "end": {
-              "line": 1122,
+              "line": 1172,
               "column": 30
             }
           },
@@ -4194,11 +7594,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1124,
+              "line": 1174,
               "column": 8
             },
             "end": {
-              "line": 1124,
+              "line": 1174,
               "column": 30
             }
           },
@@ -4217,11 +7617,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1126,
+              "line": 1176,
               "column": 8
             },
             "end": {
-              "line": 1126,
+              "line": 1176,
               "column": 29
             }
           },
@@ -4240,11 +7640,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1128,
+              "line": 1178,
               "column": 8
             },
             "end": {
-              "line": 1128,
+              "line": 1178,
               "column": 32
             }
           },
@@ -4263,11 +7663,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1130,
+              "line": 1180,
               "column": 8
             },
             "end": {
-              "line": 1130,
+              "line": 1180,
               "column": 30
             }
           },
@@ -4286,11 +7686,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1132,
+              "line": 1182,
               "column": 8
             },
             "end": {
-              "line": 1132,
+              "line": 1182,
               "column": 24
             }
           },
@@ -4309,11 +7709,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1134,
+              "line": 1184,
               "column": 8
             },
             "end": {
-              "line": 1134,
+              "line": 1184,
               "column": 28
             }
           },
@@ -4332,11 +7732,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1137,
+              "line": 1187,
               "column": 6
             },
             "end": {
-              "line": 1139,
+              "line": 1189,
               "column": 7
             }
           },
@@ -4355,11 +7755,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 486,
+              "line": 435,
               "column": 8
             },
             "end": {
-              "line": 486,
+              "line": 435,
               "column": 23
             }
           },
@@ -4378,11 +7778,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 488,
+              "line": 437,
               "column": 8
             },
             "end": {
-              "line": 488,
+              "line": 437,
               "column": 25
             }
           },
@@ -4401,11 +7801,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 490,
+              "line": 439,
               "column": 8
             },
             "end": {
-              "line": 490,
+              "line": 439,
               "column": 22
             }
           },
@@ -4424,11 +7824,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 492,
+              "line": 441,
               "column": 8
             },
             "end": {
-              "line": 492,
+              "line": 441,
               "column": 24
             }
           },
@@ -4447,11 +7847,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 494,
+              "line": 443,
               "column": 8
             },
             "end": {
-              "line": 494,
+              "line": 443,
               "column": 18
             }
           },
@@ -4470,11 +7870,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 496,
+              "line": 445,
               "column": 8
             },
             "end": {
-              "line": 496,
+              "line": 445,
               "column": 15
             }
           },
@@ -4492,11 +7892,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 46,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 48,
+              "line": 51,
               "column": 5
             }
           },
@@ -4544,11 +7944,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 460,
+              "line": 452,
               "column": 6
             },
             "end": {
-              "line": 465,
+              "line": 457,
               "column": 7
             }
           },
@@ -4588,11 +7988,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 475,
+              "line": 467,
               "column": 6
             },
             "end": {
-              "line": 477,
+              "line": 469,
               "column": 7
             }
           },
@@ -4626,11 +8026,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 487,
+              "line": 479,
               "column": 6
             },
             "end": {
-              "line": 489,
+              "line": 481,
               "column": 7
             }
           },
@@ -4758,11 +8158,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 603,
+              "line": 553,
               "column": 6
             },
             "end": {
-              "line": 609,
+              "line": 559,
               "column": 7
             }
           },
@@ -4780,11 +8180,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 511,
+              "line": 460,
               "column": 6
             },
             "end": {
-              "line": 543,
+              "line": 493,
               "column": 7
             }
           },
@@ -5333,11 +8733,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1168,
+              "line": 1218,
               "column": 6
             },
             "end": {
-              "line": 1172,
+              "line": 1222,
               "column": 7
             }
           },
@@ -5452,11 +8852,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1206,
+              "line": 1256,
               "column": 6
             },
             "end": {
-              "line": 1214,
+              "line": 1264,
               "column": 7
             }
           },
@@ -5490,11 +8890,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1224,
+              "line": 1274,
               "column": 6
             },
             "end": {
-              "line": 1230,
+              "line": 1280,
               "column": 7
             }
           },
@@ -5528,11 +8928,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1241,
+              "line": 1291,
               "column": 6
             },
             "end": {
-              "line": 1244,
+              "line": 1294,
               "column": 7
             }
           },
@@ -5562,11 +8962,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1254,
+              "line": 1304,
               "column": 6
             },
             "end": {
-              "line": 1256,
+              "line": 1306,
               "column": 7
             }
           },
@@ -5591,11 +8991,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1266,
+              "line": 1316,
               "column": 6
             },
             "end": {
-              "line": 1268,
+              "line": 1318,
               "column": 7
             }
           },
@@ -5620,11 +9020,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1278,
+              "line": 1328,
               "column": 6
             },
             "end": {
-              "line": 1280,
+              "line": 1330,
               "column": 7
             }
           },
@@ -5649,11 +9049,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1290,
+              "line": 1340,
               "column": 6
             },
             "end": {
-              "line": 1292,
+              "line": 1342,
               "column": 7
             }
           },
@@ -5678,11 +9078,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1324,
+              "line": 1374,
               "column": 6
             },
             "end": {
-              "line": 1356,
+              "line": 1406,
               "column": 7
             }
           },
@@ -5722,11 +9122,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1379,
+              "line": 1429,
               "column": 6
             },
             "end": {
-              "line": 1387,
+              "line": 1437,
               "column": 7
             }
           },
@@ -5760,11 +9160,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1494,
+              "line": 1544,
               "column": 6
             },
             "end": {
-              "line": 1499,
+              "line": 1549,
               "column": 7
             }
           },
@@ -5788,11 +9188,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1520,
+              "line": 1570,
               "column": 6
             },
             "end": {
-              "line": 1531,
+              "line": 1581,
               "column": 7
             }
           },
@@ -5810,11 +9210,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1545,
+              "line": 1595,
               "column": 6
             },
             "end": {
-              "line": 1558,
+              "line": 1608,
               "column": 7
             }
           },
@@ -5832,11 +9232,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 621,
+              "line": 571,
               "column": 6
             },
             "end": {
-              "line": 630,
+              "line": 580,
               "column": 7
             }
           },
@@ -5854,11 +9254,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1587,
+              "line": 1637,
               "column": 6
             },
             "end": {
-              "line": 1598,
+              "line": 1648,
               "column": 7
             }
           },
@@ -5887,11 +9287,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1685,
+              "line": 1735,
               "column": 6
             },
             "end": {
-              "line": 1695,
+              "line": 1745,
               "column": 7
             }
           },
@@ -5925,11 +9325,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1706,
+              "line": 1756,
               "column": 6
             },
             "end": {
-              "line": 1711,
+              "line": 1761,
               "column": 7
             }
           },
@@ -5958,11 +9358,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1723,
+              "line": 1773,
               "column": 6
             },
             "end": {
-              "line": 1728,
+              "line": 1778,
               "column": 7
             }
           },
@@ -5986,11 +9386,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1760,
+              "line": 1810,
               "column": 6
             },
             "end": {
-              "line": 1764,
+              "line": 1814,
               "column": 7
             }
           },
@@ -6019,11 +9419,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1785,
+              "line": 1835,
               "column": 6
             },
             "end": {
-              "line": 1787,
+              "line": 1837,
               "column": 7
             }
           },
@@ -6053,11 +9453,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1810,
+              "line": 1860,
               "column": 6
             },
             "end": {
-              "line": 1820,
+              "line": 1870,
               "column": 7
             }
           },
@@ -6091,11 +9491,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1836,
+              "line": 1886,
               "column": 6
             },
             "end": {
-              "line": 1845,
+              "line": 1895,
               "column": 7
             }
           },
@@ -6126,11 +9526,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1860,
+              "line": 1910,
               "column": 6
             },
             "end": {
-              "line": 1869,
+              "line": 1919,
               "column": 7
             }
           },
@@ -6155,11 +9555,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1888,
+              "line": 1938,
               "column": 6
             },
             "end": {
-              "line": 1925,
+              "line": 1975,
               "column": 7
             }
           },
@@ -6200,11 +9600,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1940,
+              "line": 1990,
               "column": 6
             },
             "end": {
-              "line": 1949,
+              "line": 1999,
               "column": 7
             }
           },
@@ -6229,11 +9629,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1965,
+              "line": 2015,
               "column": 6
             },
             "end": {
-              "line": 1973,
+              "line": 2023,
               "column": 7
             }
           },
@@ -6264,11 +9664,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1988,
+              "line": 2038,
               "column": 6
             },
             "end": {
-              "line": 2005,
+              "line": 2055,
               "column": 7
             }
           },
@@ -6297,11 +9697,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2018,
+              "line": 2068,
               "column": 6
             },
             "end": {
-              "line": 2025,
+              "line": 2075,
               "column": 7
             }
           },
@@ -6330,11 +9730,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2039,
+              "line": 2089,
               "column": 6
             },
             "end": {
-              "line": 2049,
+              "line": 2099,
               "column": 7
             }
           },
@@ -6368,11 +9768,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2062,
+              "line": 2112,
               "column": 6
             },
             "end": {
-              "line": 2068,
+              "line": 2118,
               "column": 7
             }
           },
@@ -6401,11 +9801,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2079,
+              "line": 2129,
               "column": 6
             },
             "end": {
-              "line": 2087,
+              "line": 2137,
               "column": 7
             }
           },
@@ -6429,11 +9829,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2098,
+              "line": 2148,
               "column": 6
             },
             "end": {
-              "line": 2111,
+              "line": 2161,
               "column": 7
             }
           },
@@ -6457,11 +9857,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2125,
+              "line": 2175,
               "column": 6
             },
             "end": {
-              "line": 2131,
+              "line": 2181,
               "column": 7
             }
           },
@@ -6485,45 +9885,6 @@
           ],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_marshalArgs",
-          "description": "Gather the argument values for a method specified in the provided array\nof argument metadata.\n\nThe `path` and `value` arguments are used to fill in wildcard descriptor\nwhen the method is being called as a result of a path notification.",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2146,
-              "column": 6
-            },
-            "end": {
-              "line": 2181,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "args",
-              "type": "!Array.<!MethodArg>",
-              "description": "Array of argument metadata"
-            },
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Property/path name that triggered the method effect"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of current property changes"
-            }
-          ],
-          "return": {
-            "type": "Array.<*>",
-            "desc": "Array of argument values"
           },
           "inheritedFrom": "Polymer.PropertyEffects"
         },
@@ -6596,11 +9957,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 590,
+              "line": 540,
               "column": 6
             },
             "end": {
-              "line": 595,
+              "line": 545,
               "column": 7
             }
           },
@@ -6618,11 +9979,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 226,
+              "line": 216,
               "column": 6
             },
             "end": {
-              "line": 230,
+              "line": 220,
               "column": 7
             }
           },
@@ -6640,11 +10001,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 644,
+              "line": 594,
               "column": 6
             },
             "end": {
-              "line": 660,
+              "line": 610,
               "column": 7
             }
           },
@@ -6669,11 +10030,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 683,
+              "line": 633,
               "column": 6
             },
             "end": {
-              "line": 687,
+              "line": 637,
               "column": 7
             }
           },
@@ -6697,11 +10058,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 704,
+              "line": 654,
               "column": 6
             },
             "end": {
-              "line": 709,
+              "line": 659,
               "column": 7
             }
           },
@@ -6733,11 +10094,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 201,
+              "line": 197,
               "column": 6
             },
             "end": {
-              "line": 212,
+              "line": 208,
               "column": 7
             }
           },
@@ -6767,11 +10128,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 720,
+              "line": 670,
               "column": 6
             },
             "end": {
-              "line": 723,
+              "line": 673,
               "column": 7
             }
           },
@@ -6835,11 +10196,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 263,
+              "line": 258,
               "column": 6
             },
             "end": {
-              "line": 303,
+              "line": 295,
               "column": 7
             }
           },
@@ -6873,11 +10234,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2597,
+              "line": 2592,
               "column": 6
             },
             "end": {
-              "line": 2607,
+              "line": 2602,
               "column": 7
             }
           },
@@ -6912,11 +10273,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 341,
+              "line": 333,
               "column": 6
             },
             "end": {
-              "line": 350,
+              "line": 342,
               "column": 7
             }
           },
@@ -6955,7 +10316,7 @@
               "column": 6
             },
             "end": {
-              "line": 2581,
+              "line": 2576,
               "column": 7
             }
           },
@@ -7000,11 +10361,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 396,
+              "line": 388,
               "column": 6
             },
             "end": {
-              "line": 399,
+              "line": 391,
               "column": 7
             }
           },
@@ -7029,11 +10390,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 351,
-              "column": 6
+              "line": 326,
+              "column": 7
             },
             "end": {
-              "line": 355,
+              "line": 330,
               "column": 7
             }
           },
@@ -7084,11 +10445,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 190,
+              "line": 181,
               "column": 6
             },
             "end": {
-              "line": 193,
+              "line": 184,
               "column": 7
             }
           },
@@ -7439,11 +10800,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2653,
+              "line": 2648,
               "column": 6
             },
             "end": {
-              "line": 2718,
+              "line": 2713,
               "column": 7
             }
           },
@@ -7473,11 +10834,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2734,
+              "line": 2729,
               "column": 6
             },
             "end": {
-              "line": 2751,
+              "line": 2746,
               "column": 7
             }
           },
@@ -7527,11 +10888,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 138,
+              "line": 129,
               "column": 6
             },
             "end": {
-              "line": 147,
+              "line": 138,
               "column": 7
             }
           },
@@ -7549,33 +10910,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 319,
-              "column": 6
+              "line": 294,
+              "column": 5
             },
             "end": {
-              "line": 326,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_prepareTemplate",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 328,
-              "column": 6
-            },
-            "end": {
-              "line": 342,
+              "line": 317,
               "column": 7
             }
           },
@@ -7593,11 +10932,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 368,
+              "line": 343,
               "column": 6
             },
             "end": {
-              "line": 373,
+              "line": 348,
               "column": 7
             }
           },
@@ -7626,11 +10965,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 553,
+              "line": 503,
               "column": 6
             },
             "end": {
-              "line": 555,
+              "line": 505,
               "column": 7
             }
           },
@@ -7660,11 +10999,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 566,
+              "line": 516,
               "column": 6
             },
             "end": {
-              "line": 577,
+              "line": 527,
               "column": 7
             }
           },
@@ -7686,11 +11025,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 39,
+          "line": 42,
           "column": 1
         },
         "end": {
-          "line": 51,
+          "line": 54,
           "column": 2
         }
       },
@@ -7703,11 +11042,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 46,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 48,
+              "line": 51,
               "column": 5
             }
           },
@@ -7726,11 +11065,11 @@
           "name": "",
           "range": {
             "start": {
-              "line": 31,
+              "line": 34,
               "column": 3
             },
             "end": {
-              "line": 31,
+              "line": 34,
               "column": 16
             }
           }
@@ -7750,11 +11089,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 2
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 3
             }
           },
@@ -7771,11 +11110,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 83,
               "column": 2
             },
             "end": {
-              "line": 83,
+              "line": 85,
               "column": 3
             }
           },
@@ -7786,52 +11125,6 @@
           }
         },
         {
-          "name": "elements",
-          "type": "?",
-          "description": "Get an array of the elements generated by this repeater\n\t\t ",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 94,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "templateInstances",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 101,
-              "column": 2
-            },
-            "end": {
-              "line": 106,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -7839,11 +11132,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -7862,11 +11155,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -7885,11 +11178,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 5
             }
           },
@@ -7906,11 +11199,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 53,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 56,
               "column": 5
             }
           },
@@ -7928,11 +11221,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 56,
+              "line": 58,
               "column": 4
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 5
             }
           },
@@ -7951,11 +11244,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 66,
+              "line": 68,
               "column": 5
             }
           },
@@ -7968,16 +11261,193 @@
       ],
       "methods": [
         {
+          "name": "trackColumns",
+          "description": "Adds an observer to render the cells when the columns are changed.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 48,
+              "column": 2
+            },
+            "end": {
+              "line": 60,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "stopTrackingColumns",
+          "description": "Stops reacting to column changes.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 66,
+              "column": 2
+            },
+            "end": {
+              "line": 73,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "renderCells",
+          "description": "Renders all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 79,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "destroyCells",
+          "description": "Destroys all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 87,
+              "column": 2
+            },
+            "end": {
+              "line": 89,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardChange",
+          "description": "Forwards a property change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 97,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "String",
+              "description": "the property"
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "the new value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardPathChange",
+          "description": "Forwards a path change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 106,
+              "column": 2
+            },
+            "end": {
+              "line": 110,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changeRecord",
+              "type": "Object",
+              "description": "the change record"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forEachElement",
+          "description": "Runs a callback on each element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 117,
+              "column": 2
+            },
+            "end": {
+              "line": 119,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "callback",
+              "type": "OmnitableRepeaterMixin~forEachElementCallback",
+              "description": "the callback"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 90,
               "column": 2
             },
             "end": {
-              "line": 87,
+              "line": 95,
               "column": 3
             }
           },
@@ -7989,46 +11459,16 @@
           ]
         },
         {
-          "name": "_detachTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 2
-            },
-            "end": {
-              "line": 91,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "column"
-            },
-            {
-              "name": "element"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_configureElement",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 100,
               "column": 2
             },
             "end": {
-              "line": 95,
+              "line": 103,
               "column": 3
             }
           },
@@ -8039,28 +11479,7 @@
             },
             {
               "name": "column"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
-          "name": "_configureTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 97,
-              "column": 2
             },
-            "end": {
-              "line": 104,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
             {
               "name": "instance"
             }
@@ -8068,64 +11487,6 @@
           "return": {
             "type": "void"
           }
-        },
-        {
-          "name": "getElementTemplateInstance",
-          "description": "Get the template instance rendered by the specified element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 113,
-              "column": 2
-            },
-            "end": {
-              "line": 115,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The instance."
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "getElementColumn",
-          "description": "Get the column that was used to rendered the specified element",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 122,
-              "column": 2
-            },
-            "end": {
-              "line": 124,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The column."
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
           "name": "_columnsChanged",
@@ -8134,11 +11495,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 126,
+              "line": 171,
               "column": 2
             },
             "end": {
-              "line": 150,
+              "line": 195,
               "column": 3
             }
           },
@@ -8160,11 +11521,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 152,
+              "line": 197,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 206,
               "column": 3
             }
           },
@@ -8186,11 +11547,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 163,
+              "line": 208,
               "column": 2
             },
             "end": {
-              "line": 201,
+              "line": 234,
               "column": 3
             }
           },
@@ -8215,11 +11576,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 203,
+              "line": 236,
               "column": 2
             },
             "end": {
-              "line": 211,
+              "line": 244,
               "column": 3
             }
           },
@@ -8244,11 +11605,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 213,
+              "line": 246,
               "column": 2
             },
             "end": {
-              "line": 229,
+              "line": 262,
               "column": 3
             }
           },
@@ -8267,53 +11628,17 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
-          "name": "_forwardProperty",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 231,
-              "column": 2
-            },
-            "end": {
-              "line": 237,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "value"
-            },
-            {
-              "name": "flush",
-              "defaultValue": "false"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 239,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 269,
               "column": 3
             }
           },
@@ -8327,10 +11652,6 @@
             },
             {
               "name": "value"
-            },
-            {
-              "name": "isPathNotification",
-              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -8348,11 +11669,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 106,
+              "line": 105,
               "column": 2
             },
             "end": {
-              "line": 115,
+              "line": 114,
               "column": 3
             }
           },
@@ -8372,18 +11693,18 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 117,
+              "line": 116,
               "column": 2
             },
             "end": {
-              "line": 127,
+              "line": 118,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "itemChange"
+              "name": "changeRecord"
             }
           ],
           "return": {
@@ -8396,11 +11717,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 129,
+              "line": 120,
               "column": 2
             },
             "end": {
-              "line": 133,
+              "line": 122,
               "column": 3
             }
           },
@@ -8420,11 +11741,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 135,
+              "line": 124,
               "column": 2
             },
             "end": {
-              "line": 139,
+              "line": 134,
               "column": 3
             }
           },
@@ -8432,6 +11753,9 @@
           "params": [
             {
               "name": "expanded"
+            },
+            {
+              "name": "prevValue"
             }
           ],
           "return": {
@@ -8444,11 +11768,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 38,
+          "line": 40,
           "column": 1
         },
         "end": {
-          "line": 140,
+          "line": 135,
           "column": 2
         }
       },
@@ -8462,11 +11786,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -8480,11 +11804,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -8497,11 +11821,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 5
             }
           },
@@ -8513,11 +11837,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 53,
               "column": 4
             },
             "end": {
-              "line": 54,
+              "line": 56,
               "column": 5
             }
           },
@@ -8529,11 +11853,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 56,
+              "line": 58,
               "column": 4
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 5
             }
           },
@@ -8545,11 +11869,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 4
             },
             "end": {
-              "line": 66,
+              "line": 68,
               "column": 5
             }
           },
@@ -8568,11 +11892,11 @@
           "name": "item-expand-line",
           "range": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 2
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 39
             }
           }
@@ -8595,11 +11919,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 3
             },
             "end": {
-              "line": 54,
+              "line": 56,
               "column": 4
             }
           },
@@ -8616,11 +11940,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 56,
+              "line": 58,
               "column": 3
             },
             "end": {
-              "line": 58,
+              "line": 60,
               "column": 4
             }
           },
@@ -8631,52 +11955,6 @@
           }
         },
         {
-          "name": "elements",
-          "type": "?",
-          "description": "Get an array of the elements generated by this repeater\n\t\t ",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 94,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "templateInstances",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 101,
-              "column": 2
-            },
-            "end": {
-              "line": 106,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "columns",
           "type": "Array | null | undefined",
           "description": "",
@@ -8684,11 +11962,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -8707,11 +11985,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -8730,11 +12008,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 5
             },
             "end": {
-              "line": 28,
+              "line": 30,
               "column": 6
             }
           },
@@ -8752,11 +12030,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 5
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 6
             }
           },
@@ -8773,11 +12051,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 5
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 6
             }
           },
@@ -8795,11 +12073,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 5
             },
             "end": {
-              "line": 42,
+              "line": 44,
               "column": 6
             }
           },
@@ -8813,16 +12091,193 @@
       ],
       "methods": [
         {
+          "name": "trackColumns",
+          "description": "Adds an observer to render the cells when the columns are changed.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 48,
+              "column": 2
+            },
+            "end": {
+              "line": 60,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "stopTrackingColumns",
+          "description": "Stops reacting to column changes.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 66,
+              "column": 2
+            },
+            "end": {
+              "line": 73,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "renderCells",
+          "description": "Renders all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 79,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "destroyCells",
+          "description": "Destroys all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 87,
+              "column": 2
+            },
+            "end": {
+              "line": 89,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardChange",
+          "description": "Forwards a property change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 97,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "String",
+              "description": "the property"
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "the new value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forwardPathChange",
+          "description": "Forwards a path change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 106,
+              "column": 2
+            },
+            "end": {
+              "line": 110,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changeRecord",
+              "type": "Object",
+              "description": "the change record"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
+          "name": "forEachElement",
+          "description": "Runs a callback on each element.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-repeater-mixin.html",
+            "start": {
+              "line": 117,
+              "column": 2
+            },
+            "end": {
+              "line": 119,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "callback",
+              "type": "OmnitableRepeaterMixin~forEachElementCallback",
+              "description": "the callback"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
+        },
+        {
           "name": "_getTemplateInstance",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 81,
               "column": 3
             },
             "end": {
-              "line": 73,
+              "line": 86,
               "column": 4
             }
           },
@@ -8834,142 +12289,40 @@
           ]
         },
         {
-          "name": "_detachTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 75,
-              "column": 3
-            },
-            "end": {
-              "line": 77,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "column"
-            },
-            {
-              "name": "element"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_configureElement",
-          "description": "Configure a newly created repeated element\nMust be defined in implementors.",
+          "description": "Configure a newly created repeated element",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 79,
+              "line": 160,
               "column": 2
             },
             "end": {
-              "line": 79,
-              "column": 31
+              "line": 169,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
               "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "undefined"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "_configureTemplateInstance",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 79,
-              "column": 3
+              "type": "HTMLElement",
+              "description": "the root cell element"
             },
-            "end": {
-              "line": 86,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
             {
-              "name": "instance"
+              "name": "column",
+              "type": "OmnitableColumnMixin",
+              "description": "the column"
+            },
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "the template instance"
             }
           ],
           "return": {
             "type": "void"
-          }
-        },
-        {
-          "name": "getElementTemplateInstance",
-          "description": "Get the template instance rendered by the specified element.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 113,
-              "column": 2
-            },
-            "end": {
-              "line": 115,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The instance."
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
-          "name": "getElementColumn",
-          "description": "Get the column that was used to rendered the specified element",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 122,
-              "column": 2
-            },
-            "end": {
-              "line": 124,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The column."
           },
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
@@ -8980,11 +12333,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 126,
+              "line": 171,
               "column": 2
             },
             "end": {
-              "line": 150,
+              "line": 195,
               "column": 3
             }
           },
@@ -9006,11 +12359,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 152,
+              "line": 197,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 206,
               "column": 3
             }
           },
@@ -9032,11 +12385,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 163,
+              "line": 208,
               "column": 2
             },
             "end": {
-              "line": 201,
+              "line": 234,
               "column": 3
             }
           },
@@ -9061,11 +12414,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 203,
+              "line": 236,
               "column": 2
             },
             "end": {
-              "line": 211,
+              "line": 244,
               "column": 3
             }
           },
@@ -9090,11 +12443,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 213,
+              "line": 246,
               "column": 2
             },
             "end": {
-              "line": 229,
+              "line": 262,
               "column": 3
             }
           },
@@ -9113,53 +12466,17 @@
           "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
         },
         {
-          "name": "_forwardProperty",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-repeater-mixin.html",
-            "start": {
-              "line": 231,
-              "column": 2
-            },
-            "end": {
-              "line": 237,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "value"
-            },
-            {
-              "name": "flush",
-              "defaultValue": "false"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableRepeaterMixin"
-        },
-        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 239,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 269,
               "column": 3
             }
           },
@@ -9173,10 +12490,6 @@
             },
             {
               "name": "value"
-            },
-            {
-              "name": "isPathNotification",
-              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -9194,11 +12507,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 67,
               "column": 3
             },
             "end": {
-              "line": 69,
+              "line": 76,
               "column": 4
             }
           },
@@ -9222,14 +12535,14 @@
               "column": 3
             },
             "end": {
-              "line": 98,
+              "line": 90,
               "column": 4
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "itemChange"
+              "name": "changeRecord"
             }
           ],
           "return": {
@@ -9242,11 +12555,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 92,
               "column": 3
             },
             "end": {
-              "line": 104,
+              "line": 94,
               "column": 4
             }
           },
@@ -9261,40 +12574,16 @@
           }
         },
         {
-          "name": "_expandedChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 106,
-              "column": 3
-            },
-            "end": {
-              "line": 110,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "expanded"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_foldedChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 112,
+              "line": 96,
               "column": 3
             },
             "end": {
-              "line": 116,
+              "line": 98,
               "column": 4
             }
           },
@@ -9314,11 +12603,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 16,
+          "line": 18,
           "column": 2
         },
         "end": {
-          "line": 117,
+          "line": 99,
           "column": 3
         }
       },
@@ -9332,11 +12621,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -9350,11 +12639,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-repeater-mixin.html",
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -9367,11 +12656,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 5
             },
             "end": {
-              "line": 28,
+              "line": 30,
               "column": 6
             }
           },
@@ -9383,11 +12672,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 5
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 6
             }
           },
@@ -9399,11 +12688,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 5
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 6
             }
           },
@@ -9415,11 +12704,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 5
             },
             "end": {
-              "line": 42,
+              "line": 44,
               "column": 6
             }
           },
@@ -9438,11 +12727,11 @@
           "name": "group-row",
           "range": {
             "start": {
-              "line": 6,
+              "line": 8,
               "column": 2
             },
             "end": {
-              "line": 6,
+              "line": 8,
               "column": 32
             }
           }
@@ -9466,11 +12755,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1098,
+              "line": 1148,
               "column": 8
             },
             "end": {
-              "line": 1098,
+              "line": 1148,
               "column": 32
             }
           },
@@ -9489,11 +12778,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1100,
+              "line": 1150,
               "column": 8
             },
             "end": {
-              "line": 1100,
+              "line": 1150,
               "column": 34
             }
           },
@@ -9512,11 +12801,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1102,
+              "line": 1152,
               "column": 8
             },
             "end": {
-              "line": 1102,
+              "line": 1152,
               "column": 28
             }
           },
@@ -9535,11 +12824,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1104,
+              "line": 1154,
               "column": 8
             },
             "end": {
-              "line": 1104,
+              "line": 1154,
               "column": 31
             }
           },
@@ -9558,11 +12847,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1106,
+              "line": 1156,
               "column": 8
             },
             "end": {
-              "line": 1106,
+              "line": 1156,
               "column": 28
             }
           },
@@ -9581,11 +12870,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1108,
+              "line": 1158,
               "column": 8
             },
             "end": {
-              "line": 1108,
+              "line": 1158,
               "column": 35
             }
           },
@@ -9604,11 +12893,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1110,
+              "line": 1160,
               "column": 8
             },
             "end": {
-              "line": 1110,
+              "line": 1160,
               "column": 24
             }
           },
@@ -9627,11 +12916,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1112,
+              "line": 1162,
               "column": 8
             },
             "end": {
-              "line": 1112,
+              "line": 1162,
               "column": 24
             }
           },
@@ -9650,11 +12939,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1114,
+              "line": 1164,
               "column": 8
             },
             "end": {
-              "line": 1114,
+              "line": 1164,
               "column": 38
             }
           },
@@ -9673,11 +12962,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1116,
+              "line": 1166,
               "column": 8
             },
             "end": {
-              "line": 1116,
+              "line": 1166,
               "column": 20
             }
           },
@@ -9696,11 +12985,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1118,
+              "line": 1168,
               "column": 8
             },
             "end": {
-              "line": 1118,
+              "line": 1168,
               "column": 27
             }
           },
@@ -9719,11 +13008,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1120,
+              "line": 1170,
               "column": 8
             },
             "end": {
-              "line": 1120,
+              "line": 1170,
               "column": 23
             }
           },
@@ -9742,11 +13031,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1122,
+              "line": 1172,
               "column": 8
             },
             "end": {
-              "line": 1122,
+              "line": 1172,
               "column": 30
             }
           },
@@ -9765,11 +13054,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1124,
+              "line": 1174,
               "column": 8
             },
             "end": {
-              "line": 1124,
+              "line": 1174,
               "column": 30
             }
           },
@@ -9788,11 +13077,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1126,
+              "line": 1176,
               "column": 8
             },
             "end": {
-              "line": 1126,
+              "line": 1176,
               "column": 29
             }
           },
@@ -9811,11 +13100,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1128,
+              "line": 1178,
               "column": 8
             },
             "end": {
-              "line": 1128,
+              "line": 1178,
               "column": 32
             }
           },
@@ -9834,11 +13123,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1130,
+              "line": 1180,
               "column": 8
             },
             "end": {
-              "line": 1130,
+              "line": 1180,
               "column": 30
             }
           },
@@ -9857,11 +13146,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1132,
+              "line": 1182,
               "column": 8
             },
             "end": {
-              "line": 1132,
+              "line": 1182,
               "column": 24
             }
           },
@@ -9880,11 +13169,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1134,
+              "line": 1184,
               "column": 8
             },
             "end": {
-              "line": 1134,
+              "line": 1184,
               "column": 28
             }
           },
@@ -9903,11 +13192,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1137,
+              "line": 1187,
               "column": 6
             },
             "end": {
-              "line": 1139,
+              "line": 1189,
               "column": 7
             }
           },
@@ -9926,11 +13215,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 486,
+              "line": 435,
               "column": 8
             },
             "end": {
-              "line": 486,
+              "line": 435,
               "column": 23
             }
           },
@@ -9949,11 +13238,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 488,
+              "line": 437,
               "column": 8
             },
             "end": {
-              "line": 488,
+              "line": 437,
               "column": 25
             }
           },
@@ -9972,11 +13261,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 490,
+              "line": 439,
               "column": 8
             },
             "end": {
-              "line": 490,
+              "line": 439,
               "column": 22
             }
           },
@@ -9995,11 +13284,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 492,
+              "line": 441,
               "column": 8
             },
             "end": {
-              "line": 492,
+              "line": 441,
               "column": 24
             }
           },
@@ -10018,11 +13307,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 494,
+              "line": 443,
               "column": 8
             },
             "end": {
-              "line": 494,
+              "line": 443,
               "column": 18
             }
           },
@@ -10041,11 +13330,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 496,
+              "line": 445,
               "column": 8
             },
             "end": {
-              "line": 496,
+              "line": 445,
               "column": 15
             }
           },
@@ -10063,11 +13352,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 5
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 6
             }
           },
@@ -10116,11 +13405,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 460,
+              "line": 452,
               "column": 6
             },
             "end": {
-              "line": 465,
+              "line": 457,
               "column": 7
             }
           },
@@ -10160,11 +13449,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 475,
+              "line": 467,
               "column": 6
             },
             "end": {
-              "line": 477,
+              "line": 469,
               "column": 7
             }
           },
@@ -10198,11 +13487,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 487,
+              "line": 479,
               "column": 6
             },
             "end": {
-              "line": 489,
+              "line": 481,
               "column": 7
             }
           },
@@ -10330,11 +13619,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 603,
+              "line": 553,
               "column": 6
             },
             "end": {
-              "line": 609,
+              "line": 559,
               "column": 7
             }
           },
@@ -10352,11 +13641,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 511,
+              "line": 460,
               "column": 6
             },
             "end": {
-              "line": 543,
+              "line": 493,
               "column": 7
             }
           },
@@ -10905,11 +14194,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1168,
+              "line": 1218,
               "column": 6
             },
             "end": {
-              "line": 1172,
+              "line": 1222,
               "column": 7
             }
           },
@@ -11024,11 +14313,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1206,
+              "line": 1256,
               "column": 6
             },
             "end": {
-              "line": 1214,
+              "line": 1264,
               "column": 7
             }
           },
@@ -11062,11 +14351,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1224,
+              "line": 1274,
               "column": 6
             },
             "end": {
-              "line": 1230,
+              "line": 1280,
               "column": 7
             }
           },
@@ -11100,11 +14389,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1241,
+              "line": 1291,
               "column": 6
             },
             "end": {
-              "line": 1244,
+              "line": 1294,
               "column": 7
             }
           },
@@ -11134,11 +14423,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1254,
+              "line": 1304,
               "column": 6
             },
             "end": {
-              "line": 1256,
+              "line": 1306,
               "column": 7
             }
           },
@@ -11163,11 +14452,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1266,
+              "line": 1316,
               "column": 6
             },
             "end": {
-              "line": 1268,
+              "line": 1318,
               "column": 7
             }
           },
@@ -11192,11 +14481,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1278,
+              "line": 1328,
               "column": 6
             },
             "end": {
-              "line": 1280,
+              "line": 1330,
               "column": 7
             }
           },
@@ -11221,11 +14510,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1290,
+              "line": 1340,
               "column": 6
             },
             "end": {
-              "line": 1292,
+              "line": 1342,
               "column": 7
             }
           },
@@ -11250,11 +14539,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1324,
+              "line": 1374,
               "column": 6
             },
             "end": {
-              "line": 1356,
+              "line": 1406,
               "column": 7
             }
           },
@@ -11294,11 +14583,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1379,
+              "line": 1429,
               "column": 6
             },
             "end": {
-              "line": 1387,
+              "line": 1437,
               "column": 7
             }
           },
@@ -11332,11 +14621,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1494,
+              "line": 1544,
               "column": 6
             },
             "end": {
-              "line": 1499,
+              "line": 1549,
               "column": 7
             }
           },
@@ -11360,11 +14649,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1520,
+              "line": 1570,
               "column": 6
             },
             "end": {
-              "line": 1531,
+              "line": 1581,
               "column": 7
             }
           },
@@ -11382,11 +14671,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1545,
+              "line": 1595,
               "column": 6
             },
             "end": {
-              "line": 1558,
+              "line": 1608,
               "column": 7
             }
           },
@@ -11404,11 +14693,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 621,
+              "line": 571,
               "column": 6
             },
             "end": {
-              "line": 630,
+              "line": 580,
               "column": 7
             }
           },
@@ -11426,11 +14715,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1587,
+              "line": 1637,
               "column": 6
             },
             "end": {
-              "line": 1598,
+              "line": 1648,
               "column": 7
             }
           },
@@ -11459,11 +14748,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1685,
+              "line": 1735,
               "column": 6
             },
             "end": {
-              "line": 1695,
+              "line": 1745,
               "column": 7
             }
           },
@@ -11497,11 +14786,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1706,
+              "line": 1756,
               "column": 6
             },
             "end": {
-              "line": 1711,
+              "line": 1761,
               "column": 7
             }
           },
@@ -11530,11 +14819,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1723,
+              "line": 1773,
               "column": 6
             },
             "end": {
-              "line": 1728,
+              "line": 1778,
               "column": 7
             }
           },
@@ -11558,11 +14847,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1760,
+              "line": 1810,
               "column": 6
             },
             "end": {
-              "line": 1764,
+              "line": 1814,
               "column": 7
             }
           },
@@ -11591,11 +14880,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1785,
+              "line": 1835,
               "column": 6
             },
             "end": {
-              "line": 1787,
+              "line": 1837,
               "column": 7
             }
           },
@@ -11625,11 +14914,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1810,
+              "line": 1860,
               "column": 6
             },
             "end": {
-              "line": 1820,
+              "line": 1870,
               "column": 7
             }
           },
@@ -11663,11 +14952,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1836,
+              "line": 1886,
               "column": 6
             },
             "end": {
-              "line": 1845,
+              "line": 1895,
               "column": 7
             }
           },
@@ -11698,11 +14987,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1860,
+              "line": 1910,
               "column": 6
             },
             "end": {
-              "line": 1869,
+              "line": 1919,
               "column": 7
             }
           },
@@ -11727,11 +15016,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1888,
+              "line": 1938,
               "column": 6
             },
             "end": {
-              "line": 1925,
+              "line": 1975,
               "column": 7
             }
           },
@@ -11772,11 +15061,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1940,
+              "line": 1990,
               "column": 6
             },
             "end": {
-              "line": 1949,
+              "line": 1999,
               "column": 7
             }
           },
@@ -11801,11 +15090,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1965,
+              "line": 2015,
               "column": 6
             },
             "end": {
-              "line": 1973,
+              "line": 2023,
               "column": 7
             }
           },
@@ -11836,11 +15125,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 1988,
+              "line": 2038,
               "column": 6
             },
             "end": {
-              "line": 2005,
+              "line": 2055,
               "column": 7
             }
           },
@@ -11869,11 +15158,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2018,
+              "line": 2068,
               "column": 6
             },
             "end": {
-              "line": 2025,
+              "line": 2075,
               "column": 7
             }
           },
@@ -11902,11 +15191,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2039,
+              "line": 2089,
               "column": 6
             },
             "end": {
-              "line": 2049,
+              "line": 2099,
               "column": 7
             }
           },
@@ -11940,11 +15229,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2062,
+              "line": 2112,
               "column": 6
             },
             "end": {
-              "line": 2068,
+              "line": 2118,
               "column": 7
             }
           },
@@ -11973,11 +15262,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2079,
+              "line": 2129,
               "column": 6
             },
             "end": {
-              "line": 2087,
+              "line": 2137,
               "column": 7
             }
           },
@@ -12001,11 +15290,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2098,
+              "line": 2148,
               "column": 6
             },
             "end": {
-              "line": 2111,
+              "line": 2161,
               "column": 7
             }
           },
@@ -12029,11 +15318,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2125,
+              "line": 2175,
               "column": 6
             },
             "end": {
-              "line": 2131,
+              "line": 2181,
               "column": 7
             }
           },
@@ -12057,45 +15346,6 @@
           ],
           "return": {
             "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_marshalArgs",
-          "description": "Gather the argument values for a method specified in the provided array\nof argument metadata.\n\nThe `path` and `value` arguments are used to fill in wildcard descriptor\nwhen the method is being called as a result of a path notification.",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2146,
-              "column": 6
-            },
-            "end": {
-              "line": 2181,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "args",
-              "type": "!Array.<!MethodArg>",
-              "description": "Array of argument metadata"
-            },
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Property/path name that triggered the method effect"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of current property changes"
-            }
-          ],
-          "return": {
-            "type": "Array.<*>",
-            "desc": "Array of argument values"
           },
           "inheritedFrom": "Polymer.PropertyEffects"
         },
@@ -12168,11 +15418,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 590,
+              "line": 540,
               "column": 6
             },
             "end": {
-              "line": 595,
+              "line": 545,
               "column": 7
             }
           },
@@ -12190,11 +15440,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 226,
+              "line": 216,
               "column": 6
             },
             "end": {
-              "line": 230,
+              "line": 220,
               "column": 7
             }
           },
@@ -12212,11 +15462,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 644,
+              "line": 594,
               "column": 6
             },
             "end": {
-              "line": 660,
+              "line": 610,
               "column": 7
             }
           },
@@ -12241,11 +15491,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 683,
+              "line": 633,
               "column": 6
             },
             "end": {
-              "line": 687,
+              "line": 637,
               "column": 7
             }
           },
@@ -12269,11 +15519,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 704,
+              "line": 654,
               "column": 6
             },
             "end": {
-              "line": 709,
+              "line": 659,
               "column": 7
             }
           },
@@ -12302,11 +15552,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 3
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 4
             }
           },
@@ -12325,11 +15575,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 201,
+              "line": 197,
               "column": 6
             },
             "end": {
-              "line": 212,
+              "line": 208,
               "column": 7
             }
           },
@@ -12359,11 +15609,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 720,
+              "line": 670,
               "column": 6
             },
             "end": {
-              "line": 723,
+              "line": 673,
               "column": 7
             }
           },
@@ -12427,11 +15677,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 263,
+              "line": 258,
               "column": 6
             },
             "end": {
-              "line": 303,
+              "line": 295,
               "column": 7
             }
           },
@@ -12465,11 +15715,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2597,
+              "line": 2592,
               "column": 6
             },
             "end": {
-              "line": 2607,
+              "line": 2602,
               "column": 7
             }
           },
@@ -12504,11 +15754,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 341,
+              "line": 333,
               "column": 6
             },
             "end": {
-              "line": 350,
+              "line": 342,
               "column": 7
             }
           },
@@ -12547,7 +15797,7 @@
               "column": 6
             },
             "end": {
-              "line": 2581,
+              "line": 2576,
               "column": 7
             }
           },
@@ -12592,11 +15842,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/template-stamp.html",
             "start": {
-              "line": 396,
+              "line": 388,
               "column": 6
             },
             "end": {
-              "line": 399,
+              "line": 391,
               "column": 7
             }
           },
@@ -12621,11 +15871,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 351,
-              "column": 6
+              "line": 326,
+              "column": 7
             },
             "end": {
-              "line": 355,
+              "line": 330,
               "column": 7
             }
           },
@@ -12676,11 +15926,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 190,
+              "line": 181,
               "column": 6
             },
             "end": {
-              "line": 193,
+              "line": 184,
               "column": 7
             }
           },
@@ -13031,11 +16281,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2653,
+              "line": 2648,
               "column": 6
             },
             "end": {
-              "line": 2718,
+              "line": 2713,
               "column": 7
             }
           },
@@ -13065,11 +16315,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/property-effects.html",
             "start": {
-              "line": 2734,
+              "line": 2729,
               "column": 6
             },
             "end": {
-              "line": 2751,
+              "line": 2746,
               "column": 7
             }
           },
@@ -13119,11 +16369,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/properties-mixin.html",
             "start": {
-              "line": 138,
+              "line": 129,
               "column": 6
             },
             "end": {
-              "line": 147,
+              "line": 138,
               "column": 7
             }
           },
@@ -13141,33 +16391,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 319,
-              "column": 6
+              "line": 294,
+              "column": 5
             },
             "end": {
-              "line": 326,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_prepareTemplate",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 328,
-              "column": 6
-            },
-            "end": {
-              "line": 342,
+              "line": 317,
               "column": 7
             }
           },
@@ -13185,11 +16413,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 368,
+              "line": 343,
               "column": 6
             },
             "end": {
-              "line": 373,
+              "line": 348,
               "column": 7
             }
           },
@@ -13218,11 +16446,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 553,
+              "line": 503,
               "column": 6
             },
             "end": {
-              "line": 555,
+              "line": 505,
               "column": 7
             }
           },
@@ -13252,11 +16480,11 @@
           "sourceRange": {
             "file": "../polymer/lib/mixins/element-mixin.html",
             "start": {
-              "line": 566,
+              "line": 516,
               "column": 6
             },
             "end": {
-              "line": 577,
+              "line": 527,
               "column": 7
             }
           },
@@ -13278,11 +16506,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 24,
+          "line": 26,
           "column": 2
         },
         "end": {
-          "line": 49,
+          "line": 51,
           "column": 3
         }
       },
@@ -13295,11 +16523,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 5
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 6
             }
           },
@@ -13328,11 +16556,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -13353,11 +16581,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -13376,11 +16604,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 30,
+              "line": 34,
               "column": 4
             },
             "end": {
-              "line": 33,
+              "line": 37,
               "column": 5
             }
           },
@@ -13400,11 +16628,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 35,
+              "line": 39,
               "column": 4
             },
             "end": {
-              "line": 38,
+              "line": 42,
               "column": 5
             }
           },
@@ -13424,11 +16652,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -13448,11 +16676,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 54,
               "column": 5
             }
           },
@@ -13471,11 +16699,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 52,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 59,
               "column": 5
             }
           },
@@ -13495,11 +16723,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 57,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -13519,11 +16747,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 65,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 72,
               "column": 5
             }
           },
@@ -13536,98 +16764,6 @@
           "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -13635,11 +16771,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -13659,11 +16795,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -13682,11 +16818,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -13707,11 +16843,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -13731,11 +16867,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -13756,11 +16892,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -13780,11 +16916,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -13805,11 +16941,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -13829,11 +16965,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -13852,11 +16988,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -13876,11 +17012,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -13900,11 +17036,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -13924,11 +17060,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 90,
               "column": 5
             },
             "end": {
-              "line": 88,
+              "line": 93,
               "column": 6
             }
           },
@@ -13946,11 +17082,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 89,
+              "line": 94,
               "column": 5
             },
             "end": {
-              "line": 92,
+              "line": 97,
               "column": 6
             }
           },
@@ -13969,11 +17105,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -13993,11 +17129,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -14017,11 +17153,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -14040,11 +17176,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 94,
+              "line": 99,
               "column": 5
             },
             "end": {
-              "line": 97,
+              "line": 102,
               "column": 6
             }
           },
@@ -14062,11 +17198,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 98,
+              "line": 103,
               "column": 5
             },
             "end": {
-              "line": 101,
+              "line": 106,
               "column": 6
             }
           },
@@ -14085,11 +17221,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -14108,11 +17244,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -14132,11 +17268,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -14146,30 +17282,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -14267,65 +17379,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "currency",
           "type": "string | null | undefined",
           "description": "Base Currency used in filters",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 73,
               "column": 6
             }
           },
@@ -14342,11 +17406,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 78,
               "column": 5
             },
             "end": {
-              "line": 76,
+              "line": 81,
               "column": 6
             }
           },
@@ -14364,11 +17428,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 87,
               "column": 5
             },
             "end": {
-              "line": 84,
+              "line": 89,
               "column": 6
             }
           },
@@ -14385,11 +17449,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 102,
+              "line": 107,
               "column": 5
             },
             "end": {
-              "line": 105,
+              "line": 110,
               "column": 6
             }
           },
@@ -14404,16 +17468,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "",
+          "description": "Cleans up references to recycled instances when the element is detached.",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-range-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 79,
+              "line": 77,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 80,
               "column": 3
             }
           },
@@ -14422,7 +17486,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.RangeColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
           "name": "toNumber",
@@ -14431,11 +17495,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 91,
+              "line": 95,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 3
             }
           },
@@ -14469,11 +17533,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 188,
+              "line": 193,
               "column": 3
             },
             "end": {
-              "line": 190,
+              "line": 195,
               "column": 4
             }
           },
@@ -14486,11 +17550,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 203,
+              "line": 208,
               "column": 3
             },
             "end": {
-              "line": 217,
+              "line": 222,
               "column": 4
             }
           },
@@ -14518,11 +17582,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 192,
+              "line": 197,
               "column": 3
             },
             "end": {
-              "line": 194,
+              "line": 199,
               "column": 4
             }
           },
@@ -14543,11 +17607,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 218,
+              "line": 223,
               "column": 3
             },
             "end": {
-              "line": 227,
+              "line": 232,
               "column": 4
             }
           },
@@ -14568,11 +17632,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 253,
+              "line": 258,
               "column": 3
             },
             "end": {
-              "line": 260,
+              "line": 265,
               "column": 4
             }
           },
@@ -14596,11 +17660,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 154,
+              "line": 158,
               "column": 2
             },
             "end": {
-              "line": 157,
+              "line": 161,
               "column": 3
             }
           },
@@ -14623,11 +17687,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 165,
+              "line": 169,
               "column": 2
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 3
             }
           },
@@ -14652,11 +17716,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 2
             },
             "end": {
-              "line": 200,
+              "line": 204,
               "column": 3
             }
           },
@@ -14684,11 +17748,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -14703,11 +17767,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -14729,11 +17793,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 228,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 245,
+              "line": 249,
               "column": 3
             }
           },
@@ -14752,11 +17816,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 247,
+              "line": 251,
               "column": 2
             },
             "end": {
-              "line": 252,
+              "line": 256,
               "column": 3
             }
           },
@@ -14777,11 +17841,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 299,
+              "line": 304,
               "column": 3
             },
             "end": {
-              "line": 308,
+              "line": 313,
               "column": 4
             }
           },
@@ -14801,11 +17865,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 278,
+              "line": 283,
               "column": 3
             },
             "end": {
-              "line": 284,
+              "line": 289,
               "column": 4
             }
           },
@@ -14823,11 +17887,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -14842,11 +17906,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 279,
+              "line": 283,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 293,
               "column": 3
             }
           },
@@ -14870,11 +17934,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 295,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 3
             }
           },
@@ -14892,11 +17956,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 340,
               "column": 3
             }
           },
@@ -14914,11 +17978,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 338,
+              "line": 342,
               "column": 2
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 3
             }
           },
@@ -14940,11 +18004,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -14969,11 +18033,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -14993,11 +18057,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -15015,11 +18079,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 310,
+              "line": 315,
               "column": 3
             },
             "end": {
-              "line": 315,
+              "line": 320,
               "column": 4
             }
           },
@@ -15036,11 +18100,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 317,
+              "line": 322,
               "column": 3
             },
             "end": {
-              "line": 329,
+              "line": 334,
               "column": 4
             }
           },
@@ -15052,71 +18116,324 @@
           ]
         },
         {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 242,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 235,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_createTemplatizer",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 248,
-              "column": 2
-            },
-            "end": {
-              "line": 272,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateElementOrSelector"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_cellTemplateChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 274,
-              "column": 2
-            },
-            "end": {
-              "line": 278,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cellTemplate"
-            }
-          ],
           "return": {
             "type": "void"
           },
@@ -15129,11 +18446,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -15149,62 +18466,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -15223,11 +18495,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -15255,11 +18527,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -15281,11 +18553,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -15316,11 +18588,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -15338,11 +18610,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -15364,11 +18636,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -15386,11 +18658,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -15408,11 +18680,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -15430,11 +18702,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -15452,11 +18724,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -15473,11 +18745,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 121,
               "column": 3
             },
             "end": {
-              "line": 141,
+              "line": 146,
               "column": 4
             }
           },
@@ -15509,11 +18781,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 151,
+              "line": 156,
               "column": 3
             },
             "end": {
-              "line": 186,
+              "line": 191,
               "column": 4
             }
           },
@@ -15546,11 +18818,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 229,
+              "line": 234,
               "column": 3
             },
             "end": {
-              "line": 232,
+              "line": 237,
               "column": 4
             }
           },
@@ -15570,11 +18842,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 234,
+              "line": 239,
               "column": 3
             },
             "end": {
-              "line": 245,
+              "line": 250,
               "column": 4
             }
           },
@@ -15594,11 +18866,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 262,
+              "line": 267,
               "column": 3
             },
             "end": {
-              "line": 276,
+              "line": 281,
               "column": 4
             }
           },
@@ -15618,11 +18890,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 286,
+              "line": 291,
               "column": 3
             },
             "end": {
-              "line": 297,
+              "line": 302,
               "column": 4
             }
           },
@@ -15639,11 +18911,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 50,
+          "line": 53,
           "column": 2
         },
         "end": {
-          "line": 330,
+          "line": 335,
           "column": 3
         }
       },
@@ -15657,11 +18929,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -15675,11 +18947,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -15693,11 +18965,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 30,
+              "line": 34,
               "column": 4
             },
             "end": {
-              "line": 33,
+              "line": 37,
               "column": 5
             }
           },
@@ -15711,11 +18983,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 35,
+              "line": 39,
               "column": 4
             },
             "end": {
-              "line": 38,
+              "line": 42,
               "column": 5
             }
           },
@@ -15729,11 +19001,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -15747,11 +19019,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -15765,11 +19037,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -15783,11 +19055,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -15801,11 +19073,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -15819,11 +19091,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -15837,11 +19109,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -15855,11 +19127,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -15873,11 +19145,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -15891,11 +19163,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -15909,11 +19181,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -15927,11 +19199,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -15945,11 +19217,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -15962,11 +19234,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 90,
               "column": 5
             },
             "end": {
-              "line": 88,
+              "line": 93,
               "column": 6
             }
           },
@@ -15975,76 +19247,6 @@
         },
         {
           "name": "edit-width",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 5
-            },
-            "end": {
-              "line": 92,
-              "column": 6
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
-          "name": "min-width",
-          "description": "The minimum width of this column.",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 135,
-              "column": 4
-            },
-            "end": {
-              "line": 138,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "edit-min-width",
-          "description": "The minimum width of this column in edit mode.",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 143,
-              "column": 4
-            },
-            "end": {
-              "line": 146,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "flex",
-          "description": "Width growing factor for this column.",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 151,
-              "column": 4
-            },
-            "end": {
-              "line": 154,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-class",
           "description": "",
           "sourceRange": {
             "start": {
@@ -16060,15 +19262,85 @@
           "type": "string | null | undefined"
         },
         {
+          "name": "min-width",
+          "description": "The minimum width of this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 139,
+              "column": 4
+            },
+            "end": {
+              "line": 142,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "edit-min-width",
+          "description": "The minimum width of this column in edit mode.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 147,
+              "column": 4
+            },
+            "end": {
+              "line": 150,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "flex",
+          "description": "Width growing factor for this column.",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 155,
+              "column": 4
+            },
+            "end": {
+              "line": 158,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "cell-class",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 99,
+              "column": 5
+            },
+            "end": {
+              "line": 102,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
           "name": "header-cell-class",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 98,
+              "line": 103,
               "column": 5
             },
             "end": {
-              "line": 101,
+              "line": 106,
               "column": 6
             }
           },
@@ -16081,11 +19353,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -16099,11 +19371,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -16117,34 +19389,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -16224,11 +19478,11 @@
           "description": "Base Currency used in filters",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 71,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 73,
               "column": 6
             }
           },
@@ -16240,11 +19494,11 @@
           "description": "If this is set true then currency property will be the currency with highest occurrence in values",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 78,
               "column": 5
             },
             "end": {
-              "line": 76,
+              "line": 81,
               "column": 6
             }
           },
@@ -16256,11 +19510,11 @@
           "description": "Exchange rates of currencies. Example: {\"EUR\": 1, \"USD\":0.8169982616, \"AUD\":0.6529827192, \"SEK\": 0.1019271438}'\nDefault exchange rate is 1 and it is used for every currency that is present on column values but missing from exchange rates object.",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 87,
               "column": 5
             },
             "end": {
-              "line": 84,
+              "line": 89,
               "column": 6
             }
           },
@@ -16286,98 +19540,6 @@
       "path": "cosmoz-omnitable-column-autocomplete.html",
       "properties": [
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -16385,11 +19547,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -16409,11 +19571,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -16432,11 +19594,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -16457,11 +19619,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -16481,11 +19643,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -16505,11 +19667,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 53,
+              "line": 55,
               "column": 5
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 6
             }
           },
@@ -16528,11 +19690,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -16553,11 +19715,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -16576,11 +19738,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 5
             },
             "end": {
-              "line": 51,
+              "line": 53,
               "column": 6
             }
           },
@@ -16600,11 +19762,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -16623,11 +19785,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -16646,11 +19808,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -16670,11 +19832,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -16694,11 +19856,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -16719,11 +19881,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -16743,11 +19905,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -16766,11 +19928,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 83,
               "column": 5
             },
             "end": {
-              "line": 84,
+              "line": 86,
               "column": 6
             }
           },
@@ -16788,11 +19950,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 88,
               "column": 5
             },
             "end": {
-              "line": 89,
+              "line": 91,
               "column": 6
             }
           },
@@ -16811,11 +19973,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -16835,11 +19997,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -16858,11 +20020,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 78,
               "column": 5
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 6
             }
           },
@@ -16881,11 +20043,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -16904,11 +20066,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -16928,11 +20090,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -16942,30 +20104,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -17063,65 +20201,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "query",
           "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 6
             }
           },
@@ -17139,11 +20229,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 68,
               "column": 5
             },
             "end": {
-              "line": 69,
+              "line": 71,
               "column": 6
             }
           },
@@ -17161,11 +20251,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 74,
+              "line": 76,
               "column": 6
             }
           },
@@ -17179,17 +20269,109 @@
       ],
       "methods": [
         {
-          "name": "ready",
-          "description": "",
-          "privacy": "protected",
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 242,
+              "line": 28,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Cleans up references to recycled instances when the element is detached.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 80,
               "column": 3
             }
           },
@@ -17198,52 +20380,235 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_createTemplatizer",
-          "description": "",
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 248,
+              "line": 89,
               "column": 2
             },
             "end": {
-              "line": 272,
+              "line": 103,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "templateElementOrSelector"
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
             }
           ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_cellTemplateChanged",
-          "description": "",
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 274,
+              "line": 112,
               "column": 2
             },
             "end": {
-              "line": 278,
+              "line": 118,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "cellTemplate"
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
             }
           ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 235,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
           "return": {
             "type": "void"
           },
@@ -17256,11 +20621,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -17276,62 +20641,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -17349,11 +20669,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 97,
+              "line": 99,
               "column": 3
             },
             "end": {
-              "line": 111,
+              "line": 113,
               "column": 4
             }
           },
@@ -17374,11 +20694,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 113,
+              "line": 115,
               "column": 3
             },
             "end": {
-              "line": 118,
+              "line": 120,
               "column": 4
             }
           },
@@ -17400,11 +20720,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -17431,11 +20751,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 95,
               "column": 3
             },
             "end": {
-              "line": 95,
+              "line": 97,
               "column": 4
             }
           },
@@ -17457,11 +20777,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -17483,11 +20803,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -17518,11 +20838,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -17537,11 +20857,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -17559,11 +20879,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -17587,11 +20907,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 174,
+              "line": 176,
               "column": 3
             },
             "end": {
-              "line": 176,
+              "line": 178,
               "column": 4
             }
           },
@@ -17604,11 +20924,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 120,
+              "line": 122,
               "column": 3
             },
             "end": {
-              "line": 123,
+              "line": 125,
               "column": 4
             }
           },
@@ -17628,11 +20948,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 125,
+              "line": 127,
               "column": 3
             },
             "end": {
-              "line": 152,
+              "line": 154,
               "column": 4
             }
           },
@@ -17653,11 +20973,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -17675,11 +20995,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -17697,11 +21017,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -17719,11 +21039,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -17741,11 +21061,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -17763,11 +21083,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -17787,11 +21107,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -17809,11 +21129,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 154,
+              "line": 156,
               "column": 3
             },
             "end": {
-              "line": 172,
+              "line": 174,
               "column": 4
             }
           },
@@ -17833,11 +21153,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 38,
+          "line": 40,
           "column": 2
         },
         "end": {
-          "line": 177,
+          "line": 179,
           "column": 3
         }
       },
@@ -17851,11 +21171,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -17869,11 +21189,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -17887,11 +21207,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -17905,11 +21225,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -17923,11 +21243,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -17940,11 +21260,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 53,
+              "line": 55,
               "column": 5
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 6
             }
           },
@@ -17957,11 +21277,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -17975,11 +21295,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -17992,11 +21312,11 @@
           "description": "Ask for a list of values",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 5
             },
             "end": {
-              "line": 51,
+              "line": 53,
               "column": 6
             }
           },
@@ -18009,11 +21329,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -18027,11 +21347,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -18045,11 +21365,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -18063,11 +21383,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -18081,11 +21401,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -18099,11 +21419,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -18117,11 +21437,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -18134,11 +21454,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 83,
               "column": 5
             },
             "end": {
-              "line": 84,
+              "line": 86,
               "column": 6
             }
           },
@@ -18150,11 +21470,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 88,
               "column": 5
             },
             "end": {
-              "line": 89,
+              "line": 91,
               "column": 6
             }
           },
@@ -18167,11 +21487,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -18185,11 +21505,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -18202,11 +21522,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 78,
               "column": 5
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 6
             }
           },
@@ -18219,11 +21539,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -18237,11 +21557,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -18255,34 +21575,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -18362,11 +21664,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 6
             }
           },
@@ -18378,11 +21680,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 68,
               "column": 5
             },
             "end": {
-              "line": 69,
+              "line": 71,
               "column": 6
             }
           },
@@ -18394,11 +21696,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 74,
+              "line": 76,
               "column": 6
             }
           },
@@ -18436,98 +21738,6 @@
       "path": "cosmoz-omnitable-column-boolean.html",
       "properties": [
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -18535,11 +21745,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -18559,11 +21769,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -18582,11 +21792,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -18607,11 +21817,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -18631,11 +21841,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -18655,11 +21865,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 5
             },
             "end": {
-              "line": 56,
+              "line": 58,
               "column": 6
             }
           },
@@ -18678,11 +21888,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -18703,11 +21913,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -18727,11 +21937,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -18752,11 +21962,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -18775,11 +21985,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -18798,11 +22008,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -18822,11 +22032,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -18846,11 +22056,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -18871,11 +22081,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -18895,11 +22105,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -18919,11 +22129,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -18943,11 +22153,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -18966,11 +22176,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 84,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 87,
               "column": 6
             }
           },
@@ -18989,11 +22199,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -19013,11 +22223,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -19037,11 +22247,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -19060,11 +22270,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -19084,11 +22294,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -19098,30 +22308,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -19219,65 +22405,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "trueLabel",
           "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 58,
+              "line": 60,
               "column": 5
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 6
             }
           },
@@ -19295,11 +22433,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 68,
               "column": 6
             }
           },
@@ -19317,11 +22455,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 70,
               "column": 5
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 6
             }
           },
@@ -19339,11 +22477,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 5
             },
             "end": {
-              "line": 76,
+              "line": 78,
               "column": 6
             }
           },
@@ -19357,17 +22495,109 @@
       ],
       "methods": [
         {
-          "name": "ready",
-          "description": "",
-          "privacy": "protected",
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 242,
+              "line": 28,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Cleans up references to recycled instances when the element is detached.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 80,
               "column": 3
             }
           },
@@ -19376,52 +22606,235 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_createTemplatizer",
-          "description": "",
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 248,
+              "line": 89,
               "column": 2
             },
             "end": {
-              "line": 272,
+              "line": 103,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "templateElementOrSelector"
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
             }
           ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_cellTemplateChanged",
-          "description": "",
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 274,
+              "line": 112,
               "column": 2
             },
             "end": {
-              "line": 278,
+              "line": 118,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "cellTemplate"
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
             }
           ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 235,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
           "return": {
             "type": "void"
           },
@@ -19434,11 +22847,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -19454,62 +22867,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -19527,11 +22895,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 119,
+              "line": 121,
               "column": 3
             },
             "end": {
-              "line": 122,
+              "line": 124,
               "column": 4
             }
           },
@@ -19551,11 +22919,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 171,
+              "line": 173,
               "column": 3
             },
             "end": {
-              "line": 176,
+              "line": 178,
               "column": 4
             }
           },
@@ -19577,11 +22945,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -19609,11 +22977,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 358,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 287,
               "column": 3
             }
           },
@@ -19634,11 +23002,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 145,
+              "line": 147,
               "column": 3
             },
             "end": {
-              "line": 157,
+              "line": 159,
               "column": 4
             }
           },
@@ -19659,11 +23027,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -19693,11 +23061,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 124,
+              "line": 126,
               "column": 3
             },
             "end": {
-              "line": 128,
+              "line": 130,
               "column": 4
             }
           },
@@ -19711,11 +23079,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -19733,11 +23101,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -19762,11 +23130,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -19780,11 +23148,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 130,
+              "line": 132,
               "column": 3
             },
             "end": {
-              "line": 132,
+              "line": 134,
               "column": 4
             }
           },
@@ -19802,11 +23170,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -19828,11 +23196,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -19850,11 +23218,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -19872,11 +23240,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -19894,11 +23262,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -19916,11 +23284,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -19937,11 +23305,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 159,
+              "line": 161,
               "column": 3
             },
             "end": {
-              "line": 164,
+              "line": 166,
               "column": 4
             }
           },
@@ -19959,11 +23327,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 166,
+              "line": 168,
               "column": 3
             },
             "end": {
-              "line": 169,
+              "line": 171,
               "column": 4
             }
           },
@@ -19980,11 +23348,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 97,
+              "line": 99,
               "column": 3
             },
             "end": {
-              "line": 108,
+              "line": 110,
               "column": 4
             }
           },
@@ -20004,11 +23372,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 110,
+              "line": 112,
               "column": 3
             },
             "end": {
-              "line": 117,
+              "line": 119,
               "column": 4
             }
           },
@@ -20028,11 +23396,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 134,
+              "line": 136,
               "column": 3
             },
             "end": {
-              "line": 139,
+              "line": 141,
               "column": 4
             }
           },
@@ -20052,11 +23420,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 2
         },
         "end": {
-          "line": 177,
+          "line": 179,
           "column": 3
         }
       },
@@ -20070,11 +23438,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -20088,11 +23456,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -20106,11 +23474,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -20124,11 +23492,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -20142,11 +23510,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -20159,11 +23527,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 5
             },
             "end": {
-              "line": 56,
+              "line": 58,
               "column": 6
             }
           },
@@ -20176,11 +23544,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -20194,11 +23562,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -20212,11 +23580,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -20230,11 +23598,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -20248,11 +23616,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -20266,11 +23634,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -20284,11 +23652,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -20302,11 +23670,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -20320,11 +23688,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -20338,11 +23706,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -20356,11 +23724,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -20374,11 +23742,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -20391,11 +23759,11 @@
           "description": "No need to grow, as the values in a boolean column should have known fixed width",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 84,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 87,
               "column": 6
             }
           },
@@ -20408,11 +23776,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -20426,11 +23794,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -20444,11 +23812,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -20462,11 +23830,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -20480,34 +23848,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -20587,11 +23937,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 58,
+              "line": 60,
               "column": 5
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 6
             }
           },
@@ -20603,11 +23953,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 68,
               "column": 6
             }
           },
@@ -20619,11 +23969,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 5
             },
             "end": {
-              "line": 76,
+              "line": 78,
               "column": 6
             }
           },
@@ -20662,11 +24012,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -20687,11 +24037,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -20710,12 +24060,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {
@@ -20734,12 +24084,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {
@@ -20758,11 +24108,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -20782,11 +24132,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 54,
               "column": 5
             }
           },
@@ -20805,11 +24155,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 52,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 59,
               "column": 5
             }
           },
@@ -20829,11 +24179,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 57,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -20853,11 +24203,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 65,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 72,
               "column": 5
             }
           },
@@ -20877,12 +24227,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 30,
-              "column": 4
+              "line": 48,
+              "column": 5
             },
             "end": {
-              "line": 33,
-              "column": 5
+              "line": 51,
+              "column": 6
             }
           },
           "metadata": {
@@ -20901,11 +24251,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -20925,11 +24275,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -20949,11 +24299,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -20973,12 +24323,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {
@@ -20990,98 +24340,6 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -21089,11 +24347,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -21113,11 +24371,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -21136,11 +24394,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -21161,11 +24419,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -21185,11 +24443,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -21210,11 +24468,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -21234,11 +24492,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -21259,11 +24517,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -21283,11 +24541,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -21306,11 +24564,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -21330,11 +24588,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -21354,11 +24612,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -21378,11 +24636,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 61,
+              "line": 68,
               "column": 5
             },
             "end": {
-              "line": 64,
+              "line": 71,
               "column": 6
             }
           },
@@ -21400,11 +24658,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 72,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 75,
               "column": 6
             }
           },
@@ -21423,11 +24681,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -21446,11 +24704,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 64,
               "column": 5
             },
             "end": {
-              "line": 60,
+              "line": 67,
               "column": 6
             }
           },
@@ -21469,11 +24727,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -21492,11 +24750,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -21516,11 +24774,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -21530,30 +24788,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -21649,69 +24883,21 @@
             }
           },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         }
       ],
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "",
+          "description": "Cleans up references to recycled instances when the element is detached.",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-range-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 79,
+              "line": 77,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 80,
               "column": 3
             }
           },
@@ -21720,7 +24906,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.RangeColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
           "name": "toNumber",
@@ -21729,11 +24915,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 91,
+              "line": 95,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 3
             }
           },
@@ -21768,12 +24954,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 89,
-              "column": 2
+              "line": 121,
+              "column": 3
             },
             "end": {
-              "line": 91,
-              "column": 3
+              "line": 123,
+              "column": 4
             }
           },
           "metadata": {},
@@ -21787,11 +24973,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 358,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 287,
               "column": 3
             }
           },
@@ -21812,11 +24998,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 93,
               "column": 3
             },
             "end": {
-              "line": 97,
+              "line": 104,
               "column": 4
             }
           },
@@ -21838,11 +25024,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 330,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 263,
               "column": 3
             }
           },
@@ -21865,12 +25051,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 127,
-              "column": 2
+              "line": 184,
+              "column": 3
             },
             "end": {
-              "line": 136,
-              "column": 3
+              "line": 193,
+              "column": 4
             }
           },
           "metadata": {},
@@ -21892,11 +25078,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 154,
+              "line": 158,
               "column": 2
             },
             "end": {
-              "line": 157,
+              "line": 161,
               "column": 3
             }
           },
@@ -21919,11 +25105,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 165,
+              "line": 169,
               "column": 2
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 3
             }
           },
@@ -21948,11 +25134,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 2
             },
             "end": {
-              "line": 200,
+              "line": 204,
               "column": 3
             }
           },
@@ -21980,11 +25166,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -21999,11 +25185,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -22025,11 +25211,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 228,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 245,
+              "line": 249,
               "column": 3
             }
           },
@@ -22048,11 +25234,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 247,
+              "line": 251,
               "column": 2
             },
             "end": {
-              "line": 252,
+              "line": 256,
               "column": 3
             }
           },
@@ -22073,11 +25259,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 79,
               "column": 3
             },
             "end": {
-              "line": 84,
+              "line": 91,
               "column": 4
             }
           },
@@ -22098,12 +25284,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 142,
-              "column": 2
+              "line": 199,
+              "column": 3
             },
             "end": {
-              "line": 148,
-              "column": 3
+              "line": 205,
+              "column": 4
             }
           },
           "metadata": {},
@@ -22121,11 +25307,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -22139,11 +25325,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 99,
+              "line": 106,
               "column": 3
             },
             "end": {
-              "line": 109,
+              "line": 116,
               "column": 4
             }
           },
@@ -22164,11 +25350,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 295,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 3
             }
           },
@@ -22186,11 +25372,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 340,
               "column": 3
             }
           },
@@ -22208,11 +25394,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 338,
+              "line": 342,
               "column": 2
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 3
             }
           },
@@ -22234,11 +25420,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -22263,11 +25449,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -22287,11 +25473,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -22310,11 +25496,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 398,
+              "line": 402,
               "column": 2
             },
             "end": {
-              "line": 404,
+              "line": 408,
               "column": 3
             }
           },
@@ -22333,11 +25519,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 406,
+              "line": 410,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 412,
               "column": 3
             }
           },
@@ -22359,12 +25545,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 68,
-              "column": 2
+              "line": 86,
+              "column": 3
             },
             "end": {
-              "line": 87,
-              "column": 3
+              "line": 119,
+              "column": 4
             }
           },
           "metadata": {},
@@ -22392,18 +25578,76 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "getAbsoluteISOString",
+          "description": "Computes the local timezone and adds it to a local ISO string",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-mixin.html",
+            "start": {
+              "line": 164,
+              "column": 3
+            },
+            "end": {
+              "line": 172,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string, without timezone info"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "an ISO date string, with timezone info"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnMixin"
+        },
+        {
+          "name": "_getTimezoneString",
+          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-mixin.html",
+            "start": {
+              "line": 179,
+              "column": 3
+            },
+            "end": {
+              "line": 182,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "the ISO timezone"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnMixin"
+        },
+        {
           "name": "_computeFormatter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 138,
-              "column": 2
+              "line": 195,
+              "column": 3
             },
             "end": {
-              "line": 140,
-              "column": 3
+              "line": 197,
+              "column": 4
             }
           },
           "metadata": {},
@@ -22421,12 +25665,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 150,
-              "column": 2
+              "line": 207,
+              "column": 3
             },
             "end": {
-              "line": 161,
-              "column": 3
+              "line": 218,
+              "column": 4
             }
           },
           "metadata": {},
@@ -22447,12 +25691,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 163,
-              "column": 2
+              "line": 220,
+              "column": 3
             },
             "end": {
-              "line": 175,
-              "column": 3
+              "line": 222,
+              "column": 4
             }
           },
           "metadata": {},
@@ -22464,71 +25708,324 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 242,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 235,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_createTemplatizer",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 248,
-              "column": 2
-            },
-            "end": {
-              "line": 272,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateElementOrSelector"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_cellTemplateChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 274,
-              "column": 2
-            },
-            "end": {
-              "line": 278,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cellTemplate"
-            }
-          ],
           "return": {
             "type": "void"
           },
@@ -22541,11 +26038,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -22561,62 +26058,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -22635,11 +26087,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -22667,11 +26119,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -22693,11 +26145,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -22728,11 +26180,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -22750,11 +26202,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -22776,11 +26228,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -22798,11 +26250,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -22820,11 +26272,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -22842,11 +26294,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -22864,11 +26316,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -22885,11 +26337,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 48,
+          "line": 55,
           "column": 2
         },
         "end": {
-          "line": 110,
+          "line": 117,
           "column": 3
         }
       },
@@ -22903,11 +26355,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -22921,11 +26373,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -22939,12 +26391,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {},
@@ -22957,12 +26409,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {},
@@ -22975,11 +26427,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -22993,11 +26445,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -23011,11 +26463,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -23029,11 +26481,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -23047,12 +26499,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {},
@@ -23065,11 +26517,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -23083,11 +26535,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -23101,11 +26553,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -23119,11 +26571,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -23137,11 +26589,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -23155,11 +26607,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -23173,11 +26625,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -23191,11 +26643,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -23209,11 +26661,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -23227,11 +26679,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -23245,11 +26697,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -23263,11 +26715,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -23280,11 +26732,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 61,
+              "line": 68,
               "column": 5
             },
             "end": {
-              "line": 64,
+              "line": 71,
               "column": 6
             }
           },
@@ -23296,11 +26748,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 72,
               "column": 5
             },
             "end": {
-              "line": 68,
+              "line": 75,
               "column": 6
             }
           },
@@ -23313,11 +26765,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -23330,11 +26782,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 64,
               "column": 5
             },
             "end": {
-              "line": 60,
+              "line": 67,
               "column": 6
             }
           },
@@ -23347,11 +26799,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -23365,11 +26817,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -23383,34 +26835,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -23567,27 +27001,6 @@
               "attributeType": "Number"
             }
           }
-        },
-        {
-          "name": "t",
-          "type": "Object | null | undefined",
-          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 74,
-              "column": 5
-            },
-            "end": {
-              "line": 79,
-              "column": 6
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          }
         }
       ],
       "methods": [
@@ -23597,28 +27010,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 83,
+              "line": 75,
               "column": 3
             },
             "end": {
-              "line": 86,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 88,
-              "column": 3
-            },
-            "end": {
-              "line": 91,
+              "line": 78,
               "column": 4
             }
           },
@@ -23631,11 +27027,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 80,
               "column": 3
             },
             "end": {
-              "line": 97,
+              "line": 84,
               "column": 4
             }
           },
@@ -23652,11 +27048,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 99,
+              "line": 86,
               "column": 3
             },
             "end": {
-              "line": 104,
+              "line": 91,
               "column": 4
             }
           },
@@ -23676,11 +27072,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 106,
+              "line": 93,
               "column": 3
             },
             "end": {
-              "line": 111,
+              "line": 98,
               "column": 4
             }
           },
@@ -23700,11 +27096,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 113,
+              "line": 100,
               "column": 3
             },
             "end": {
-              "line": 119,
+              "line": 106,
               "column": 4
             }
           },
@@ -23724,11 +27120,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 108,
               "column": 3
             },
             "end": {
-              "line": 125,
+              "line": 112,
               "column": 4
             }
           },
@@ -23745,11 +27141,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 127,
+              "line": 114,
               "column": 3
             },
             "end": {
-              "line": 132,
+              "line": 119,
               "column": 4
             }
           },
@@ -23769,11 +27165,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 46,
+          "line": 50,
           "column": 2
         },
         "end": {
-          "line": 133,
+          "line": 120,
           "column": 3
         }
       },
@@ -23796,22 +27192,6 @@
           },
           "metadata": {},
           "type": "Array | null | undefined"
-        },
-        {
-          "name": "t",
-          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
-          "sourceRange": {
-            "start": {
-              "line": 74,
-              "column": 5
-            },
-            "end": {
-              "line": 79,
-              "column": 6
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined"
         }
       ],
       "events": [],
@@ -23828,96 +27208,48 @@
       "path": "cosmoz-omnitable-column-list.html",
       "properties": [
         {
-          "name": "editableTemplatizer",
-          "type": "?",
+          "name": "textProperty",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 293,
-              "column": 2
+              "line": 77,
+              "column": 5
             },
             "end": {
-              "line": 296,
-              "column": 3
+              "line": 80,
+              "column": 6
             }
           },
           "metadata": {
             "polymer": {
-              "readOnly": true
+              "attributeType": "String"
             }
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "defaultValue": "\"\""
         },
         {
-          "name": "cellTemplatizer",
-          "type": "?",
+          "name": "valueProperty",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 297,
-              "column": 2
+              "line": 82,
+              "column": 5
             },
             "end": {
-              "line": 300,
-              "column": 3
+              "line": 85,
+              "column": 6
             }
           },
           "metadata": {
             "polymer": {
-              "readOnly": true
+              "attributeType": "String"
             }
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "defaultValue": "\"\""
         },
         {
           "name": "title",
@@ -23927,11 +27259,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -23951,11 +27283,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -23974,11 +27306,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -23999,11 +27331,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -24023,11 +27355,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -24047,11 +27379,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 69,
               "column": 5
             },
             "end": {
-              "line": 72,
+              "line": 75,
               "column": 6
             }
           },
@@ -24070,11 +27402,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -24095,11 +27427,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -24118,11 +27450,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 64,
+              "line": 67,
               "column": 6
             }
           },
@@ -24142,11 +27474,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -24165,11 +27497,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -24188,11 +27520,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -24212,11 +27544,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -24236,11 +27568,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -24261,11 +27593,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -24285,11 +27617,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -24309,11 +27641,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -24333,11 +27665,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -24357,11 +27689,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -24381,11 +27713,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -24405,11 +27737,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -24429,11 +27761,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -24452,11 +27784,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -24476,11 +27808,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -24490,30 +27822,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -24611,109 +27919,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "textProperty",
-          "type": "string | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 74,
-              "column": 5
-            },
-            "end": {
-              "line": 77,
-              "column": 6
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "String"
-            }
-          },
-          "defaultValue": "\"\""
-        },
-        {
-          "name": "valueProperty",
-          "type": "string | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 79,
-              "column": 5
-            },
-            "end": {
-              "line": 82,
-              "column": 6
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "String"
-            }
-          },
-          "defaultValue": "\"\""
-        },
-        {
           "name": "autocompleteItems",
           "type": "Array | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 54,
               "column": 5
             },
             "end": {
-              "line": 55,
+              "line": 58,
               "column": 6
             }
           },
@@ -24728,17 +27944,163 @@
       ],
       "methods": [
         {
-          "name": "ready",
+          "name": "getString",
           "description": "",
-          "privacy": "protected",
+          "privacy": "public",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 242,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 263,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath",
+              "defaultValue": "this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "toXlsxValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 264,
+              "column": 2
+            },
+            "end": {
+              "line": 269,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath",
+              "defaultValue": "this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Cleans up references to recycled instances when the element is detached.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 80,
               "column": 3
             }
           },
@@ -24747,52 +28109,235 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_createTemplatizer",
-          "description": "",
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 248,
+              "line": 89,
               "column": 2
             },
             "end": {
-              "line": 272,
+              "line": 103,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "templateElementOrSelector"
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
             }
           ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
-          "name": "_cellTemplateChanged",
-          "description": "",
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
           "privacy": "protected",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 274,
+              "line": 112,
               "column": 2
             },
             "end": {
-              "line": 278,
+              "line": 118,
               "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
-              "name": "cellTemplate"
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
             }
           ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 235,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
           "return": {
             "type": "void"
           },
@@ -24805,11 +28350,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -24825,62 +28370,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -24893,71 +28393,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getString",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
-            "start": {
-              "line": 22,
-              "column": 2
-            },
-            "end": {
-              "line": 33,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath",
-              "defaultValue": "this.valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
-        },
-        {
-          "name": "toXlsxValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 337,
-              "column": 2
-            },
-            "end": {
-              "line": 342,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "item"
-            },
-            {
-              "name": "valuePath",
-              "defaultValue": "this.valuePath"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_pathsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -24985,11 +28431,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 358,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 287,
               "column": 3
             }
           },
@@ -25011,11 +28457,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -25037,11 +28483,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -25072,11 +28518,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -25091,11 +28537,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -25113,11 +28559,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -25141,11 +28587,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 136,
+              "line": 139,
               "column": 3
             },
             "end": {
-              "line": 138,
+              "line": 141,
               "column": 4
             }
           },
@@ -25159,11 +28605,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -25184,11 +28630,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 119,
+              "line": 122,
               "column": 3
             },
             "end": {
-              "line": 134,
+              "line": 137,
               "column": 4
             }
           },
@@ -25209,11 +28655,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -25231,11 +28677,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -25253,11 +28699,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -25275,11 +28721,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -25297,11 +28743,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -25319,11 +28765,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -25343,11 +28789,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -25365,11 +28811,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 86,
+              "line": 89,
               "column": 3
             },
             "end": {
-              "line": 92,
+              "line": 95,
               "column": 4
             }
           },
@@ -25392,11 +28838,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 94,
+              "line": 97,
               "column": 3
             },
             "end": {
-              "line": 117,
+              "line": 120,
               "column": 4
             }
           },
@@ -25413,11 +28859,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 38,
+          "line": 44,
           "column": 2
         },
         "end": {
-          "line": 139,
+          "line": 142,
           "column": 3
         }
       },
@@ -25426,16 +28872,48 @@
       "name": "OmnitableColumnList",
       "attributes": [
         {
+          "name": "text-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 77,
+              "column": 5
+            },
+            "end": {
+              "line": 80,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
+          "name": "value-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 82,
+              "column": 5
+            },
+            "end": {
+              "line": 85,
+              "column": 6
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
           "name": "title",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -25449,11 +28927,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -25467,11 +28945,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -25485,11 +28963,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -25503,11 +28981,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -25520,11 +28998,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 66,
+              "line": 69,
               "column": 5
             },
             "end": {
-              "line": 72,
+              "line": 75,
               "column": 6
             }
           },
@@ -25537,11 +29015,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -25555,11 +29033,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -25572,11 +29050,11 @@
           "description": "Ask for a list of values",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 63,
               "column": 5
             },
             "end": {
-              "line": 64,
+              "line": 67,
               "column": 6
             }
           },
@@ -25589,11 +29067,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -25607,11 +29085,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -25625,11 +29103,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -25643,11 +29121,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -25661,11 +29139,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -25679,11 +29157,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -25697,11 +29175,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -25715,11 +29193,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -25733,11 +29211,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -25751,11 +29229,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -25769,11 +29247,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -25787,11 +29265,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -25805,11 +29283,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -25823,11 +29301,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -25841,34 +29319,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -25944,47 +29404,15 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "text-property",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 74,
-              "column": 5
-            },
-            "end": {
-              "line": 77,
-              "column": 6
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
-          "name": "value-property",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 79,
-              "column": 5
-            },
-            "end": {
-              "line": 82,
-              "column": 6
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
           "name": "autocomplete-items",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 51,
+              "line": 54,
               "column": 5
             },
             "end": {
-              "line": 55,
+              "line": 58,
               "column": 6
             }
           },
@@ -26013,8 +29441,8 @@
       "slots": [],
       "tagname": "cosmoz-omnitable-column-list",
       "mixins": [
-        "Cosmoz.OmnitableColumnMixin",
-        "Cosmoz.ListColumnMixin"
+        "Cosmoz.ListColumnMixin",
+        "Cosmoz.OmnitableColumnMixin"
       ]
     },
     {
@@ -26023,96 +29451,52 @@
       "path": "cosmoz-omnitable-column-list-horizontal.html",
       "properties": [
         {
-          "name": "editableTemplatizer",
-          "type": "?",
+          "name": "textProperty",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-column-list-mixin.html",
             "start": {
-              "line": 293,
-              "column": 2
+              "line": 13,
+              "column": 4
             },
             "end": {
-              "line": 296,
-              "column": 3
+              "line": 16,
+              "column": 5
             }
           },
           "metadata": {
             "polymer": {
-              "readOnly": true
+              "attributeType": "String"
             }
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "defaultValue": "\"label\"",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
         },
         {
-          "name": "cellTemplatizer",
-          "type": "?",
+          "name": "valueProperty",
+          "type": "string | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
+            "file": "cosmoz-omnitable-column-list-mixin.html",
             "start": {
-              "line": 297,
-              "column": 2
+              "line": 18,
+              "column": 4
             },
             "end": {
-              "line": 300,
-              "column": 3
+              "line": 21,
+              "column": 5
             }
           },
           "metadata": {
             "polymer": {
-              "readOnly": true
+              "attributeType": "String"
             }
           },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+          "defaultValue": "\"value\"",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
         },
         {
           "name": "title",
@@ -26122,11 +29506,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -26146,11 +29530,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -26169,11 +29553,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -26194,11 +29578,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -26218,11 +29602,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -26242,11 +29626,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 86,
               "column": 5
             },
             "end": {
-              "line": 83,
+              "line": 92,
               "column": 6
             }
           },
@@ -26265,11 +29649,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -26290,11 +29674,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -26313,11 +29697,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 80,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 84,
               "column": 6
             }
           },
@@ -26337,11 +29721,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -26360,11 +29744,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -26383,11 +29767,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -26407,11 +29791,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -26431,11 +29815,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -26456,11 +29840,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -26480,11 +29864,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -26504,11 +29888,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -26528,11 +29912,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -26552,11 +29936,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -26576,11 +29960,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -26600,11 +29984,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -26624,11 +30008,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -26647,11 +30031,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -26671,11 +30055,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -26685,30 +30069,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -26806,113 +30166,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "textProperty",
-          "type": "string | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
-            "start": {
-              "line": 10,
-              "column": 4
-            },
-            "end": {
-              "line": 13,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "String"
-            }
-          },
-          "defaultValue": "\"label\"",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
-        },
-        {
-          "name": "valueProperty",
-          "type": "string | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
-            "start": {
-              "line": 15,
-              "column": 4
-            },
-            "end": {
-              "line": 18,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "String"
-            }
-          },
-          "defaultValue": "\"value\"",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
-        },
-        {
           "name": "autocompleteSelectedItems",
           "type": "Array | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 75,
               "column": 6
             }
           },
@@ -26925,199 +30189,17 @@
       ],
       "methods": [
         {
-          "name": "ready",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 242,
-              "column": 2
-            },
-            "end": {
-              "line": 246,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_createTemplatizer",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 248,
-              "column": 2
-            },
-            "end": {
-              "line": 272,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateElementOrSelector"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_cellTemplateChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 274,
-              "column": 2
-            },
-            "end": {
-              "line": 278,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cellTemplate"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_externalValuesChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 280,
-              "column": 2
-            },
-            "end": {
-              "line": 291,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "newExternalValuesValue"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_computePreferredDropdownHorizontalAlign",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 327,
-              "column": 2
-            },
-            "end": {
-              "line": 329,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "columnIndex"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "getString",
           "description": "",
           "privacy": "public",
           "sourceRange": {
-            "start": {
-              "line": 144,
-              "column": 3
-            },
-            "end": {
-              "line": 151,
-              "column": 4
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "toXlsxValue",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 337,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 342,
+              "line": 263,
               "column": 3
             }
           },
@@ -27134,17 +30216,439 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
+          "name": "toXlsxValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 264,
+              "column": 2
+            },
+            "end": {
+              "line": 269,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath",
+              "defaultValue": "this.valuePath"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Cleans up references to recycled instances when the element is detached.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 80,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 232,
+              "column": 2
+            },
+            "end": {
+              "line": 235,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_externalValuesChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 237,
+              "column": 2
+            },
+            "end": {
+              "line": 248,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "newExternalValuesValue"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
+          "name": "_computePreferredDropdownHorizontalAlign",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-mixin.html",
+            "start": {
+              "line": 254,
+              "column": 2
+            },
+            "end": {
+              "line": 256,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "columnIndex"
+            }
+          ],
+          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
+        },
+        {
           "name": "_pathsChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -27172,11 +30676,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 358,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 287,
               "column": 3
             }
           },
@@ -27198,11 +30702,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -27224,11 +30728,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -27259,11 +30763,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -27278,11 +30782,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -27300,11 +30804,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -27328,11 +30832,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 140,
+              "line": 149,
               "column": 3
             },
             "end": {
-              "line": 142,
+              "line": 151,
               "column": 4
             }
           },
@@ -27345,11 +30849,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 115,
+              "line": 124,
               "column": 3
             },
             "end": {
-              "line": 121,
+              "line": 130,
               "column": 4
             }
           },
@@ -27369,11 +30873,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 123,
+              "line": 132,
               "column": 3
             },
             "end": {
-              "line": 138,
+              "line": 147,
               "column": 4
             }
           },
@@ -27394,11 +30898,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -27416,11 +30920,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -27438,11 +30942,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -27460,11 +30964,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -27482,11 +30986,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -27504,11 +31008,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -27528,11 +31032,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -27550,11 +31054,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 87,
+              "line": 96,
               "column": 3
             },
             "end": {
-              "line": 106,
+              "line": 115,
               "column": 4
             }
           },
@@ -27572,11 +31076,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 108,
+              "line": 117,
               "column": 3
             },
             "end": {
-              "line": 113,
+              "line": 122,
               "column": 4
             }
           },
@@ -27593,7 +31097,7 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 55,
+          "line": 60,
           "column": 2
         },
         "end": {
@@ -27606,16 +31110,52 @@
       "name": "OmnitableColumnListHorizontal",
       "attributes": [
         {
+          "name": "text-property",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "start": {
+              "line": 13,
+              "column": 4
+            },
+            "end": {
+              "line": 16,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
+        },
+        {
+          "name": "value-property",
+          "description": "",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-list-mixin.html",
+            "start": {
+              "line": 18,
+              "column": 4
+            },
+            "end": {
+              "line": 21,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined",
+          "inheritedFrom": "Cosmoz.ListColumnMixin"
+        },
+        {
           "name": "title",
           "description": "",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -27629,11 +31169,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -27647,11 +31187,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -27665,11 +31205,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -27683,11 +31223,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -27700,11 +31240,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 86,
               "column": 5
             },
             "end": {
-              "line": 83,
+              "line": 92,
               "column": 6
             }
           },
@@ -27717,11 +31257,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -27735,11 +31275,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -27752,11 +31292,11 @@
           "description": "Ask for a list of values",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 80,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 84,
               "column": 6
             }
           },
@@ -27769,11 +31309,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -27787,11 +31327,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -27805,11 +31345,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -27823,11 +31363,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -27841,11 +31381,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -27859,11 +31399,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -27877,11 +31417,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -27895,11 +31435,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -27913,11 +31453,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -27931,11 +31471,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -27949,11 +31489,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -27967,11 +31507,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -27985,11 +31525,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -28003,11 +31543,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -28021,34 +31561,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -28124,51 +31646,15 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "text-property",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
-            "start": {
-              "line": 10,
-              "column": 4
-            },
-            "end": {
-              "line": 13,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
-        },
-        {
-          "name": "value-property",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-list-mixin.html",
-            "start": {
-              "line": 15,
-              "column": 4
-            },
-            "end": {
-              "line": 18,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined",
-          "inheritedFrom": "Cosmoz.ListColumnMixin"
-        },
-        {
           "name": "autocomplete-selected-items",
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 73,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 75,
               "column": 6
             }
           },
@@ -28191,8 +31677,8 @@
       "slots": [],
       "tagname": "cosmoz-omnitable-column-list-horizontal",
       "mixins": [
-        "Cosmoz.OmnitableColumnMixin",
-        "Cosmoz.ListColumnMixin"
+        "Cosmoz.ListColumnMixin",
+        "Cosmoz.OmnitableColumnMixin"
       ]
     },
     {
@@ -28208,11 +31694,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -28233,11 +31719,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -28256,11 +31742,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 30,
+              "line": 34,
               "column": 4
             },
             "end": {
-              "line": 33,
+              "line": 37,
               "column": 5
             }
           },
@@ -28280,11 +31766,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 35,
+              "line": 39,
               "column": 4
             },
             "end": {
-              "line": 38,
+              "line": 42,
               "column": 5
             }
           },
@@ -28304,11 +31790,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -28328,11 +31814,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 54,
               "column": 5
             }
           },
@@ -28351,11 +31837,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 52,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 59,
               "column": 5
             }
           },
@@ -28375,11 +31861,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 57,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -28399,11 +31885,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 65,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 72,
               "column": 5
             }
           },
@@ -28416,98 +31902,6 @@
           "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -28515,11 +31909,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -28539,11 +31933,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -28562,11 +31956,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -28587,11 +31981,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -28611,11 +32005,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -28636,11 +32030,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -28660,11 +32054,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -28685,11 +32079,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -28709,11 +32103,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -28732,11 +32126,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -28756,11 +32150,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -28780,11 +32174,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -28804,11 +32198,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 70,
               "column": 5
             },
             "end": {
-              "line": 62,
+              "line": 73,
               "column": 6
             }
           },
@@ -28826,11 +32220,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 74,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 77,
               "column": 6
             }
           },
@@ -28849,11 +32243,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -28873,11 +32267,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -28897,11 +32291,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -28920,11 +32314,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 55,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 58,
+              "line": 69,
               "column": 6
             }
           },
@@ -28942,11 +32336,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 78,
               "column": 5
             },
             "end": {
-              "line": 70,
+              "line": 81,
               "column": 6
             }
           },
@@ -28965,11 +32359,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -28988,11 +32382,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -29012,11 +32406,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -29026,30 +32420,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -29147,65 +32517,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "maximumFractionDigits",
           "type": "number | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 74,
+              "line": 85,
               "column": 6
             }
           },
@@ -29223,11 +32545,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 86,
               "column": 5
             },
             "end": {
-              "line": 78,
+              "line": 89,
               "column": 6
             }
           },
@@ -29245,11 +32567,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 90,
               "column": 5
             },
             "end": {
-              "line": 82,
+              "line": 93,
               "column": 6
             }
           },
@@ -29267,11 +32589,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 83,
+              "line": 94,
               "column": 5
             },
             "end": {
-              "line": 86,
+              "line": 97,
               "column": 6
             }
           },
@@ -29286,16 +32608,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "",
+          "description": "Cleans up references to recycled instances when the element is detached.",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-range-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 79,
+              "line": 77,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 80,
               "column": 3
             }
           },
@@ -29304,7 +32626,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.RangeColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
           "name": "toNumber",
@@ -29313,11 +32635,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 91,
+              "line": 95,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 3
             }
           },
@@ -29352,11 +32674,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 109,
+              "line": 113,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 115,
               "column": 3
             }
           },
@@ -29370,11 +32692,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 110,
+              "line": 141,
               "column": 3
             },
             "end": {
-              "line": 128,
+              "line": 159,
               "column": 4
             }
           },
@@ -29403,11 +32725,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 337,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 342,
+              "line": 269,
               "column": 3
             }
           },
@@ -29430,11 +32752,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 330,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 263,
               "column": 3
             }
           },
@@ -29456,11 +32778,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 130,
+              "line": 161,
               "column": 3
             },
             "end": {
-              "line": 136,
+              "line": 167,
               "column": 4
             }
           },
@@ -29482,11 +32804,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 154,
+              "line": 158,
               "column": 2
             },
             "end": {
-              "line": 157,
+              "line": 161,
               "column": 3
             }
           },
@@ -29509,11 +32831,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 165,
+              "line": 169,
               "column": 2
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 3
             }
           },
@@ -29538,11 +32860,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 2
             },
             "end": {
-              "line": 200,
+              "line": 204,
               "column": 3
             }
           },
@@ -29570,11 +32892,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -29589,11 +32911,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -29615,11 +32937,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 228,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 245,
+              "line": 249,
               "column": 3
             }
           },
@@ -29638,11 +32960,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 247,
+              "line": 251,
               "column": 2
             },
             "end": {
-              "line": 252,
+              "line": 256,
               "column": 3
             }
           },
@@ -29664,11 +32986,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 254,
+              "line": 258,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 260,
               "column": 3
             }
           },
@@ -29687,11 +33009,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 258,
+              "line": 262,
               "column": 2
             },
             "end": {
-              "line": 264,
+              "line": 268,
               "column": 3
             }
           },
@@ -29710,11 +33032,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -29729,11 +33051,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 279,
+              "line": 283,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 293,
               "column": 3
             }
           },
@@ -29757,11 +33079,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 295,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 3
             }
           },
@@ -29779,11 +33101,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 340,
               "column": 3
             }
           },
@@ -29801,11 +33123,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 338,
+              "line": 342,
               "column": 2
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 3
             }
           },
@@ -29827,11 +33149,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -29856,11 +33178,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -29880,11 +33202,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -29903,11 +33225,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 398,
+              "line": 402,
               "column": 2
             },
             "end": {
-              "line": 404,
+              "line": 408,
               "column": 3
             }
           },
@@ -29926,11 +33248,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 406,
+              "line": 410,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 412,
               "column": 3
             }
           },
@@ -29946,71 +33268,324 @@
           "inheritedFrom": "Cosmoz.RangeColumnMixin"
         },
         {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 242,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 235,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_createTemplatizer",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 248,
-              "column": 2
-            },
-            "end": {
-              "line": 272,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateElementOrSelector"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_cellTemplateChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 274,
-              "column": 2
-            },
-            "end": {
-              "line": 278,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cellTemplate"
-            }
-          ],
           "return": {
             "type": "void"
           },
@@ -30023,11 +33598,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -30043,62 +33618,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -30117,11 +33647,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -30149,11 +33679,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -30175,11 +33705,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -30210,11 +33740,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -30232,11 +33762,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -30258,11 +33788,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -30280,11 +33810,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -30302,11 +33832,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -30324,11 +33854,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -30346,11 +33876,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -30367,11 +33897,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 90,
+              "line": 101,
               "column": 3
             },
             "end": {
-              "line": 101,
+              "line": 112,
               "column": 4
             }
           },
@@ -30387,6 +33917,32 @@
               "name": "maximumFractionDigits"
             }
           ]
+        },
+        {
+          "name": "onBadInputFloatLabel",
+          "description": "Check if label should float based on validity\n\nNumber inputs can have allowed characters that aren't numbers (-,e) and won't\ntrigger a value change and thus not float the label.\nHowever, the validity will report badInput so we can trigger a label float by\nsetting it to something truthy but still not visible.\nFixed in paper-input 3.x",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 126,
+              "column": 3
+            },
+            "end": {
+              "line": 132,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event",
+              "type": "Event",
+              "description": "KeyboardEvent"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
         }
       ],
       "staticMethods": [],
@@ -30394,11 +33950,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 46,
+          "line": 53,
           "column": 2
         },
         "end": {
-          "line": 137,
+          "line": 168,
           "column": 3
         }
       },
@@ -30412,11 +33968,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -30430,11 +33986,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -30448,11 +34004,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 30,
+              "line": 34,
               "column": 4
             },
             "end": {
-              "line": 33,
+              "line": 37,
               "column": 5
             }
           },
@@ -30466,11 +34022,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 35,
+              "line": 39,
               "column": 4
             },
             "end": {
-              "line": 38,
+              "line": 42,
               "column": 5
             }
           },
@@ -30484,11 +34040,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -30502,11 +34058,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -30520,11 +34076,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -30538,11 +34094,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -30556,11 +34112,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -30574,11 +34130,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -30592,11 +34148,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -30610,11 +34166,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -30628,11 +34184,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -30646,11 +34202,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -30664,11 +34220,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -30682,11 +34238,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -30700,11 +34256,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -30717,11 +34273,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 70,
               "column": 5
             },
             "end": {
-              "line": 62,
+              "line": 73,
               "column": 6
             }
           },
@@ -30733,11 +34289,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 74,
               "column": 5
             },
             "end": {
-              "line": 66,
+              "line": 77,
               "column": 6
             }
           },
@@ -30750,11 +34306,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -30768,11 +34324,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -30786,11 +34342,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -30803,11 +34359,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 55,
+              "line": 66,
               "column": 5
             },
             "end": {
-              "line": 58,
+              "line": 69,
               "column": 6
             }
           },
@@ -30819,11 +34375,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 78,
               "column": 5
             },
             "end": {
-              "line": 70,
+              "line": 81,
               "column": 6
             }
           },
@@ -30836,11 +34392,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -30854,11 +34410,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -30872,34 +34428,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -30979,11 +34517,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 74,
+              "line": 85,
               "column": 6
             }
           },
@@ -30995,11 +34533,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 86,
               "column": 5
             },
             "end": {
-              "line": 78,
+              "line": 89,
               "column": 6
             }
           },
@@ -31011,11 +34549,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 90,
               "column": 5
             },
             "end": {
-              "line": 82,
+              "line": 93,
               "column": 6
             }
           },
@@ -31048,11 +34586,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -31073,11 +34611,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -31096,12 +34634,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {
@@ -31120,12 +34658,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {
@@ -31144,11 +34682,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -31168,11 +34706,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 54,
               "column": 5
             }
           },
@@ -31191,11 +34729,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 52,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 59,
               "column": 5
             }
           },
@@ -31215,11 +34753,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 57,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -31239,11 +34777,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 65,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 72,
               "column": 5
             }
           },
@@ -31263,12 +34801,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 30,
-              "column": 4
+              "line": 48,
+              "column": 5
             },
             "end": {
-              "line": 33,
-              "column": 5
+              "line": 51,
+              "column": 6
             }
           },
           "metadata": {
@@ -31287,11 +34825,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -31311,11 +34849,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -31335,11 +34873,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -31359,12 +34897,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {
@@ -31376,98 +34914,6 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -31475,11 +34921,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -31499,11 +34945,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -31522,11 +34968,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -31547,11 +34993,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -31571,11 +35017,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -31596,11 +35042,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -31620,11 +35066,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -31645,11 +35091,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -31669,11 +35115,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -31692,11 +35138,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -31716,11 +35162,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -31740,11 +35186,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -31764,11 +35210,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 77,
               "column": 5
             },
             "end": {
-              "line": 72,
+              "line": 80,
               "column": 6
             }
           },
@@ -31786,11 +35232,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 74,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 77,
+              "line": 85,
               "column": 6
             }
           },
@@ -31809,11 +35255,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -31832,11 +35278,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 72,
               "column": 5
             },
             "end": {
-              "line": 67,
+              "line": 75,
               "column": 6
             }
           },
@@ -31855,11 +35301,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -31878,11 +35324,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -31902,11 +35348,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -31916,30 +35362,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -32037,65 +35459,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_fixedDate",
           "type": "?",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 89,
               "column": 3
             },
             "end": {
-              "line": 83,
+              "line": 91,
               "column": 4
             }
           },
@@ -32112,11 +35486,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 67,
               "column": 5
             },
             "end": {
-              "line": 62,
+              "line": 70,
               "column": 6
             }
           },
@@ -32131,16 +35505,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "",
+          "description": "Cleans up references to recycled instances when the element is detached.",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-range-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 79,
+              "line": 77,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 80,
               "column": 3
             }
           },
@@ -32149,7 +35523,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.RangeColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
           "name": "toNumber",
@@ -32158,11 +35532,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 91,
+              "line": 95,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 3
             }
           },
@@ -32197,12 +35571,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 89,
-              "column": 2
+              "line": 121,
+              "column": 3
             },
             "end": {
-              "line": 91,
-              "column": 3
+              "line": 123,
+              "column": 4
             }
           },
           "metadata": {},
@@ -32215,11 +35589,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 132,
+              "line": 143,
               "column": 3
             },
             "end": {
-              "line": 145,
+              "line": 156,
               "column": 4
             }
           },
@@ -32247,11 +35621,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 147,
+              "line": 158,
               "column": 3
             },
             "end": {
-              "line": 152,
+              "line": 163,
               "column": 4
             }
           },
@@ -32273,11 +35647,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 330,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 263,
               "column": 3
             }
           },
@@ -32300,12 +35674,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 127,
-              "column": 2
+              "line": 184,
+              "column": 3
             },
             "end": {
-              "line": 136,
-              "column": 3
+              "line": 193,
+              "column": 4
             }
           },
           "metadata": {},
@@ -32327,11 +35701,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 154,
+              "line": 158,
               "column": 2
             },
             "end": {
-              "line": 157,
+              "line": 161,
               "column": 3
             }
           },
@@ -32354,11 +35728,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 165,
+              "line": 169,
               "column": 2
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 3
             }
           },
@@ -32383,11 +35757,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 2
             },
             "end": {
-              "line": 200,
+              "line": 204,
               "column": 3
             }
           },
@@ -32415,11 +35789,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -32434,11 +35808,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -32460,11 +35834,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 228,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 245,
+              "line": 249,
               "column": 3
             }
           },
@@ -32483,11 +35857,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 247,
+              "line": 251,
               "column": 2
             },
             "end": {
-              "line": 252,
+              "line": 256,
               "column": 3
             }
           },
@@ -32509,11 +35883,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 254,
+              "line": 258,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 260,
               "column": 3
             }
           },
@@ -32531,11 +35905,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 100,
+              "line": 111,
               "column": 3
             },
             "end": {
-              "line": 106,
+              "line": 117,
               "column": 4
             }
           },
@@ -32553,11 +35927,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -32572,11 +35946,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 279,
+              "line": 283,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 293,
               "column": 3
             }
           },
@@ -32600,11 +35974,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 295,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 3
             }
           },
@@ -32622,11 +35996,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 340,
               "column": 3
             }
           },
@@ -32644,11 +36018,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 338,
+              "line": 342,
               "column": 2
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 3
             }
           },
@@ -32670,11 +36044,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -32699,11 +36073,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -32723,11 +36097,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -32745,11 +36119,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 108,
+              "line": 119,
               "column": 3
             },
             "end": {
-              "line": 115,
+              "line": 126,
               "column": 4
             }
           },
@@ -32766,11 +36140,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 117,
+              "line": 128,
               "column": 3
             },
             "end": {
-              "line": 123,
+              "line": 134,
               "column": 4
             }
           },
@@ -32787,11 +36161,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 101,
               "column": 3
             },
             "end": {
-              "line": 98,
+              "line": 109,
               "column": 4
             }
           },
@@ -32819,16 +36193,74 @@
           }
         },
         {
+          "name": "getAbsoluteISOString",
+          "description": "Computes the local timezone and adds it to a local ISO string",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-mixin.html",
+            "start": {
+              "line": 164,
+              "column": 3
+            },
+            "end": {
+              "line": 172,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string, without timezone info"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "an ISO date string, with timezone info"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnMixin"
+        },
+        {
+          "name": "_getTimezoneString",
+          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-mixin.html",
+            "start": {
+              "line": 179,
+              "column": 3
+            },
+            "end": {
+              "line": 182,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "the ISO timezone"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnMixin"
+        },
+        {
           "name": "_computeFormatter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 172,
+              "line": 183,
               "column": 3
             },
             "end": {
-              "line": 179,
+              "line": 190,
               "column": 4
             }
           },
@@ -32846,12 +36278,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 150,
-              "column": 2
+              "line": 207,
+              "column": 3
             },
             "end": {
-              "line": 161,
-              "column": 3
+              "line": 218,
+              "column": 4
             }
           },
           "metadata": {},
@@ -32872,12 +36304,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 163,
-              "column": 2
+              "line": 220,
+              "column": 3
             },
             "end": {
-              "line": 175,
-              "column": 3
+              "line": 222,
+              "column": 4
             }
           },
           "metadata": {},
@@ -32889,71 +36321,324 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 242,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 235,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_createTemplatizer",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 248,
-              "column": 2
-            },
-            "end": {
-              "line": 272,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateElementOrSelector"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_cellTemplateChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 274,
-              "column": 2
-            },
-            "end": {
-              "line": 278,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cellTemplate"
-            }
-          ],
           "return": {
             "type": "void"
           },
@@ -32966,11 +36651,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -32986,62 +36671,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -33060,11 +36700,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -33092,11 +36732,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -33118,11 +36758,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -33153,11 +36793,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -33175,11 +36815,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -33201,11 +36841,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -33223,11 +36863,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -33245,11 +36885,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -33267,11 +36907,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -33289,11 +36929,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -33310,11 +36950,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 154,
+              "line": 165,
               "column": 3
             },
             "end": {
-              "line": 168,
+              "line": 179,
               "column": 4
             }
           },
@@ -33334,11 +36974,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 45,
+          "line": 51,
           "column": 2
         },
         "end": {
-          "line": 180,
+          "line": 191,
           "column": 3
         }
       },
@@ -33352,11 +36992,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -33370,11 +37010,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -33388,12 +37028,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {},
@@ -33406,12 +37046,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {},
@@ -33424,11 +37064,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -33442,11 +37082,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -33460,11 +37100,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -33478,11 +37118,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -33496,12 +37136,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {},
@@ -33514,11 +37154,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -33532,11 +37172,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -33550,11 +37190,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -33568,11 +37208,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -33586,11 +37226,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -33604,11 +37244,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -33622,11 +37262,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -33640,11 +37280,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -33658,11 +37298,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -33676,11 +37316,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -33694,11 +37334,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -33712,11 +37352,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -33729,11 +37369,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 69,
+              "line": 77,
               "column": 5
             },
             "end": {
-              "line": 72,
+              "line": 80,
               "column": 6
             }
           },
@@ -33745,11 +37385,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 74,
+              "line": 82,
               "column": 5
             },
             "end": {
-              "line": 77,
+              "line": 85,
               "column": 6
             }
           },
@@ -33762,11 +37402,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -33779,11 +37419,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 64,
+              "line": 72,
               "column": 5
             },
             "end": {
-              "line": 67,
+              "line": 75,
               "column": 6
             }
           },
@@ -33796,11 +37436,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -33814,11 +37454,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -33832,34 +37472,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -33939,11 +37561,11 @@
           "description": "Specifies the value granularity of the time input's value in the filter.\n1 => full seconds\n0.1 => milliseconds",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 67,
               "column": 5
             },
             "end": {
-              "line": 62,
+              "line": 70,
               "column": 6
             }
           },
@@ -33976,11 +37598,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -34001,11 +37623,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -34024,12 +37646,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {
@@ -34048,12 +37670,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {
@@ -34072,11 +37694,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -34096,11 +37718,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 54,
               "column": 5
             }
           },
@@ -34119,11 +37741,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 52,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 59,
               "column": 5
             }
           },
@@ -34143,11 +37765,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 57,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -34167,11 +37789,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 65,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 72,
               "column": 5
             }
           },
@@ -34191,12 +37813,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 30,
-              "column": 4
+              "line": 48,
+              "column": 5
             },
             "end": {
-              "line": 33,
-              "column": 5
+              "line": 51,
+              "column": 6
             }
           },
           "metadata": {
@@ -34214,11 +37836,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 62,
+              "line": 70,
               "column": 5
             },
             "end": {
-              "line": 65,
+              "line": 73,
               "column": 6
             }
           },
@@ -34236,11 +37858,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 75,
               "column": 5
             },
             "end": {
-              "line": 70,
+              "line": 78,
               "column": 6
             }
           },
@@ -34259,11 +37881,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -34283,12 +37905,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {
@@ -34300,98 +37922,6 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "title",
           "type": "string | null | undefined",
           "description": "",
@@ -34399,11 +37929,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -34423,11 +37953,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -34446,11 +37976,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -34471,11 +38001,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -34495,11 +38025,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -34520,11 +38050,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -34544,11 +38074,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -34569,11 +38099,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -34593,11 +38123,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -34616,11 +38146,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -34640,11 +38170,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -34664,11 +38194,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -34688,11 +38218,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 80,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 83,
               "column": 6
             }
           },
@@ -34710,11 +38240,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 85,
               "column": 5
             },
             "end": {
-              "line": 80,
+              "line": 88,
               "column": 6
             }
           },
@@ -34733,11 +38263,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -34756,11 +38286,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 90,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 93,
               "column": 6
             }
           },
@@ -34779,11 +38309,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -34802,11 +38332,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -34826,11 +38356,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -34840,30 +38370,6 @@
             }
           },
           "defaultValue": "0",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          },
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -34961,65 +38467,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "filterStep",
           "type": "number | null | undefined",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 65,
               "column": 5
             },
             "end": {
-              "line": 60,
+              "line": 68,
               "column": 6
             }
           },
@@ -35034,16 +38492,16 @@
       "methods": [
         {
           "name": "disconnectedCallback",
-          "description": "",
+          "description": "Cleans up references to recycled instances when the element is detached.",
           "privacy": "public",
           "sourceRange": {
-            "file": "cosmoz-omnitable-column-range-mixin.html",
+            "file": "cosmoz-omnitable-templatize-mixin.html",
             "start": {
-              "line": 79,
+              "line": 77,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 80,
               "column": 3
             }
           },
@@ -35052,7 +38510,7 @@
           "return": {
             "type": "void"
           },
-          "inheritedFrom": "Cosmoz.RangeColumnMixin"
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
         },
         {
           "name": "toNumber",
@@ -35061,11 +38519,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 91,
+              "line": 95,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 3
             }
           },
@@ -35100,12 +38558,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 89,
-              "column": 2
+              "line": 121,
+              "column": 3
             },
             "end": {
-              "line": 91,
-              "column": 3
+              "line": 123,
+              "column": 4
             }
           },
           "metadata": {},
@@ -35119,11 +38577,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 358,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 287,
               "column": 3
             }
           },
@@ -35144,11 +38602,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 122,
               "column": 3
             },
             "end": {
-              "line": 119,
+              "line": 127,
               "column": 4
             }
           },
@@ -35170,11 +38628,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 330,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 263,
               "column": 3
             }
           },
@@ -35197,12 +38655,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 127,
-              "column": 2
+              "line": 184,
+              "column": 3
             },
             "end": {
-              "line": 136,
-              "column": 3
+              "line": 193,
+              "column": 4
             }
           },
           "metadata": {},
@@ -35224,11 +38682,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 154,
+              "line": 158,
               "column": 2
             },
             "end": {
-              "line": 157,
+              "line": 161,
               "column": 3
             }
           },
@@ -35251,11 +38709,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 165,
+              "line": 169,
               "column": 2
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 3
             }
           },
@@ -35280,11 +38738,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 2
             },
             "end": {
-              "line": 200,
+              "line": 204,
               "column": 3
             }
           },
@@ -35312,11 +38770,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -35331,11 +38789,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -35357,11 +38815,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 228,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 245,
+              "line": 249,
               "column": 3
             }
           },
@@ -35380,11 +38838,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 247,
+              "line": 251,
               "column": 2
             },
             "end": {
-              "line": 252,
+              "line": 256,
               "column": 3
             }
           },
@@ -35406,11 +38864,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 254,
+              "line": 258,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 260,
               "column": 3
             }
           },
@@ -35428,11 +38886,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 89,
+              "line": 97,
               "column": 3
             },
             "end": {
-              "line": 95,
+              "line": 103,
               "column": 4
             }
           },
@@ -35450,11 +38908,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -35469,11 +38927,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 279,
+              "line": 283,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 293,
               "column": 3
             }
           },
@@ -35497,11 +38955,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 295,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 3
             }
           },
@@ -35519,11 +38977,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 340,
               "column": 3
             }
           },
@@ -35541,11 +38999,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 338,
+              "line": 342,
               "column": 2
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 3
             }
           },
@@ -35567,11 +39025,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -35596,11 +39054,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -35620,11 +39078,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -35642,11 +39100,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 97,
+              "line": 105,
               "column": 3
             },
             "end": {
-              "line": 104,
+              "line": 112,
               "column": 4
             }
           },
@@ -35663,11 +39121,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 106,
+              "line": 114,
               "column": 3
             },
             "end": {
-              "line": 112,
+              "line": 120,
               "column": 4
             }
           },
@@ -35685,12 +39143,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 68,
-              "column": 2
+              "line": 86,
+              "column": 3
             },
             "end": {
-              "line": 87,
-              "column": 3
+              "line": 119,
+              "column": 4
             }
           },
           "metadata": {},
@@ -35718,16 +39176,74 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "getAbsoluteISOString",
+          "description": "Computes the local timezone and adds it to a local ISO string",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-mixin.html",
+            "start": {
+              "line": 164,
+              "column": 3
+            },
+            "end": {
+              "line": 172,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string, without timezone info"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "an ISO date string, with timezone info"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnMixin"
+        },
+        {
+          "name": "_getTimezoneString",
+          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-column-date-mixin.html",
+            "start": {
+              "line": 179,
+              "column": 3
+            },
+            "end": {
+              "line": 182,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "the ISO timezone"
+          },
+          "inheritedFrom": "Cosmoz.DateColumnMixin"
+        },
+        {
           "name": "_computeFormatter",
           "description": "OVERRIDES",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 130,
               "column": 3
             },
             "end": {
-              "line": 131,
+              "line": 139,
               "column": 4
             }
           },
@@ -35745,12 +39261,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 150,
-              "column": 2
+              "line": 207,
+              "column": 3
             },
             "end": {
-              "line": 161,
-              "column": 3
+              "line": 218,
+              "column": 4
             }
           },
           "metadata": {},
@@ -35771,12 +39287,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 163,
-              "column": 2
+              "line": 220,
+              "column": 3
             },
             "end": {
-              "line": 175,
-              "column": 3
+              "line": 222,
+              "column": 4
             }
           },
           "metadata": {},
@@ -35788,71 +39304,324 @@
           "inheritedFrom": "Cosmoz.DateColumnMixin"
         },
         {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 242,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 235,
               "column": 3
             }
           },
           "metadata": {},
           "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_createTemplatizer",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 248,
-              "column": 2
-            },
-            "end": {
-              "line": 272,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateElementOrSelector"
-            }
-          ],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "_cellTemplateChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 274,
-              "column": 2
-            },
-            "end": {
-              "line": 278,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cellTemplate"
-            }
-          ],
           "return": {
             "type": "void"
           },
@@ -35865,11 +39634,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -35885,62 +39654,17 @@
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -35959,11 +39683,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -35991,11 +39715,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -36017,11 +39741,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -36052,11 +39776,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -36074,11 +39798,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -36100,11 +39824,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -36122,11 +39846,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -36144,11 +39868,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -36166,11 +39890,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -36188,11 +39912,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -36209,11 +39933,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 48,
+          "line": 54,
           "column": 2
         },
         "end": {
-          "line": 132,
+          "line": 140,
           "column": 3
         }
       },
@@ -36227,11 +39951,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -36245,11 +39969,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -36263,12 +39987,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {},
@@ -36281,12 +40005,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {},
@@ -36299,11 +40023,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -36316,11 +40040,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 62,
+              "line": 70,
               "column": 5
             },
             "end": {
-              "line": 65,
+              "line": 73,
               "column": 6
             }
           },
@@ -36332,11 +40056,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 75,
               "column": 5
             },
             "end": {
-              "line": 70,
+              "line": 78,
               "column": 6
             }
           },
@@ -36349,11 +40073,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -36367,12 +40091,12 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-date-mixin.html",
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {},
@@ -36385,11 +40109,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -36403,11 +40127,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -36421,11 +40145,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -36439,11 +40163,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -36457,11 +40181,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -36475,11 +40199,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -36493,11 +40217,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -36511,11 +40235,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -36529,11 +40253,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -36547,11 +40271,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -36565,11 +40289,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -36583,11 +40307,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -36600,11 +40324,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 80,
               "column": 5
             },
             "end": {
-              "line": 75,
+              "line": 83,
               "column": 6
             }
           },
@@ -36616,11 +40340,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 77,
+              "line": 85,
               "column": 5
             },
             "end": {
-              "line": 80,
+              "line": 88,
               "column": 6
             }
           },
@@ -36633,11 +40357,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -36650,11 +40374,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 90,
               "column": 5
             },
             "end": {
-              "line": 85,
+              "line": 93,
               "column": 6
             }
           },
@@ -36667,11 +40391,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -36685,11 +40409,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -36703,34 +40427,16 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-mixin.html",
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined",
-          "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "file": "cosmoz-omnitable-column-mixin.html",
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined",
           "inheritedFrom": "Cosmoz.OmnitableColumnMixin"
         },
         {
@@ -36810,11 +40516,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 65,
               "column": 5
             },
             "end": {
-              "line": 60,
+              "line": 68,
               "column": 6
             }
           },
@@ -36846,11 +40552,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 32,
+              "line": 36,
               "column": 4
             },
             "end": {
-              "line": 35,
+              "line": 39,
               "column": 5
             }
           },
@@ -36868,11 +40574,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -36890,11 +40596,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 48,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 51,
+              "line": 55,
               "column": 5
             }
           },
@@ -36912,11 +40618,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 56,
+              "line": 60,
               "column": 4
             },
             "end": {
-              "line": 58,
+              "line": 62,
               "column": 5
             }
           },
@@ -36933,11 +40639,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 67,
               "column": 4
             },
             "end": {
-              "line": 67,
+              "line": 71,
               "column": 5
             }
           },
@@ -36956,11 +40662,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 79,
               "column": 5
             }
           },
@@ -36978,11 +40684,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 84,
               "column": 4
             },
             "end": {
-              "line": 83,
+              "line": 87,
               "column": 5
             }
           },
@@ -37000,11 +40706,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 88,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 95,
               "column": 5
             }
           },
@@ -37022,11 +40728,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -37044,11 +40750,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 104,
+              "line": 108,
               "column": 4
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 5
             }
           },
@@ -37066,11 +40772,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 112,
+              "line": 116,
               "column": 4
             },
             "end": {
-              "line": 115,
+              "line": 119,
               "column": 5
             }
           },
@@ -37088,11 +40794,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 117,
+              "line": 121,
               "column": 4
             },
             "end": {
-              "line": 120,
+              "line": 124,
               "column": 5
             }
           },
@@ -37110,11 +40816,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 126,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 130,
               "column": 5
             }
           },
@@ -37133,11 +40839,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 128,
+              "line": 132,
               "column": 4
             },
             "end": {
-              "line": 132,
+              "line": 136,
               "column": 5
             }
           },
@@ -37156,11 +40862,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 134,
+              "line": 138,
               "column": 4
             },
             "end": {
-              "line": 137,
+              "line": 141,
               "column": 5
             }
           },
@@ -37178,11 +40884,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 139,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 143,
+              "line": 147,
               "column": 5
             }
           },
@@ -37201,11 +40907,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 147,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 151,
+              "line": 155,
               "column": 5
             }
           },
@@ -37224,11 +40930,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 161,
+              "line": 165,
               "column": 5
             }
           },
@@ -37248,11 +40954,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 170,
+              "line": 174,
               "column": 5
             }
           },
@@ -37271,11 +40977,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 175,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -37292,11 +40998,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 182,
+              "line": 186,
               "column": 4
             },
             "end": {
-              "line": 185,
+              "line": 189,
               "column": 5
             }
           },
@@ -37314,11 +41020,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 190,
+              "line": 194,
               "column": 4
             },
             "end": {
-              "line": 193,
+              "line": 197,
               "column": 5
             }
           },
@@ -37336,11 +41042,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 195,
+              "line": 199,
               "column": 4
             },
             "end": {
-              "line": 198,
+              "line": 202,
               "column": 5
             }
           },
@@ -37358,11 +41064,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 203,
+              "line": 207,
               "column": 4
             },
             "end": {
-              "line": 206,
+              "line": 210,
               "column": 5
             }
           },
@@ -37380,11 +41086,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 212,
               "column": 4
             },
             "end": {
-              "line": 214,
+              "line": 218,
               "column": 5
             }
           },
@@ -37405,11 +41111,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 219,
+              "line": 223,
               "column": 4
             },
             "end": {
-              "line": 223,
+              "line": 227,
               "column": 5
             }
           },
@@ -37428,11 +41134,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 225,
+              "line": 229,
               "column": 4
             },
             "end": {
-              "line": 228,
+              "line": 232,
               "column": 5
             }
           },
@@ -37450,11 +41156,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 230,
+              "line": 234,
               "column": 4
             },
             "end": {
-              "line": 233,
+              "line": 237,
               "column": 5
             }
           },
@@ -37472,11 +41178,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 235,
+              "line": 239,
               "column": 4
             },
             "end": {
-              "line": 237,
+              "line": 241,
               "column": 5
             }
           },
@@ -37493,11 +41199,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 239,
+              "line": 243,
               "column": 4
             },
             "end": {
-              "line": 242,
+              "line": 246,
               "column": 5
             }
           },
@@ -37514,11 +41220,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 243,
+              "line": 247,
               "column": 4
             },
             "end": {
-              "line": 246,
+              "line": 250,
               "column": 5
             }
           },
@@ -37536,11 +41242,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 251,
+              "line": 255,
               "column": 4
             },
             "end": {
-              "line": 253,
+              "line": 257,
               "column": 5
             }
           },
@@ -37549,75 +41255,20 @@
               "attributeType": "Boolean"
             }
           }
-        },
-        {
-          "name": "t",
-          "type": "Object | null | undefined",
-          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 256,
-              "column": 4
-            },
-            "end": {
-              "line": 261,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          }
         }
       ],
       "methods": [
-        {
-          "name": "_",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 273,
-              "column": 2
-            },
-            "end": {
-              "line": 276,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "ngettext",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 278,
-              "column": 2
-            },
-            "end": {
-              "line": 281,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
         {
           "name": "connectedCallback",
           "description": "",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 295,
+              "line": 282,
               "column": 2
             },
             "end": {
-              "line": 325,
+              "line": 312,
               "column": 3
             }
           },
@@ -37633,11 +41284,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 327,
+              "line": 314,
               "column": 2
             },
             "end": {
-              "line": 345,
+              "line": 332,
               "column": 3
             }
           },
@@ -37653,11 +41304,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 347,
+              "line": 334,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 356,
               "column": 3
             }
           },
@@ -37673,11 +41324,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 369,
+              "line": 358,
               "column": 2
             },
             "end": {
-              "line": 377,
+              "line": 360,
               "column": 3
             }
           },
@@ -37693,11 +41344,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 381,
+              "line": 364,
               "column": 2
             },
             "end": {
-              "line": 383,
+              "line": 366,
               "column": 3
             }
           },
@@ -37714,11 +41365,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 385,
+              "line": 368,
               "column": 2
             },
             "end": {
-              "line": 387,
+              "line": 370,
               "column": 3
             }
           },
@@ -37738,11 +41389,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 389,
+              "line": 372,
               "column": 2
             },
             "end": {
-              "line": 392,
+              "line": 375,
               "column": 3
             }
           },
@@ -37759,11 +41410,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 394,
+              "line": 377,
               "column": 2
             },
             "end": {
-              "line": 396,
+              "line": 379,
               "column": 3
             }
           },
@@ -37783,11 +41434,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 398,
+              "line": 381,
               "column": 2
             },
             "end": {
-              "line": 402,
+              "line": 385,
               "column": 3
             }
           },
@@ -37807,11 +41458,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 404,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 407,
+              "line": 390,
               "column": 3
             }
           },
@@ -37827,11 +41478,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 409,
+              "line": 392,
               "column": 2
             },
             "end": {
-              "line": 415,
+              "line": 398,
               "column": 3
             }
           },
@@ -37851,11 +41502,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 417,
+              "line": 400,
               "column": 2
             },
             "end": {
-              "line": 434,
+              "line": 417,
               "column": 3
             }
           },
@@ -37875,11 +41526,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 436,
+              "line": 419,
               "column": 2
             },
             "end": {
-              "line": 450,
+              "line": 433,
               "column": 3
             }
           },
@@ -37899,11 +41550,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 453,
+              "line": 436,
               "column": 2
             },
             "end": {
-              "line": 461,
+              "line": 444,
               "column": 3
             }
           },
@@ -37923,11 +41574,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 464,
+              "line": 447,
               "column": 2
             },
             "end": {
-              "line": 474,
+              "line": 457,
               "column": 3
             }
           },
@@ -37947,11 +41598,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 476,
+              "line": 459,
               "column": 2
             },
             "end": {
-              "line": 479,
+              "line": 462,
               "column": 3
             }
           },
@@ -37971,11 +41622,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 481,
+              "line": 464,
               "column": 2
             },
             "end": {
-              "line": 484,
+              "line": 467,
               "column": 3
             }
           },
@@ -37991,11 +41642,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 486,
+              "line": 469,
               "column": 2
             },
             "end": {
-              "line": 492,
+              "line": 475,
               "column": 3
             }
           },
@@ -38011,11 +41662,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 494,
+              "line": 477,
               "column": 2
             },
             "end": {
-              "line": 496,
+              "line": 479,
               "column": 3
             }
           },
@@ -38031,11 +41682,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 498,
+              "line": 481,
               "column": 2
             },
             "end": {
-              "line": 566,
+              "line": 547,
               "column": 3
             }
           },
@@ -38051,11 +41702,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 574,
+              "line": 555,
               "column": 2
             },
             "end": {
-              "line": 591,
+              "line": 572,
               "column": 3
             }
           },
@@ -38084,11 +41735,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 593,
+              "line": 574,
               "column": 2
             },
             "end": {
-              "line": 598,
+              "line": 579,
               "column": 3
             }
           },
@@ -38108,11 +41759,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 601,
+              "line": 582,
               "column": 2
             },
             "end": {
-              "line": 622,
+              "line": 603,
               "column": 3
             }
           },
@@ -38133,11 +41784,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 629,
+              "line": 610,
               "column": 2
             },
             "end": {
-              "line": 638,
+              "line": 619,
               "column": 3
             }
           },
@@ -38170,11 +41821,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 640,
+              "line": 621,
               "column": 2
             },
             "end": {
-              "line": 646,
+              "line": 627,
               "column": 3
             }
           },
@@ -38194,11 +41845,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 648,
+              "line": 629,
               "column": 2
             },
             "end": {
-              "line": 650,
+              "line": 631,
               "column": 3
             }
           },
@@ -38214,11 +41865,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 652,
+              "line": 633,
               "column": 2
             },
             "end": {
-              "line": 672,
+              "line": 653,
               "column": 3
             }
           },
@@ -38234,11 +41885,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 674,
+              "line": 655,
               "column": 2
             },
             "end": {
-              "line": 680,
+              "line": 661,
               "column": 3
             }
           },
@@ -38258,11 +41909,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 682,
+              "line": 663,
               "column": 2
             },
             "end": {
-              "line": 687,
+              "line": 668,
               "column": 3
             }
           },
@@ -38278,11 +41929,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 689,
+              "line": 670,
               "column": 2
             },
             "end": {
-              "line": 741,
+              "line": 722,
               "column": 3
             }
           },
@@ -38298,11 +41949,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 743,
+              "line": 724,
               "column": 2
             },
             "end": {
-              "line": 748,
+              "line": 729,
               "column": 3
             }
           },
@@ -38318,11 +41969,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 750,
+              "line": 731,
               "column": 2
             },
             "end": {
-              "line": 782,
+              "line": 763,
               "column": 3
             }
           },
@@ -38342,11 +41993,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 792,
+              "line": 773,
               "column": 2
             },
             "end": {
-              "line": 797,
+              "line": 778,
               "column": 3
             }
           },
@@ -38374,11 +42025,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 799,
+              "line": 780,
               "column": 2
             },
             "end": {
-              "line": 843,
+              "line": 824,
               "column": 3
             }
           },
@@ -38394,11 +42045,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 845,
+              "line": 826,
               "column": 2
             },
             "end": {
-              "line": 850,
+              "line": 831,
               "column": 3
             }
           },
@@ -38414,11 +42065,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 857,
+              "line": 838,
               "column": 2
             },
             "end": {
-              "line": 915,
+              "line": 896,
               "column": 3
             }
           },
@@ -38435,11 +42086,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 917,
+              "line": 898,
               "column": 2
             },
             "end": {
-              "line": 934,
+              "line": 915,
               "column": 3
             }
           },
@@ -38459,11 +42110,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 936,
+              "line": 917,
               "column": 2
             },
             "end": {
-              "line": 954,
+              "line": 935,
               "column": 3
             }
           },
@@ -38480,11 +42131,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 956,
+              "line": 937,
               "column": 2
             },
             "end": {
-              "line": 973,
+              "line": 954,
               "column": 3
             }
           },
@@ -38500,11 +42151,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 975,
+              "line": 956,
               "column": 2
             },
             "end": {
-              "line": 983,
+              "line": 964,
               "column": 3
             }
           },
@@ -38520,11 +42171,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 992,
+              "line": 973,
               "column": 2
             },
             "end": {
-              "line": 1007,
+              "line": 988,
               "column": 3
             }
           },
@@ -38547,11 +42198,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1009,
+              "line": 990,
               "column": 2
             },
             "end": {
-              "line": 1015,
+              "line": 996,
               "column": 3
             }
           },
@@ -38568,11 +42219,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1020,
+              "line": 1001,
               "column": 2
             },
             "end": {
-              "line": 1039,
+              "line": 1020,
               "column": 3
             }
           },
@@ -38588,11 +42239,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1045,
+              "line": 1026,
               "column": 2
             },
             "end": {
-              "line": 1056,
+              "line": 1037,
               "column": 3
             }
           },
@@ -38609,11 +42260,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1063,
+              "line": 1044,
               "column": 2
             },
             "end": {
-              "line": 1070,
+              "line": 1051,
               "column": 3
             }
           },
@@ -38629,11 +42280,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1074,
+              "line": 1055,
               "column": 2
             },
             "end": {
-              "line": 1076,
+              "line": 1057,
               "column": 3
             }
           },
@@ -38650,11 +42301,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1077,
+              "line": 1058,
               "column": 2
             },
             "end": {
-              "line": 1079,
+              "line": 1060,
               "column": 3
             }
           },
@@ -38671,11 +42322,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1087,
+              "line": 1068,
               "column": 2
             },
             "end": {
-              "line": 1099,
+              "line": 1080,
               "column": 3
             }
           },
@@ -38697,11 +42348,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1105,
+              "line": 1086,
               "column": 2
             },
             "end": {
-              "line": 1114,
+              "line": 1095,
               "column": 3
             }
           },
@@ -38723,11 +42374,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1116,
+              "line": 1097,
               "column": 2
             },
             "end": {
-              "line": 1119,
+              "line": 1100,
               "column": 3
             }
           },
@@ -38747,11 +42398,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1126,
+              "line": 1107,
               "column": 2
             },
             "end": {
-              "line": 1136,
+              "line": 1117,
               "column": 3
             }
           },
@@ -38778,11 +42429,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1138,
+              "line": 1119,
               "column": 2
             },
             "end": {
-              "line": 1142,
+              "line": 1123,
               "column": 3
             }
           },
@@ -38802,11 +42453,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1144,
+              "line": 1125,
               "column": 2
             },
             "end": {
-              "line": 1154,
+              "line": 1135,
               "column": 3
             }
           },
@@ -38826,11 +42477,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1163,
+              "line": 1144,
               "column": 2
             },
             "end": {
-              "line": 1173,
+              "line": 1154,
               "column": 3
             }
           },
@@ -38853,11 +42504,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1179,
+              "line": 1160,
               "column": 2
             },
             "end": {
-              "line": 1184,
+              "line": 1165,
               "column": 3
             }
           },
@@ -38880,11 +42531,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1193,
+              "line": 1174,
               "column": 2
             },
             "end": {
-              "line": 1198,
+              "line": 1179,
               "column": 3
             }
           },
@@ -38916,11 +42567,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1200,
+              "line": 1181,
               "column": 2
             },
             "end": {
-              "line": 1202,
+              "line": 1183,
               "column": 3
             }
           },
@@ -38940,11 +42591,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1204,
+              "line": 1185,
               "column": 2
             },
             "end": {
-              "line": 1206,
+              "line": 1187,
               "column": 3
             }
           },
@@ -38964,11 +42615,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1208,
+              "line": 1189,
               "column": 2
             },
             "end": {
-              "line": 1210,
+              "line": 1191,
               "column": 3
             }
           },
@@ -38985,11 +42636,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1212,
+              "line": 1193,
               "column": 2
             },
             "end": {
-              "line": 1214,
+              "line": 1195,
               "column": 3
             }
           },
@@ -39006,11 +42657,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 1216,
+              "line": 1197,
               "column": 2
             },
             "end": {
-              "line": 1226,
+              "line": 1207,
               "column": 3
             }
           },
@@ -39033,11 +42684,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1228,
+              "line": 1209,
               "column": 2
             },
             "end": {
-              "line": 1234,
+              "line": 1215,
               "column": 3
             }
           },
@@ -39060,11 +42711,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1236,
+              "line": 1217,
               "column": 2
             },
             "end": {
-              "line": 1258,
+              "line": 1239,
               "column": 3
             }
           },
@@ -39087,11 +42738,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1259,
+              "line": 1240,
               "column": 2
             },
             "end": {
-              "line": 1264,
+              "line": 1245,
               "column": 3
             }
           },
@@ -39108,11 +42759,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1265,
+              "line": 1246,
               "column": 2
             },
             "end": {
-              "line": 1279,
+              "line": 1260,
               "column": 3
             }
           },
@@ -39135,11 +42786,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1281,
+              "line": 1262,
               "column": 2
             },
             "end": {
-              "line": 1289,
+              "line": 1270,
               "column": 3
             }
           },
@@ -39155,11 +42806,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1291,
+              "line": 1272,
               "column": 2
             },
             "end": {
-              "line": 1305,
+              "line": 1286,
               "column": 3
             }
           },
@@ -39179,11 +42830,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1307,
+              "line": 1288,
               "column": 2
             },
             "end": {
-              "line": 1321,
+              "line": 1302,
               "column": 3
             }
           },
@@ -39203,11 +42854,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1323,
+              "line": 1304,
               "column": 2
             },
             "end": {
-              "line": 1330,
+              "line": 1311,
               "column": 3
             }
           },
@@ -39223,11 +42874,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 1332,
+              "line": 1313,
               "column": 2
             },
             "end": {
-              "line": 1334,
+              "line": 1315,
               "column": 3
             }
           },
@@ -39259,11 +42910,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 18,
+          "line": 21,
           "column": 1
         },
         "end": {
-          "line": 1335,
+          "line": 1316,
           "column": 2
         }
       },
@@ -39276,11 +42927,11 @@
           "description": "Filename when saving as CSV",
           "sourceRange": {
             "start": {
-              "line": 32,
+              "line": 36,
               "column": 4
             },
             "end": {
-              "line": 35,
+              "line": 39,
               "column": 5
             }
           },
@@ -39292,11 +42943,11 @@
           "description": "Filename when saving as XLSX",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -39308,11 +42959,11 @@
           "description": "Sheet name when saving as XLSX",
           "sourceRange": {
             "start": {
-              "line": 48,
+              "line": 52,
               "column": 4
             },
             "end": {
-              "line": 51,
+              "line": 55,
               "column": 5
             }
           },
@@ -39324,11 +42975,11 @@
           "description": "Array used to list items.",
           "sourceRange": {
             "start": {
-              "line": 56,
+              "line": 60,
               "column": 4
             },
             "end": {
-              "line": 58,
+              "line": 62,
               "column": 5
             }
           },
@@ -39340,11 +42991,11 @@
           "description": "If set to true, then group a row will be displayed for groups that contain no items.",
           "sourceRange": {
             "start": {
-              "line": 72,
+              "line": 76,
               "column": 4
             },
             "end": {
-              "line": 75,
+              "line": 79,
               "column": 5
             }
           },
@@ -39356,11 +43007,11 @@
           "description": "Specific columns to enable",
           "sourceRange": {
             "start": {
-              "line": 80,
+              "line": 84,
               "column": 4
             },
             "end": {
-              "line": 83,
+              "line": 87,
               "column": 5
             }
           },
@@ -39372,11 +43023,11 @@
           "description": "Whether bottom-bar has actions.",
           "sourceRange": {
             "start": {
-              "line": 88,
+              "line": 92,
               "column": 4
             },
             "end": {
-              "line": 91,
+              "line": 95,
               "column": 5
             }
           },
@@ -39388,11 +43039,11 @@
           "description": "Shows a loading overlay to indicate data will be updated",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -39404,11 +43055,11 @@
           "description": "List of selected rows/items in `data`.",
           "sourceRange": {
             "start": {
-              "line": 112,
+              "line": 116,
               "column": 4
             },
             "end": {
-              "line": 115,
+              "line": 119,
               "column": 5
             }
           },
@@ -39420,11 +43071,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 117,
+              "line": 121,
               "column": 4
             },
             "end": {
-              "line": 120,
+              "line": 124,
               "column": 5
             }
           },
@@ -39436,11 +43087,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 126,
               "column": 4
             },
             "end": {
-              "line": 126,
+              "line": 130,
               "column": 5
             }
           },
@@ -39452,11 +43103,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 128,
+              "line": 132,
               "column": 4
             },
             "end": {
-              "line": 132,
+              "line": 136,
               "column": 5
             }
           },
@@ -39468,11 +43119,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 134,
+              "line": 138,
               "column": 4
             },
             "end": {
-              "line": 137,
+              "line": 141,
               "column": 5
             }
           },
@@ -39484,11 +43135,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 139,
+              "line": 143,
               "column": 4
             },
             "end": {
-              "line": 143,
+              "line": 147,
               "column": 5
             }
           },
@@ -39500,11 +43151,11 @@
           "description": "The column name to group on.",
           "sourceRange": {
             "start": {
-              "line": 147,
+              "line": 151,
               "column": 4
             },
             "end": {
-              "line": 151,
+              "line": 155,
               "column": 5
             }
           },
@@ -39516,11 +43167,11 @@
           "description": "The column that matches the current `groupOn` value.",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 161,
+              "line": 165,
               "column": 5
             }
           },
@@ -39532,11 +43183,11 @@
           "description": "Items matching current set filter(s)",
           "sourceRange": {
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 170,
+              "line": 174,
               "column": 5
             }
           },
@@ -39548,11 +43199,11 @@
           "description": "Grouped items structure after filtering.",
           "sourceRange": {
             "start": {
-              "line": 175,
+              "line": 179,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -39564,11 +43215,11 @@
           "description": "Sorted items structure after filtering and grouping.",
           "sourceRange": {
             "start": {
-              "line": 182,
+              "line": 186,
               "column": 4
             },
             "end": {
-              "line": 185,
+              "line": 189,
               "column": 5
             }
           },
@@ -39580,11 +43231,11 @@
           "description": "List of columns definition for this table.",
           "sourceRange": {
             "start": {
-              "line": 203,
+              "line": 207,
               "column": 4
             },
             "end": {
-              "line": 206,
+              "line": 210,
               "column": 5
             }
           },
@@ -39596,11 +43247,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 212,
               "column": 4
             },
             "end": {
-              "line": 214,
+              "line": 218,
               "column": 5
             }
           },
@@ -39612,11 +43263,11 @@
           "description": "List of <b>visible</b> columns.",
           "sourceRange": {
             "start": {
-              "line": 219,
+              "line": 223,
               "column": 4
             },
             "end": {
-              "line": 223,
+              "line": 227,
               "column": 5
             }
           },
@@ -39628,11 +43279,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 225,
+              "line": 229,
               "column": 4
             },
             "end": {
-              "line": 228,
+              "line": 232,
               "column": 5
             }
           },
@@ -39644,32 +43295,16 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 235,
+              "line": 239,
               "column": 4
             },
             "end": {
-              "line": 237,
+              "line": 241,
               "column": 5
             }
           },
           "metadata": {},
           "type": "string | null | undefined"
-        },
-        {
-          "name": "t",
-          "description": "FIXME: remove when TranslatableBehavior is a 2.x mixin",
-          "sourceRange": {
-            "start": {
-              "line": 256,
-              "column": 4
-            },
-            "end": {
-              "line": 261,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined"
         }
       ],
       "events": [
@@ -39751,11 +43386,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 181,
+              "line": 185,
               "column": 5
             },
             "end": {
-              "line": 181,
+              "line": 185,
               "column": 46
             }
           }
@@ -39766,11 +43401,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 5
             },
             "end": {
-              "line": 184,
+              "line": 188,
               "column": 44
             }
           }
@@ -39781,11 +43416,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 185,
+              "line": 189,
               "column": 5
             },
             "end": {
-              "line": 185,
+              "line": 189,
               "column": 41
             }
           }
@@ -39796,11 +43431,11 @@
           "range": {
             "file": "cosmoz-omnitable.html",
             "start": {
-              "line": 214,
+              "line": 218,
               "column": 3
             },
             "end": {
-              "line": 214,
+              "line": 218,
               "column": 33
             }
           }
@@ -39808,101 +43443,350 @@
       ],
       "tagname": "cosmoz-omnitable",
       "mixins": [
-        "Polymer.IronResizableBehavior",
-        "Cosmoz.TranslatableBehavior"
+        "Polymer.IronResizableBehavior"
       ]
     }
   ],
   "mixins": [
     {
+      "description": "Prepares instances of templates and re-uses recycled instances.",
+      "summary": "",
+      "path": "cosmoz-omnitable-templatize-mixin.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          }
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          }
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          }
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Cleans up references to recycled instances when the element is detached.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 80,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          }
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          }
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          }
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          }
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 9,
+          "column": 1
+        },
+        "end": {
+          "line": 205,
+          "column": 3
+        }
+      },
+      "privacy": "public",
+      "name": "Cosmoz.OmnitableTemplatizeMixin",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": []
+    },
+    {
       "description": "",
       "summary": "",
       "path": "cosmoz-omnitable-column-mixin.html",
       "properties": [
-        {
-          "name": "editableTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 293,
-              "column": 2
-            },
-            "end": {
-              "line": 296,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "cellTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 297,
-              "column": 2
-            },
-            "end": {
-              "line": 300,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "dataTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 302,
-              "column": 2
-            },
-            "end": {
-              "line": 304,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "headerTemplatizer",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 306,
-              "column": 2
-            },
-            "end": {
-              "line": 308,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
         {
           "name": "title",
           "type": "string | null | undefined",
@@ -39910,11 +43794,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 12,
+              "line": 16,
               "column": 4
             },
             "end": {
-              "line": 15,
+              "line": 19,
               "column": 5
             }
           },
@@ -39932,11 +43816,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 23,
               "column": 5
             }
           },
@@ -39953,11 +43837,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -39976,11 +43860,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -39998,11 +43882,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -40021,11 +43905,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -40043,11 +43927,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -40066,11 +43950,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -40088,11 +43972,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -40111,11 +43995,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -40132,11 +44016,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -40153,11 +44037,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -40175,11 +44059,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -40197,11 +44081,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -40220,11 +44104,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -40242,11 +44126,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -40264,11 +44148,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -40286,11 +44170,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -40308,11 +44192,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -40330,11 +44214,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -40352,11 +44236,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 161,
+              "line": 165,
               "column": 4
             },
             "end": {
-              "line": 164,
+              "line": 168,
               "column": 5
             }
           },
@@ -40374,11 +44258,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 166,
+              "line": 170,
               "column": 4
             },
             "end": {
-              "line": 168,
+              "line": 172,
               "column": 5
             }
           },
@@ -40395,11 +44279,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -40417,11 +44301,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
@@ -40431,28 +44315,6 @@
             }
           },
           "defaultValue": "0"
-        },
-        {
-          "name": "cellTemplate",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "observer": "\"_cellTemplateChanged\"",
-              "attributeType": "Object"
-            }
-          }
         },
         {
           "name": "cellTitleFn",
@@ -40539,64 +44401,344 @@
               "attributeType": "String"
             }
           }
-        },
-        {
-          "name": "_dataTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 223,
-              "column": 4
-            },
-            "end": {
-              "line": 226,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null"
-        },
-        {
-          "name": "_headerTemplatizer",
-          "type": "Object | null | undefined",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 228,
-              "column": 4
-            },
-            "end": {
-              "line": 231,
-              "column": 5
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "attributeType": "Object"
-            }
-          },
-          "defaultValue": "null"
         }
       ],
       "methods": [
+        {
+          "name": "getTemplateInstance",
+          "description": "Creates a new template instance of the required type.\n\nThe light and shadow DOM is searched for templates matching the selector\n`template.<type>`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 28,
+              "column": 2
+            },
+            "end": {
+              "line": 43,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the template instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "recycleInstance",
+          "description": "Marks an instance for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 51,
+              "column": 2
+            },
+            "end": {
+              "line": 61,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the detached instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "isRecycledInstance",
+          "description": "Tests whether the instance is marked for re-use.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 68,
+              "column": 2
+            },
+            "end": {
+              "line": 70,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            }
+          ],
+          "return": {
+            "type": "Boolean",
+            "desc": "true if instance is recycled"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Cleans up references to recycled instances when the element is detached.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 77,
+              "column": 2
+            },
+            "end": {
+              "line": 80,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_reuseInstance",
+          "description": "Reuses an already created instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 89,
+              "column": 2
+            },
+            "end": {
+              "line": 103,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "TemplateInstance",
+              "description": "an instance"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instances properties"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_createInstance",
+          "description": "Creates a new instance of the required type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 112,
+              "column": 2
+            },
+            "end": {
+              "line": 118,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "the instance's properies"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstance",
+            "desc": "the instance"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_getTemplateCtor",
+          "description": "Searches for a template node of the required type and templatizes it.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 127,
+              "column": 2
+            },
+            "end": {
+              "line": 149,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "TemplateInstanceBase",
+            "desc": "the templatized template"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardHostProp",
+          "description": "Generates a function that forwards properties to instances of a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 157,
+              "column": 2
+            },
+            "end": {
+              "line": 173,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "type",
+              "type": "String",
+              "description": "the type of the template"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "a function that forwards props to instances"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperty",
+          "description": "Forward one property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 183,
+              "column": 2
+            },
+            "end": {
+              "line": 189,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Property name."
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "Property value."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "false",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
+        {
+          "name": "_forwardProperties",
+          "description": "Forward many properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "cosmoz-omnitable-templatize-mixin.html",
+            "start": {
+              "line": 198,
+              "column": 2
+            },
+            "end": {
+              "line": 204,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "instance",
+              "type": "object",
+              "description": "Instance."
+            },
+            {
+              "name": "props",
+              "type": "object",
+              "defaultValue": "{}",
+              "description": "Properties to forward."
+            },
+            {
+              "name": "flush",
+              "type": "boolean",
+              "defaultValue": "true",
+              "description": "Whether to flush properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Cosmoz.OmnitableTemplatizeMixin"
+        },
         {
           "name": "ready",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 242,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 246,
+              "line": 235,
               "column": 3
             }
           },
@@ -40607,61 +44749,16 @@
           }
         },
         {
-          "name": "_createTemplatizer",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 248,
-              "column": 2
-            },
-            "end": {
-              "line": 272,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateElementOrSelector"
-            }
-          ]
-        },
-        {
-          "name": "_cellTemplateChanged",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 274,
-              "column": 2
-            },
-            "end": {
-              "line": 278,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cellTemplate"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_externalValuesChanged",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 280,
+              "line": 237,
               "column": 2
             },
             "end": {
-              "line": 291,
+              "line": 248,
               "column": 3
             }
           },
@@ -40676,57 +44773,16 @@
           }
         },
         {
-          "name": "getHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 310,
-              "column": 2
-            },
-            "end": {
-              "line": 315,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "releaseHeaderTemplateInstance",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 317,
-              "column": 2
-            },
-            "end": {
-              "line": 321,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_computePreferredDropdownHorizontalAlign",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 327,
+              "line": 254,
               "column": 2
             },
             "end": {
-              "line": 329,
+              "line": 256,
               "column": 3
             }
           },
@@ -40743,11 +44799,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 330,
+              "line": 257,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 263,
               "column": 3
             }
           },
@@ -40768,11 +44824,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 337,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 342,
+              "line": 269,
               "column": 3
             }
           },
@@ -40793,11 +44849,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 344,
+              "line": 271,
               "column": 2
             },
             "end": {
-              "line": 356,
+              "line": 283,
               "column": 3
             }
           },
@@ -40823,11 +44879,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 358,
+              "line": 285,
               "column": 2
             },
             "end": {
-              "line": 360,
+              "line": 287,
               "column": 3
             }
           },
@@ -40847,11 +44903,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 362,
+              "line": 289,
               "column": 2
             },
             "end": {
-              "line": 370,
+              "line": 297,
               "column": 3
             }
           },
@@ -40871,11 +44927,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 372,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 382,
+              "line": 309,
               "column": 3
             }
           },
@@ -40904,11 +44960,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 384,
+              "line": 311,
               "column": 2
             },
             "end": {
-              "line": 395,
+              "line": 322,
               "column": 3
             }
           },
@@ -40921,11 +44977,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 397,
+              "line": 324,
               "column": 2
             },
             "end": {
-              "line": 399,
+              "line": 326,
               "column": 3
             }
           },
@@ -40941,11 +44997,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 406,
+              "line": 333,
               "column": 2
             },
             "end": {
-              "line": 423,
+              "line": 350,
               "column": 3
             }
           },
@@ -40968,11 +45024,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 425,
+              "line": 352,
               "column": 2
             },
             "end": {
-              "line": 432,
+              "line": 359,
               "column": 3
             }
           },
@@ -40985,11 +45041,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 434,
+              "line": 361,
               "column": 2
             },
             "end": {
-              "line": 440,
+              "line": 367,
               "column": 3
             }
           },
@@ -41009,11 +45065,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 442,
+              "line": 369,
               "column": 2
             },
             "end": {
-              "line": 447,
+              "line": 374,
               "column": 3
             }
           },
@@ -41033,11 +45089,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 449,
+              "line": 376,
               "column": 2
             },
             "end": {
-              "line": 451,
+              "line": 378,
               "column": 3
             }
           },
@@ -41053,11 +45109,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 453,
+              "line": 380,
               "column": 2
             },
             "end": {
-              "line": 455,
+              "line": 382,
               "column": 3
             }
           },
@@ -41073,11 +45129,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 456,
+              "line": 383,
               "column": 2
             },
             "end": {
-              "line": 458,
+              "line": 385,
               "column": 3
             }
           },
@@ -41093,11 +45149,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 460,
+              "line": 387,
               "column": 2
             },
             "end": {
-              "line": 466,
+              "line": 389,
               "column": 3
             }
           },
@@ -41113,11 +45169,11 @@
           "privacy": "private",
           "sourceRange": {
             "start": {
-              "line": 468,
+              "line": 391,
               "column": 2
             },
             "end": {
-              "line": 470,
+              "line": 393,
               "column": 3
             }
           },
@@ -41133,11 +45189,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 472,
+              "line": 395,
               "column": 2
             },
             "end": {
-              "line": 490,
+              "line": 413,
               "column": 3
             }
           },
@@ -41155,11 +45211,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 492,
+              "line": 415,
               "column": 2
             },
             "end": {
-              "line": 502,
+              "line": 425,
               "column": 3
             }
           },
@@ -41176,11 +45232,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 9,
+          "line": 13,
           "column": 1
         },
         "end": {
-          "line": 503,
+          "line": 426,
           "column": 3
         }
       },
@@ -41192,23 +45248,7 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 12,
-              "column": 4
-            },
-            "end": {
-              "line": 15,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
-          "name": "value-path",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 17,
+              "line": 16,
               "column": 4
             },
             "end": {
@@ -41220,15 +45260,31 @@
           "type": "string | null | undefined"
         },
         {
+          "name": "value-path",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 21,
+              "column": 4
+            },
+            "end": {
+              "line": 23,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
           "name": "disabled",
           "description": "If the column should be disabled until enabled with enabledColumns",
           "sourceRange": {
             "start": {
-              "line": 24,
+              "line": 28,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -41240,11 +45296,11 @@
           "description": "If true, the column will be editable by using an input element for rendering.",
           "sourceRange": {
             "start": {
-              "line": 33,
+              "line": 37,
               "column": 4
             },
             "end": {
-              "line": 36,
+              "line": 40,
               "column": 5
             }
           },
@@ -41256,11 +45312,11 @@
           "description": "Values to filter this column will be managed outside of omnitable",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 45,
               "column": 4
             },
             "end": {
-              "line": 45,
+              "line": 49,
               "column": 5
             }
           },
@@ -41272,11 +45328,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 51,
               "column": 4
             },
             "end": {
-              "line": 53,
+              "line": 57,
               "column": 5
             }
           },
@@ -41288,11 +45344,11 @@
           "description": "Indicates whether the user has engaged with the\nheader/filter component of the column",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 63,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -41304,11 +45360,11 @@
           "description": "Indicate that the column is loading/performing work",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 72,
               "column": 4
             },
             "end": {
-              "line": 71,
+              "line": 75,
               "column": 5
             }
           },
@@ -41320,11 +45376,11 @@
           "description": "Whether the column wants a list of all distinct values for the column in `values`",
           "sourceRange": {
             "start": {
-              "line": 76,
+              "line": 80,
               "column": 4
             },
             "end": {
-              "line": 80,
+              "line": 84,
               "column": 5
             }
           },
@@ -41336,11 +45392,11 @@
           "description": "Column name for use with enabledColumns",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 89,
               "column": 4
             },
             "end": {
-              "line": 87,
+              "line": 91,
               "column": 5
             }
           },
@@ -41352,11 +45408,11 @@
           "description": "All values for this column.",
           "sourceRange": {
             "start": {
-              "line": 92,
+              "line": 96,
               "column": 4
             },
             "end": {
-              "line": 94,
+              "line": 98,
               "column": 5
             }
           },
@@ -41368,11 +45424,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 100,
               "column": 4
             },
             "end": {
-              "line": 99,
+              "line": 103,
               "column": 5
             }
           },
@@ -41384,11 +45440,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 101,
+              "line": 105,
               "column": 4
             },
             "end": {
-              "line": 104,
+              "line": 108,
               "column": 5
             }
           },
@@ -41400,11 +45456,11 @@
           "description": "Used to indicate that an element using this behavior is a column definition that can be used\nin cosmoz-omnitable",
           "sourceRange": {
             "start": {
-              "line": 110,
+              "line": 114,
               "column": 4
             },
             "end": {
-              "line": 114,
+              "line": 118,
               "column": 5
             }
           },
@@ -41416,11 +45472,11 @@
           "description": "Base width of this column.",
           "sourceRange": {
             "start": {
-              "line": 119,
+              "line": 123,
               "column": 4
             },
             "end": {
-              "line": 122,
+              "line": 126,
               "column": 5
             }
           },
@@ -41432,11 +45488,11 @@
           "description": "Base width of this column when in edit mode.",
           "sourceRange": {
             "start": {
-              "line": 127,
+              "line": 131,
               "column": 4
             },
             "end": {
-              "line": 130,
+              "line": 134,
               "column": 5
             }
           },
@@ -41448,11 +45504,11 @@
           "description": "The minimum width of this column.",
           "sourceRange": {
             "start": {
-              "line": 135,
+              "line": 139,
               "column": 4
             },
             "end": {
-              "line": 138,
+              "line": 142,
               "column": 5
             }
           },
@@ -41464,11 +45520,11 @@
           "description": "The minimum width of this column in edit mode.",
           "sourceRange": {
             "start": {
-              "line": 143,
+              "line": 147,
               "column": 4
             },
             "end": {
-              "line": 146,
+              "line": 150,
               "column": 5
             }
           },
@@ -41480,11 +45536,11 @@
           "description": "Width growing factor for this column.",
           "sourceRange": {
             "start": {
-              "line": 151,
+              "line": 155,
               "column": 4
             },
             "end": {
-              "line": 154,
+              "line": 158,
               "column": 5
             }
           },
@@ -41496,11 +45552,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 160,
               "column": 4
             },
             "end": {
-              "line": 159,
+              "line": 163,
               "column": 5
             }
           },
@@ -41512,23 +45568,7 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 161,
-              "column": 4
-            },
-            "end": {
-              "line": 164,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "string | null | undefined"
-        },
-        {
-          "name": "style-module",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 166,
+              "line": 165,
               "column": 4
             },
             "end": {
@@ -41540,15 +45580,31 @@
           "type": "string | null | undefined"
         },
         {
+          "name": "style-module",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 170,
+              "column": 4
+            },
+            "end": {
+              "line": 172,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "type": "string | null | undefined"
+        },
+        {
           "name": "overflow",
           "description": "Allow column to overflow without triggering\ncolumn folding (good for long descriptions)",
           "sourceRange": {
             "start": {
-              "line": 174,
+              "line": 178,
               "column": 4
             },
             "end": {
-              "line": 177,
+              "line": 181,
               "column": 5
             }
           },
@@ -41560,32 +45616,16 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 179,
+              "line": 183,
               "column": 4
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 5
             }
           },
           "metadata": {},
           "type": "number | null | undefined"
-        },
-        {
-          "name": "cell-template",
-          "description": "",
-          "sourceRange": {
-            "start": {
-              "line": 184,
-              "column": 4
-            },
-            "end": {
-              "line": 187,
-              "column": 5
-            }
-          },
-          "metadata": {},
-          "type": "Object | null | undefined"
         },
         {
           "name": "cell-title-fn",
@@ -41657,7 +45697,10 @@
         "cssVariables": [],
         "selectors": []
       },
-      "slots": []
+      "slots": [],
+      "mixins": [
+        "Cosmoz.OmnitableTemplatizeMixin"
+      ]
     },
     {
       "description": "",
@@ -41671,11 +45714,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 41,
+              "line": 128,
               "column": 2
             },
             "end": {
-              "line": 43,
+              "line": 130,
               "column": 3
             }
           },
@@ -41692,53 +45735,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 50,
+              "line": 137,
               "column": 2
             },
             "end": {
-              "line": 52,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "elements",
-          "type": "?",
-          "description": "Get an array of the elements generated by this repeater\n\t\t ",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 94,
-              "column": 2
-            },
-            "end": {
-              "line": 99,
-              "column": 3
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": true
-            }
-          }
-        },
-        {
-          "name": "templateInstances",
-          "type": "?",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 101,
-              "column": 2
-            },
-            "end": {
-              "line": 106,
+              "line": 139,
               "column": 3
             }
           },
@@ -41755,11 +45756,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -41776,11 +45777,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -41794,16 +45795,179 @@
       ],
       "methods": [
         {
+          "name": "trackColumns",
+          "description": "Adds an observer to render the cells when the columns are changed.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 48,
+              "column": 2
+            },
+            "end": {
+              "line": 60,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "stopTrackingColumns",
+          "description": "Stops reacting to column changes.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 66,
+              "column": 2
+            },
+            "end": {
+              "line": 73,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "renderCells",
+          "description": "Renders all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 2
+            },
+            "end": {
+              "line": 81,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "destroyCells",
+          "description": "Destroys all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 87,
+              "column": 2
+            },
+            "end": {
+              "line": 89,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "forwardChange",
+          "description": "Forwards a property change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 97,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "String",
+              "description": "the property"
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "description": "the new value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "forwardPathChange",
+          "description": "Forwards a path change to all cells.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 106,
+              "column": 2
+            },
+            "end": {
+              "line": 110,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changeRecord",
+              "type": "Object",
+              "description": "the change record"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
+          "name": "forEachElement",
+          "description": "Runs a callback on each element.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 117,
+              "column": 2
+            },
+            "end": {
+              "line": 119,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "callback",
+              "type": "OmnitableRepeaterMixin~forEachElementCallback",
+              "description": "the callback"
+            }
+          ],
+          "return": {
+            "type": "void"
+          }
+        },
+        {
           "name": "_getTemplateInstance",
           "description": "Get a template instance for the specified column\nMust be defined in implementors.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 60,
+              "line": 148,
               "column": 2
             },
             "end": {
-              "line": 60,
+              "line": 148,
               "column": 33
             }
           },
@@ -41811,155 +45975,49 @@
           "params": [
             {
               "name": "column",
-              "type": "Object",
+              "type": "OmnitableColumnMixin",
               "description": "The column."
             }
           ],
           "return": {
             "type": "Object",
             "desc": "The instance."
-          }
-        },
-        {
-          "name": "_detachTemplateInstance",
-          "description": "Detach and release the template instance associated with\nthe specified column and rendered in the specified element.\nMust be defined in implementors.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 71,
-              "column": 2
-            },
-            "end": {
-              "line": 71,
-              "column": 55
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance",
-              "type": "Object",
-              "description": "The instance."
-            },
-            {
-              "name": "column",
-              "type": "Object",
-              "description": "The column."
-            },
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "undefined"
           }
         },
         {
           "name": "_configureElement",
-          "description": "Configure a newly created repeated element\nMust be defined in implementors.",
+          "description": "Configure a newly created repeated element",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 160,
               "column": 2
             },
             "end": {
-              "line": 79,
-              "column": 31
+              "line": 169,
+              "column": 3
             }
           },
           "metadata": {},
           "params": [
             {
               "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "undefined"
-          }
-        },
-        {
-          "name": "_configureTemplateInstance",
-          "description": "Configure a newly created cell template instance\nMust be defined in implementors.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 87,
-              "column": 2
+              "type": "HTMLElement",
+              "description": "the root cell element"
             },
-            "end": {
-              "line": 87,
-              "column": 41
-            }
-          },
-          "metadata": {},
-          "params": [
+            {
+              "name": "column",
+              "type": "OmnitableColumnMixin",
+              "description": "the column"
+            },
             {
               "name": "instance",
-              "type": "Object",
-              "description": "The instance."
+              "type": "TemplateInstance",
+              "description": "the template instance"
             }
           ],
           "return": {
-            "type": "undefined"
-          }
-        },
-        {
-          "name": "getElementTemplateInstance",
-          "description": "Get the template instance rendered by the specified element.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 113,
-              "column": 2
-            },
-            "end": {
-              "line": 115,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The instance."
-          }
-        },
-        {
-          "name": "getElementColumn",
-          "description": "Get the column that was used to rendered the specified element",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 122,
-              "column": 2
-            },
-            "end": {
-              "line": 124,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "element",
-              "type": "Object",
-              "description": "The element."
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "The column."
+            "type": "void"
           }
         },
         {
@@ -41968,11 +46026,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 126,
+              "line": 171,
               "column": 2
             },
             "end": {
-              "line": 150,
+              "line": 195,
               "column": 3
             }
           },
@@ -41992,11 +46050,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 152,
+              "line": 197,
               "column": 2
             },
             "end": {
-              "line": 161,
+              "line": 206,
               "column": 3
             }
           },
@@ -42016,11 +46074,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 163,
+              "line": 208,
               "column": 2
             },
             "end": {
-              "line": 201,
+              "line": 234,
               "column": 3
             }
           },
@@ -42043,11 +46101,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 203,
+              "line": 236,
               "column": 2
             },
             "end": {
-              "line": 211,
+              "line": 244,
               "column": 3
             }
           },
@@ -42070,11 +46128,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 213,
+              "line": 246,
               "column": 2
             },
             "end": {
-              "line": 229,
+              "line": 262,
               "column": 3
             }
           },
@@ -42092,50 +46150,16 @@
           }
         },
         {
-          "name": "_forwardProperty",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 231,
-              "column": 2
-            },
-            "end": {
-              "line": 237,
-              "column": 3
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "instance"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "value"
-            },
-            {
-              "name": "flush",
-              "defaultValue": "false"
-            }
-          ],
-          "return": {
-            "type": "void"
-          }
-        },
-        {
           "name": "_forwardNotifyPath",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 239,
+              "line": 264,
               "column": 2
             },
             "end": {
-              "line": 244,
+              "line": 269,
               "column": 3
             }
           },
@@ -42149,10 +46173,6 @@
             },
             {
               "name": "value"
-            },
-            {
-              "name": "isPathNotification",
-              "defaultValue": "false"
             },
             {
               "name": "flush",
@@ -42169,11 +46189,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 14,
+          "line": 24,
           "column": 1
         },
         "end": {
-          "line": 245,
+          "line": 270,
           "column": 3
         }
       },
@@ -42185,11 +46205,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 17,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 19,
+              "line": 29,
               "column": 5
             }
           },
@@ -42201,11 +46221,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 21,
+              "line": 31,
               "column": 4
             },
             "end": {
-              "line": 24,
+              "line": 34,
               "column": 5
             }
           },
@@ -42232,11 +46252,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 5
             }
           },
@@ -42255,11 +46275,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -42276,11 +46296,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 30,
+              "line": 34,
               "column": 4
             },
             "end": {
-              "line": 33,
+              "line": 37,
               "column": 5
             }
           },
@@ -42298,11 +46318,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 35,
+              "line": 39,
               "column": 4
             },
             "end": {
-              "line": 38,
+              "line": 42,
               "column": 5
             }
           },
@@ -42320,11 +46340,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -42342,11 +46362,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 54,
               "column": 5
             }
           },
@@ -42363,11 +46383,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 52,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 59,
               "column": 5
             }
           },
@@ -42385,11 +46405,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 57,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -42407,11 +46427,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 65,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 72,
               "column": 5
             }
           },
@@ -42430,11 +46450,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 79,
+              "line": 83,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 85,
               "column": 3
             }
           },
@@ -42450,11 +46470,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 91,
+              "line": 95,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 3
             }
           },
@@ -42487,11 +46507,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 109,
+              "line": 113,
               "column": 2
             },
             "end": {
-              "line": 111,
+              "line": 115,
               "column": 3
             }
           },
@@ -42504,11 +46524,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 120,
+              "line": 124,
               "column": 2
             },
             "end": {
-              "line": 129,
+              "line": 133,
               "column": 3
             }
           },
@@ -42536,11 +46556,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 131,
+              "line": 135,
               "column": 2
             },
             "end": {
-              "line": 137,
+              "line": 141,
               "column": 3
             }
           },
@@ -42561,11 +46581,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 139,
+              "line": 143,
               "column": 2
             },
             "end": {
-              "line": 149,
+              "line": 153,
               "column": 3
             }
           },
@@ -42586,11 +46606,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 150,
+              "line": 154,
               "column": 2
             },
             "end": {
-              "line": 152,
+              "line": 156,
               "column": 3
             }
           },
@@ -42606,11 +46626,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 154,
+              "line": 158,
               "column": 2
             },
             "end": {
-              "line": 157,
+              "line": 161,
               "column": 3
             }
           },
@@ -42631,11 +46651,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 169,
               "column": 2
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 3
             }
           },
@@ -42658,11 +46678,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 2
             },
             "end": {
-              "line": 200,
+              "line": 204,
               "column": 3
             }
           },
@@ -42688,11 +46708,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 202,
+              "line": 206,
               "column": 2
             },
             "end": {
-              "line": 210,
+              "line": 214,
               "column": 3
             }
           },
@@ -42705,11 +46725,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 212,
+              "line": 216,
               "column": 2
             },
             "end": {
-              "line": 226,
+              "line": 230,
               "column": 3
             }
           },
@@ -42729,11 +46749,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 228,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 245,
+              "line": 249,
               "column": 3
             }
           },
@@ -42750,11 +46770,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 247,
+              "line": 251,
               "column": 2
             },
             "end": {
-              "line": 252,
+              "line": 256,
               "column": 3
             }
           },
@@ -42774,11 +46794,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 254,
+              "line": 258,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 260,
               "column": 3
             }
           },
@@ -42795,11 +46815,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 258,
+              "line": 262,
               "column": 2
             },
             "end": {
-              "line": 264,
+              "line": 268,
               "column": 3
             }
           },
@@ -42816,11 +46836,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 266,
+              "line": 270,
               "column": 2
             },
             "end": {
-              "line": 271,
+              "line": 275,
               "column": 3
             }
           },
@@ -42833,11 +46853,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 279,
+              "line": 283,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 293,
               "column": 3
             }
           },
@@ -42859,11 +46879,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 295,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 3
             }
           },
@@ -42879,11 +46899,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 340,
               "column": 3
             }
           },
@@ -42899,11 +46919,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 338,
+              "line": 342,
               "column": 2
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 3
             }
           },
@@ -42923,11 +46943,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 360,
+              "line": 364,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 371,
               "column": 3
             }
           },
@@ -42940,11 +46960,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 369,
+              "line": 373,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 384,
               "column": 3
             }
           },
@@ -42962,11 +46982,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 382,
+              "line": 386,
               "column": 2
             },
             "end": {
-              "line": 396,
+              "line": 400,
               "column": 3
             }
           },
@@ -42983,11 +47003,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 398,
+              "line": 402,
               "column": 2
             },
             "end": {
-              "line": 404,
+              "line": 408,
               "column": 3
             }
           },
@@ -43004,11 +47024,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 406,
+              "line": 410,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 412,
               "column": 3
             }
           },
@@ -43028,11 +47048,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 9,
+          "line": 13,
           "column": 0
         },
         "end": {
-          "line": 410,
+          "line": 414,
           "column": 1
         }
       },
@@ -43044,11 +47064,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 5
             }
           },
@@ -43060,11 +47080,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -43076,11 +47096,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 30,
+              "line": 34,
               "column": 4
             },
             "end": {
-              "line": 33,
+              "line": 37,
               "column": 5
             }
           },
@@ -43092,11 +47112,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 35,
+              "line": 39,
               "column": 4
             },
             "end": {
-              "line": 38,
+              "line": 42,
               "column": 5
             }
           },
@@ -43108,11 +47128,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -43140,11 +47160,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 5
             }
           },
@@ -43165,11 +47185,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -43187,12 +47207,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {
@@ -43209,12 +47229,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {
@@ -43232,11 +47252,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -43256,11 +47276,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 45,
+              "line": 49,
               "column": 4
             },
             "end": {
-              "line": 50,
+              "line": 54,
               "column": 5
             }
           },
@@ -43279,11 +47299,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 52,
+              "line": 56,
               "column": 4
             },
             "end": {
-              "line": 55,
+              "line": 59,
               "column": 5
             }
           },
@@ -43303,11 +47323,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 57,
+              "line": 61,
               "column": 4
             },
             "end": {
-              "line": 63,
+              "line": 67,
               "column": 5
             }
           },
@@ -43327,11 +47347,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 65,
+              "line": 69,
               "column": 4
             },
             "end": {
-              "line": 68,
+              "line": 72,
               "column": 5
             }
           },
@@ -43350,12 +47370,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 30,
-              "column": 4
+              "line": 48,
+              "column": 5
             },
             "end": {
-              "line": 33,
-              "column": 5
+              "line": 51,
+              "column": 6
             }
           },
           "metadata": {
@@ -43372,12 +47392,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 35,
-              "column": 4
+              "line": 53,
+              "column": 5
             },
             "end": {
-              "line": 38,
-              "column": 5
+              "line": 56,
+              "column": 6
             }
           },
           "metadata": {
@@ -43394,12 +47414,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 40,
-              "column": 4
+              "line": 58,
+              "column": 5
             },
             "end": {
-              "line": 43,
-              "column": 5
+              "line": 61,
+              "column": 6
             }
           },
           "metadata": {
@@ -43416,12 +47436,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 49,
-              "column": 4
+              "line": 67,
+              "column": 5
             },
             "end": {
-              "line": 52,
-              "column": 5
+              "line": 70,
+              "column": 6
             }
           },
           "metadata": {
@@ -43438,12 +47458,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {
@@ -43462,11 +47482,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 79,
+              "line": 83,
               "column": 2
             },
             "end": {
-              "line": 81,
+              "line": 85,
               "column": 3
             }
           },
@@ -43484,11 +47504,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 91,
+              "line": 95,
               "column": 2
             },
             "end": {
-              "line": 107,
+              "line": 111,
               "column": 3
             }
           },
@@ -43522,12 +47542,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 89,
-              "column": 2
+              "line": 121,
+              "column": 3
             },
             "end": {
-              "line": 91,
-              "column": 3
+              "line": 123,
+              "column": 4
             }
           },
           "metadata": {},
@@ -43539,12 +47559,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 100,
-              "column": 2
+              "line": 132,
+              "column": 3
             },
             "end": {
-              "line": 106,
-              "column": 3
+              "line": 138,
+              "column": 4
             }
           },
           "metadata": {},
@@ -43572,11 +47592,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 131,
+              "line": 135,
               "column": 2
             },
             "end": {
-              "line": 137,
+              "line": 141,
               "column": 3
             }
           },
@@ -43598,12 +47618,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 116,
-              "column": 2
+              "line": 148,
+              "column": 3
             },
             "end": {
-              "line": 125,
-              "column": 3
+              "line": 157,
+              "column": 4
             }
           },
           "metadata": {},
@@ -43637,12 +47657,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 127,
-              "column": 2
+              "line": 184,
+              "column": 3
             },
             "end": {
-              "line": 136,
-              "column": 3
+              "line": 193,
+              "column": 4
             }
           },
           "metadata": {},
@@ -43663,11 +47683,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 154,
+              "line": 158,
               "column": 2
             },
             "end": {
-              "line": 157,
+              "line": 161,
               "column": 3
             }
           },
@@ -43690,11 +47710,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 165,
+              "line": 169,
               "column": 2
             },
             "end": {
-              "line": 182,
+              "line": 186,
               "column": 3
             }
           },
@@ -43719,11 +47739,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 184,
+              "line": 188,
               "column": 2
             },
             "end": {
-              "line": 200,
+              "line": 204,
               "column": 3
             }
           },
@@ -43751,11 +47771,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 202,
+              "line": 206,
               "column": 2
             },
             "end": {
-              "line": 210,
+              "line": 214,
               "column": 3
             }
           },
@@ -43770,11 +47790,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 212,
+              "line": 216,
               "column": 2
             },
             "end": {
-              "line": 226,
+              "line": 230,
               "column": 3
             }
           },
@@ -43796,11 +47816,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 228,
+              "line": 232,
               "column": 2
             },
             "end": {
-              "line": 245,
+              "line": 249,
               "column": 3
             }
           },
@@ -43819,11 +47839,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 247,
+              "line": 251,
               "column": 2
             },
             "end": {
-              "line": 252,
+              "line": 256,
               "column": 3
             }
           },
@@ -43845,11 +47865,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 254,
+              "line": 258,
               "column": 2
             },
             "end": {
-              "line": 256,
+              "line": 260,
               "column": 3
             }
           },
@@ -43867,12 +47887,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 142,
-              "column": 2
+              "line": 199,
+              "column": 3
             },
             "end": {
-              "line": 148,
-              "column": 3
+              "line": 205,
+              "column": 4
             }
           },
           "metadata": {},
@@ -43889,11 +47909,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 266,
+              "line": 270,
               "column": 2
             },
             "end": {
-              "line": 271,
+              "line": 275,
               "column": 3
             }
           },
@@ -43908,11 +47928,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 279,
+              "line": 283,
               "column": 2
             },
             "end": {
-              "line": 289,
+              "line": 293,
               "column": 3
             }
           },
@@ -43936,11 +47956,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 295,
+              "line": 299,
               "column": 2
             },
             "end": {
-              "line": 321,
+              "line": 325,
               "column": 3
             }
           },
@@ -43958,11 +47978,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 323,
+              "line": 327,
               "column": 2
             },
             "end": {
-              "line": 336,
+              "line": 340,
               "column": 3
             }
           },
@@ -43980,11 +48000,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 338,
+              "line": 342,
               "column": 2
             },
             "end": {
-              "line": 358,
+              "line": 362,
               "column": 3
             }
           },
@@ -44006,11 +48026,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 360,
+              "line": 364,
               "column": 2
             },
             "end": {
-              "line": 367,
+              "line": 371,
               "column": 3
             }
           },
@@ -44025,11 +48045,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 369,
+              "line": 373,
               "column": 2
             },
             "end": {
-              "line": 380,
+              "line": 384,
               "column": 3
             }
           },
@@ -44049,11 +48069,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 382,
+              "line": 386,
               "column": 2
             },
             "end": {
-              "line": 396,
+              "line": 400,
               "column": 3
             }
           },
@@ -44072,11 +48092,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 398,
+              "line": 402,
               "column": 2
             },
             "end": {
-              "line": 404,
+              "line": 408,
               "column": 3
             }
           },
@@ -44095,11 +48115,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 406,
+              "line": 410,
               "column": 2
             },
             "end": {
-              "line": 408,
+              "line": 412,
               "column": 3
             }
           },
@@ -44120,12 +48140,12 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 68,
-              "column": 2
+              "line": 86,
+              "column": 3
             },
             "end": {
-              "line": 87,
-              "column": 3
+              "line": 119,
+              "column": 4
             }
           },
           "metadata": {},
@@ -44152,17 +48172,71 @@
           }
         },
         {
+          "name": "getAbsoluteISOString",
+          "description": "Computes the local timezone and adds it to a local ISO string",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 164,
+              "column": 3
+            },
+            "end": {
+              "line": 172,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string, without timezone info"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "an ISO date string, with timezone info"
+          }
+        },
+        {
+          "name": "_getTimezoneString",
+          "description": "Calculates the local timezone offset and formats it to ISO Timezone string.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 179,
+              "column": 3
+            },
+            "end": {
+              "line": 182,
+              "column": 4
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "localISOString",
+              "type": "String",
+              "description": "an ISO date string"
+            }
+          ],
+          "return": {
+            "type": "String",
+            "desc": "the ISO timezone"
+          }
+        },
+        {
           "name": "_computeFormatter",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 138,
-              "column": 2
+              "line": 195,
+              "column": 3
             },
             "end": {
-              "line": 140,
-              "column": 3
+              "line": 197,
+              "column": 4
             }
           },
           "metadata": {},
@@ -44178,12 +48252,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 150,
-              "column": 2
+              "line": 207,
+              "column": 3
             },
             "end": {
-              "line": 161,
-              "column": 3
+              "line": 218,
+              "column": 4
             }
           },
           "metadata": {},
@@ -44202,12 +48276,12 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 163,
-              "column": 2
+              "line": 220,
+              "column": 3
             },
             "end": {
-              "line": 175,
-              "column": 3
+              "line": 222,
+              "column": 4
             }
           },
           "metadata": {},
@@ -44223,12 +48297,12 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 12,
-          "column": 0
+          "line": 30,
+          "column": 1
         },
         "end": {
-          "line": 177,
-          "column": 1
+          "line": 224,
+          "column": 2
         }
       },
       "privacy": "public",
@@ -44240,11 +48314,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 17,
+              "line": 21,
               "column": 4
             },
             "end": {
-              "line": 21,
+              "line": 25,
               "column": 5
             }
           },
@@ -44258,11 +48332,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 23,
+              "line": 27,
               "column": 4
             },
             "end": {
-              "line": 28,
+              "line": 32,
               "column": 5
             }
           },
@@ -44275,12 +48349,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 25,
-              "column": 4
+              "line": 43,
+              "column": 5
             },
             "end": {
-              "line": 28,
-              "column": 5
+              "line": 46,
+              "column": 6
             }
           },
           "metadata": {},
@@ -44291,12 +48365,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 20,
-              "column": 4
+              "line": 38,
+              "column": 5
             },
             "end": {
-              "line": 23,
-              "column": 5
+              "line": 41,
+              "column": 6
             }
           },
           "metadata": {},
@@ -44308,11 +48382,11 @@
           "sourceRange": {
             "file": "cosmoz-omnitable-column-range-mixin.html",
             "start": {
-              "line": 40,
+              "line": 44,
               "column": 4
             },
             "end": {
-              "line": 43,
+              "line": 47,
               "column": 5
             }
           },
@@ -44325,12 +48399,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 35,
-              "column": 4
+              "line": 53,
+              "column": 5
             },
             "end": {
-              "line": 38,
-              "column": 5
+              "line": 56,
+              "column": 6
             }
           },
           "metadata": {},
@@ -44341,12 +48415,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 40,
-              "column": 4
+              "line": 58,
+              "column": 5
             },
             "end": {
-              "line": 43,
-              "column": 5
+              "line": 61,
+              "column": 6
             }
           },
           "metadata": {},
@@ -44357,12 +48431,12 @@
           "description": "No need to grow, as the values in a date column should have known fixed width",
           "sourceRange": {
             "start": {
-              "line": 49,
-              "column": 4
+              "line": 67,
+              "column": 5
             },
             "end": {
-              "line": 52,
-              "column": 5
+              "line": 70,
+              "column": 6
             }
           },
           "metadata": {},
@@ -44373,12 +48447,12 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 53,
-              "column": 4
+              "line": 71,
+              "column": 5
             },
             "end": {
-              "line": 56,
-              "column": 5
+              "line": 74,
+              "column": 6
             }
           },
           "metadata": {},
@@ -44407,11 +48481,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 10,
+              "line": 13,
               "column": 4
             },
             "end": {
-              "line": 13,
+              "line": 16,
               "column": 5
             }
           },
@@ -44429,11 +48503,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 15,
+              "line": 18,
               "column": 4
             },
             "end": {
-              "line": 18,
+              "line": 21,
               "column": 5
             }
           },
@@ -44452,11 +48526,36 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 22,
+              "line": 25,
               "column": 2
             },
             "end": {
-              "line": 33,
+              "line": 37,
+              "column": 3
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "item"
+            },
+            {
+              "name": "valuePath",
+              "defaultValue": "this.valuePath"
+            }
+          ]
+        },
+        {
+          "name": "toXlsxValue",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 39,
+              "column": 2
+            },
+            "end": {
+              "line": 41,
               "column": 3
             }
           },
@@ -44477,11 +48576,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 7,
+          "line": 10,
           "column": 1
         },
         "end": {
-          "line": 34,
+          "line": 43,
           "column": 3
         }
       },
@@ -44493,11 +48592,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 10,
+              "line": 13,
               "column": 4
             },
             "end": {
-              "line": 13,
+              "line": 16,
               "column": 5
             }
           },
@@ -44509,11 +48608,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 15,
+              "line": 18,
               "column": 4
             },
             "end": {
-              "line": 18,
+              "line": 21,
               "column": 5
             }
           },

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
 		"cosmoz-bottom-bar": "neovici/cosmoz-bottom-bar#^2.2.1",
 		"cosmoz-behaviors": "neovici/cosmoz-behaviors#^2.0.0",
 		"cosmoz-page-router": "Neovici/cosmoz-page-router#^2.1.1",
-		"paper-autocomplete-chips": "Neovici/paper-autocomplete-chips#^2.0.1",
+		"paper-autocomplete-chips": "Neovici/paper-autocomplete-chips#^2.0.4",
 		"import-filesaver": "JaySunSyn/import-filesaver",
 		"cosmoz-datetime-input": "Neovici/cosmoz-datetime-input#^2.0.0",
 		"nullxlsx": "Neovici/nullxlsx#^1.0.3",

--- a/cosmoz-omnitable-column-list-data.html
+++ b/cosmoz-omnitable-column-list-data.html
@@ -69,21 +69,8 @@
 					_othersCount: {
 						type: Number,
 						computed: '_computeOthersCount(items)'
-					},
-
-					// FIXME: remove when TranslatableBehavior is a 2.x mixin
-					t: {
-						type: Object,
-						value() {
-							return {};
-						}
 					}
 				};
-			}
-
-			_() {
-				// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-				return Cosmoz.TranslatableBehavior._.apply(this, arguments);
 			}
 
 			isEmpty() {

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -197,14 +197,6 @@
 					value: 0
 				},
 
-				// FIXME: remove when TranslatableBehavior is a 2.x mixin
-				t: {
-					type: Object,
-					value() {
-						return {};
-					}
-				},
-
 				_groupsCount: {
 					type: Number,
 					value: 0
@@ -286,12 +278,6 @@
 			this._filterItems = this._filterItems.bind(this);
 			this._groupItems = this._groupItems.bind(this);
 			this._sortFilteredGroupedItems = this._sortFilteredGroupedItems.bind(this);
-		}
-
-
-		_() {
-			// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-			return Cosmoz.TranslatableBehavior._.apply(this, arguments);
 		}
 
 		connectedCallback() {
@@ -391,11 +377,6 @@
 
 		_computeShowCheckboxes(dataIsValid, hasActions) {
 			return dataIsValid && hasActions;
-		}
-
-		ngettext() {
-			// FIXME: remove this when TranslatableBehavior is a 2.x mixin
-			return Cosmoz.TranslatableBehavior.ngettext.apply(this, arguments);
 		}
 
 		visibleChanged(turnedVisible) {

--- a/demo/helpers/x-page.html
+++ b/demo/helpers/x-page.html
@@ -154,7 +154,7 @@
 				data[1].value = undefined;
 				data[2].amount = null;
 				data[3].value = null;
-				this.async(() => {
+				window.setTimeout(() => {
 					this.data = data;
 				}, 100);
 			}


### PR DESCRIPTION
Components, Demo, converting to class-style.

This also:
- Fixes a behavior is null warning in the console. 
- Adds some testing errors that are hard to avoid in the current code state.

Testing, `yarn install; yarn start`, add `demo/` to the address.

Issue is https://github.com/Neovici/cosmoz-frontend/issues/815.