### PR TITLE
fix: hide dropdown menu icons #22545

### DIFF
--- a/cosmoz-omnitable-column-number.js
+++ b/cosmoz-omnitable-column-number.js
@@ -45,6 +45,10 @@ class OmnitableColumnNumber extends rangeColumnMixin(
 			paper-input.has-value > iron-icon {
 				display: block;
 			}
+
+			paper-dropdown-menu {
+				--iron-icon-width: 0;
+			}
 			</style>
 			<cosmoz-clear-button on-click="resetFilter" visible="[[ hasFilter(filter.*) ]]"></cosmoz-clear-button>
 			<paper-dropdown-menu label="[[ title ]]" placeholder="[[ _filterText ]]"


### PR DESCRIPTION
Check that header dropdown menus does not show an arrow down icon right of the texts.

Redmine 22545.
