### PR TITLE
Column list, adding no item bullets property

### DIFF
--- a/cosmoz-omnitable-column-list-data.js
+++ b/cosmoz-omnitable-column-list-data.js
@@ -34,9 +34,13 @@ class OmnitableColumnListData extends translatable(mixin(Template, PolymerElemen
 				margin: 0.3em 0;
 				padding-left: 1em;
 			}
+
+			ul.noItemBullets {
+				list-style-type: none;
+			}
 		</style>
 
-		<ul hidden$="[[ isEmpty(items) ]]">
+		<ul class$="[[ ifElse(noItemBullets, 'noItemBullets', '') ]]" hidden$="[[ isEmpty(items) ]]">
 			<li>
 				<span>[[ _firstItem(items) ]]</span>
 			</li>
@@ -66,6 +70,11 @@ class OmnitableColumnListData extends translatable(mixin(Template, PolymerElemen
 			},
 
 			_expanded: {
+				type: Boolean,
+				value: false
+			},
+
+			noItemBullets: {
 				type: Boolean,
 				value: false
 			},

--- a/cosmoz-omnitable-column-list.js
+++ b/cosmoz-omnitable-column-list.js
@@ -23,7 +23,8 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 	static get template() {
 		return html`
 		<template class="cell" strip-whitespace>
-			<cosmoz-omnitable-column-list-data items="[[ getTexts(valuePath, item, textProperty) ]]">
+			<cosmoz-omnitable-column-list-data items="[[ getTexts(valuePath, item, textProperty) ]]"
+				no-item-bullets="[[ noItemBullets ]]">
 			</cosmoz-omnitable-column-list-data>
 		</template>
 
@@ -66,6 +67,11 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 				value() {
 					return this._getDefaultFilter();
 				}
+			},
+
+			noItemBullets: {
+				type: Boolean,
+				value: false
 			},
 
 			textProperty: {


### PR DESCRIPTION
Column list, adding no item bullets property.

Testing, on a `cosmoz-omnitable-column-list` add the `no-item-bullets` attribute and check that the column list do not show bullets to the left of each item.

Redmine issue is #21885.