### PR TITLE
fix: autocomplete string comparable value

### DIFF
--- a/cosmoz-omnitable-column-autocomplete.js
+++ b/cosmoz-omnitable-column-autocomplete.js
@@ -70,6 +70,8 @@ class OmnitableColumnAutocomplete extends listColumnMixin(columnMixin(PolymerEle
 			}
 		};
 	}
-
+	getComparableValue(item, valuePath = this.valuePath) {
+		return this.getString(item, valuePath);
+	}
 }
 customElements.define(OmnitableColumnAutocomplete.is, OmnitableColumnAutocomplete);


### PR DESCRIPTION
Restores older autocomplete behavior where the text or tests in the columns are used for sorting and grouping (comparable value).