### PR TITLE
Column list, adding omnitable search

### DIFF
--- a/cosmoz-omnitable-column-autocomplete.js
+++ b/cosmoz-omnitable-column-autocomplete.js
@@ -151,26 +151,6 @@ class OmnitableColumnAutocomplete extends columnMixin(PolymerElement) {
 			.indexOf(value) !== -1;
 	}
 
-	_unique(values, valueProperty) {
-		if (!Array.isArray(values)) {
-			return;
-		}
-		const used = [];
-		return values.filter((item, index, array) => {
-			if (array.indexOf(item) !== index) {
-				return false;
-			}
-			if (valueProperty) {
-				const value = this.get(valueProperty, item);
-				if (used.indexOf(value) !== -1) {
-					return false;
-				}
-				used.push(value);
-			}
-			return true;
-		});
-	}
-
 	_getDefaultFilter() {
 		return [];
 	}

--- a/cosmoz-omnitable-column-list.js
+++ b/cosmoz-omnitable-column-list.js
@@ -142,25 +142,5 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 	_getDefaultFilter() {
 		return [];
 	}
-
-	_unique(values, valueProperty) {
-		if (!Array.isArray(values)) {
-			return;
-		}
-		const used = [];
-		return values.filter((item, index, array) => {
-			if (array.indexOf(item) !== index) {
-				return false;
-			}
-			if (valueProperty) {
-				const value = this.get(valueProperty, item);
-				if (used.indexOf(value) !== -1) {
-					return false;
-				}
-				used.push(value);
-			}
-			return true;
-		});
-	}
 }
 customElements.define(OmnitableColumnList.is, OmnitableColumnList);

--- a/cosmoz-omnitable-column-list.js
+++ b/cosmoz-omnitable-column-list.js
@@ -145,17 +145,17 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 
 	_unique(values, valueProperty) {
 		if (!Array.isArray(values)) {
-				return;
+			return;
 		}
 		const used = [];
 		return values.filter((item, index, array) => {
 			if (array.indexOf(item) !== index) {
-					return false;
+				return false;
 			}
 			if (valueProperty) {
 				const value = this.get(valueProperty, item);
 				if (used.indexOf(value) !== -1) {
-						return false;
+					return false;
 				}
 				used.push(value);
 			}

--- a/cosmoz-omnitable-column-list.js
+++ b/cosmoz-omnitable-column-list.js
@@ -32,8 +32,12 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 		</template>
 
 		<template class="header" strip-whitespace>
-			<paper-autocomplete-chips source="[[ autocompleteItems ]]" label="[[ title ]]"
-				selected-items="{{ filter }}" text-property="[[ textProperty ]]" value-property="[[ valueProperty ]]" show-results-on-focus>
+			<paper-autocomplete-chips text="{{ query }}"
+				source="[[ _unique(values, valueProperty) ]]" label="[[ title ]]"
+				selected-items="{{ filter }}" text-property="[[ textProperty ]]"
+				value-property="[[ valueProperty ]]" focused="{{ headerFocused }}"
+				show-results-on-focus>
+				<paper-spinner-lite style="width: 20px; height: 20px;" suffix slot="suffix" active="[[ loading ]]" hidden="[[ !loading ]]"></paper-spinner-lite>
 			</paper-autocomplete-chips>
 		</template>
 `;
@@ -66,6 +70,11 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 				value() {
 					return this._getDefaultFilter();
 				}
+			},
+
+			query: {
+				type: String,
+				notify: true
 			},
 
 			textProperty: {
@@ -132,6 +141,26 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 
 	_getDefaultFilter() {
 		return [];
+	}
+
+	_unique(values, valueProperty) {
+		if (!Array.isArray(values)) {
+				return;
+		}
+		const used = [];
+		return values.filter((item, index, array) => {
+			if (array.indexOf(item) !== index) {
+					return false;
+			}
+			if (valueProperty) {
+				const value = this.get(valueProperty, item);
+				if (used.indexOf(value) !== -1) {
+						return false;
+				}
+				used.push(value);
+			}
+			return true;
+		});
 	}
 }
 customElements.define(OmnitableColumnList.is, OmnitableColumnList);

--- a/cosmoz-omnitable-column-mixin.js
+++ b/cosmoz-omnitable-column-mixin.js
@@ -262,7 +262,25 @@ export const columnMixin = dedupingMixin(base => class extends templatizeMixin(b
 		}
 		return this.get(valuePath, item);
 	}
-
+	_unique(values, valueProperty) {
+		if (!Array.isArray(values)) {
+			return;
+		}
+		const used = [];
+		return values.filter((item, index, array) => {
+			if (array.indexOf(item) !== index) {
+				return false;
+			}
+			if (valueProperty) {
+				const value = this.get(valueProperty, item);
+				if (used.indexOf(value) !== -1) {
+					return false;
+				}
+				used.push(value);
+			}
+			return true;
+		});
+	}
 	_pathsChanged(valuePath, groupOn, sortOn) {
 		if (valuePath == null) {
 			return;


### PR DESCRIPTION
Column list, adding omnitable search.

Testing, use together with the `rm21885-1` branch on frontend and in the Articles, Article aliases view check the Invoice article numbers column.

Tests may have to be added, but putting it here in case someone wants it now.

Issue is Redmine #21885.