### PR TITLE
Column list, removing item bullets padding

### DIFF
--- a/cosmoz-omnitable-column-list-data.js
+++ b/cosmoz-omnitable-column-list-data.js
@@ -33,7 +33,7 @@ class OmnitableColumnListData extends translatable(mixin(Template, PolymerElemen
 			ul {
 				list-style-type: none;
 				margin: 0.3em 0;
-				padding-left: 1em;
+				padding-left: 0;
 			}
 		</style>
 


### PR DESCRIPTION
Column list, removing item bullets padding.

Note: This only works with columns *without* a `cz-link-list` since that component has it's own lists. But this is also the expected usage according to the issue #21885 where no links will be displayed.

Testing, on a `cosmoz-omnitable-column-list` check that the column list does not show padding to the left of each item.

Testing in frontend, go to Administration, List available roles and check that the function lists in the Functions column does not have padding on the left of each item.

Redmine issue is #21885.