### PR TITLE
fix: filters are lost after refresh

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -732,9 +732,8 @@ class Omnitable extends translatable(
 		}
 
 		this.columns = columns;
-		this.visibleColumns = columns.slice();
-
 		this._updateParamsFromHash();
+		this.visibleColumns = columns.slice();
 
 		if (Array.isArray(this.data)) {
 			this._debounceFilterItems();


### PR DESCRIPTION
After much debugging, I finally figured it out. It seems that when the omnitable is constructed, it first reads the column configuration, then it computes the visible columns and only after that it reads the hash params. The problem is that setting `visibleColumns` triggers the instantiation of the columns' header templates, which in turn causes a `cosmoz-column-filter-changed` event to be dispatched. This causes the omnitable to serialize the current filters and update the hash. The filter serialization checks if the current filters match the hash filters and synchronizes the data. It just so happens that at this moment in time, the omnitable initialization process has not finished and the hash params were not yet read. This mismatch between the hash and the current filters (which are all null or []), causes the URL to be updated, thus dropping the filter hash params.

If we read the hash params immediately after determining the columns configuration, but before triggering the column instantiation, then the filter serialization algorithm will discover the correct filters already set in place, thus preserving the hash intact.

Fixes #23129

This change is safe and will make omnitable behave more sanely.