### PR TITLE
fix: correct comparable values for object autocomplete column

### DIFF
--- a/cosmoz-omnitable-column-list-mixin.js
+++ b/cosmoz-omnitable-column-list-mixin.js
@@ -80,7 +80,7 @@ export const listColumnMixin = dedupingMixin(base =>	class extends base {
 		if (this.valueProperty == null) {
 			return value;
 		}
-		const subValues = value.reduce((acc, subItem) => {
+		const subValues = array(value).reduce((acc, subItem) => {
 			acc.push(this.get(this.valueProperty, subItem));
 			return acc;
 		}, []);


### PR DESCRIPTION
`getComparableValue` should handle an object.