### PR TITLE
fix: enable styling of local/remote column header suggestions

### DIFF
--- a/cosmoz-omnitable-column-amount.js
+++ b/cosmoz-omnitable-column-amount.js
@@ -46,6 +46,7 @@ class OmnitableColumnAmount extends rangeColumnMixin(columnMixin(translatable(
 			</style>
 			<cosmoz-clear-button on-click="resetFilter" visible="[[ hasFilter(filter.*) ]]"></cosmoz-clear-button>
 			<paper-dropdown-menu label="[[ title ]]" placeholder="[[ _filterText ]]"
+				class$="external-values-[[ externalValues ]]"
 				title="[[ _tooltip ]]" horizontal-align="[[ preferredDropdownHorizontalAlign ]]" opened="{{ headerFocused }}"
 				on-opened-changed="_onDropdownOpenedChanged">
 				<div class="dropdown-content" slot="dropdown-content" style="padding: 15px; min-width: 150px;">

--- a/cosmoz-omnitable-column-autocomplete.js
+++ b/cosmoz-omnitable-column-autocomplete.js
@@ -36,6 +36,7 @@ class OmnitableColumnAutocomplete extends columnMixin(PolymerElement) {
 			</style>
 
 			<paper-autocomplete-chips text="{{ query }}"
+				class$="external-values-[[ externalValues ]]"
 				source="[[ _unique(values, valueProperty) ]]" label="[[ title ]]"
 				selected-items="{{ filter }}" text-property="[[ textProperty ]]"
 				value-property="[[ valueProperty ]]" focused="{{ headerFocused }}"

--- a/cosmoz-omnitable-column-date.js
+++ b/cosmoz-omnitable-column-date.js
@@ -35,6 +35,7 @@ class OmnitableColumnDate extends dateColumnMixin(columnMixin(translatable(
 		<template class="header" strip-whitespace>
 			<cosmoz-clear-button on-click="resetFilter" visible="[[ hasFilter(filter.*) ]]"></cosmoz-clear-button>
 			<paper-dropdown-menu label="[[ title ]]" placeholder="[[ _filterText ]]"
+				class$="external-values-[[ externalValues ]]"
 				title="[[ _tooltip ]]" horizontal-align="[[ preferredDropdownHorizontalAlign ]]" opened="{{ headerFocused }}">
 				<div class="dropdown-content" slot="dropdown-content" style="padding: 15px; min-width: 100px;">
 					<h3 style="margin: 0;">[[ title ]]</h3>

--- a/cosmoz-omnitable-column-datetime.js
+++ b/cosmoz-omnitable-column-datetime.js
@@ -37,6 +37,7 @@ class OmnitableColumnDatetime extends
 		<template class="header" strip-whitespace>
 			<cosmoz-clear-button on-click="resetFilter" visible="[[ hasFilter(filter.*) ]]"></cosmoz-clear-button>
 			<paper-dropdown-menu label="[[ title ]]" placeholder="[[ _filterText ]]"
+				class$="external-values-[[ externalValues ]]"
 				title="[[ _tooltip ]]" horizontal-align="[[ preferredDropdownHorizontalAlign ]]" opened="{{ headerFocused }}">
 				<div class="dropdown-content" slot="dropdown-content" style="padding: 15px; min-width: 100px;">
 					<h3 style="margin: 0;">[[ title ]]</h3>

--- a/cosmoz-omnitable-column-list-horizontal.js
+++ b/cosmoz-omnitable-column-list-horizontal.js
@@ -53,6 +53,7 @@ class OmnitableColumnListHorizontal extends listColumnMixin(
 
 		<template class="header" strip-whitespace>
 			<paper-autocomplete-chips source="[[ _computeAutocompleteItems(values) ]]"
+				class$="external-values-[[ externalValues ]]"
 				label="[[ title ]]" selected-items="{{ filter }}" text-property="[[ textProperty ]]" value-property="[[ valueProperty ]]" show-results-on-focus>
 			</paper-autocomplete-chips>
 		</template>

--- a/cosmoz-omnitable-column-list.js
+++ b/cosmoz-omnitable-column-list.js
@@ -33,6 +33,7 @@ class OmnitableColumnList extends	listColumnMixin(columnMixin(translatable(
 
 		<template class="header" strip-whitespace>
 			<paper-autocomplete-chips text="{{ query }}"
+				class$="external-values-[[ externalValues ]]"
 				source="[[ _unique(values, valueProperty) ]]" label="[[ title ]]"
 				selected-items="{{ filter }}" text-property="[[ textProperty ]]"
 				value-property="[[ valueProperty ]]" focused="{{ headerFocused }}"

--- a/cosmoz-omnitable-column-number.js
+++ b/cosmoz-omnitable-column-number.js
@@ -48,6 +48,7 @@ class OmnitableColumnNumber extends rangeColumnMixin(
 			</style>
 			<cosmoz-clear-button on-click="resetFilter" visible="[[ hasFilter(filter.*) ]]"></cosmoz-clear-button>
 			<paper-dropdown-menu label="[[ title ]]" placeholder="[[ _filterText ]]"
+				class$="external-values-[[ externalValues ]]"
 				title="[[ _tooltip ]]" horizontal-align="[[ preferredDropdownHorizontalAlign ]]" opened="{{ headerFocused }}"
 				on-opened-changed="_onDropdownOpenedChanged">
 				<div class="dropdown-content" slot="dropdown-content" style="padding: 15px; min-width: 100px;">

--- a/cosmoz-omnitable-column-time.js
+++ b/cosmoz-omnitable-column-time.js
@@ -38,6 +38,7 @@ class OmnitableColumnTime extends
 		<template class="header" strip-whitespace>
 			<cosmoz-clear-button on-click="resetFilter" visible="[[ hasFilter(filter.*) ]]"></cosmoz-clear-button>
 			<paper-dropdown-menu label="[[ title ]]" placeholder="[[ _filterText ]]"
+				class$="external-values-[[ externalValues ]]"
 				title="[[ _tooltip ]]" horizontal-align="[[ preferredDropdownHorizontalAlign ]]" opened="{{ headerFocused }}">
 				<div class="dropdown-content" slot="dropdown-content" style="padding: 15px; min-width: 100px;">
 					<h3 style="margin: 0;">[[ title ]]</h3>

--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -38,6 +38,14 @@ container.innerHTML = `<dom-module id="cosmoz-omnitable-styles">
 				display: none;
 			}
 
+			cosmoz-omnitable-header-row .external-values-false {
+				--paper-input-container-color: var(--cosmoz-omnitable-local-filter-header-color);
+			}
+
+			cosmoz-omnitable-header-row .external-values-true {
+				--paper-input-container-color: var(--cosmoz-omnitable-remote-filter-header-color);
+			}
+
 			.header > cosmoz-omnitable-header-row {
 				@apply --layout-flex;
 			}


### PR DESCRIPTION
To indicate whether the suggestions come from the loaded list
or elsewhere.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>