### PR TITLE
fix(column-list-data): add ellipses to overflow

### DIFF
--- a/cosmoz-omnitable-column-list-data.js
+++ b/cosmoz-omnitable-column-list-data.js
@@ -37,6 +37,11 @@ class OmnitableColumnListData extends translatable(mixin(Template, PolymerElemen
 				margin: 0.3em 0;
 				padding-left: 0;
 			}
+
+			li {
+				text-overflow: ellipsis;
+				overflow: hidden;
+			}
 		</style>
 
 		<ul hidden$="[[ isEmpty(items) ]]">


### PR DESCRIPTION
Ellipses did not show up with list data columns.

From issue: https://github.com/Neovici/cosmoz-omnitable/issues/378