### PR TITLE
Dispatch column-item-changed event when editable date is removed

### DIFF
--- a/cosmoz-omnitable-column-date-mixin.js
+++ b/cosmoz-omnitable-column-date-mixin.js
@@ -195,9 +195,6 @@ export const dateColumnMixin = dedupingMixin(base => // eslint-disable-line max-
 				item = event.model.item,
 				oldValue = this.get(this.valuePath, item),
 				date = this._fromInputString(value);
-			if (date == null) {
-				return;
-			}
 			this.set(this.valuePath, date, item);
 			this._fireItemChangeEvent(item, this.valuePath, oldValue, this.renderValue.bind(this));
 		}


### PR DESCRIPTION
Allow column-item-changed event to dispatch when the date on editable date row is null (aka removed)
Needed for a period admin view that is not a PR yet.