### PR TITLE
feat: autocomplete: allow key/value object suggestions source

### DIFF
--- a/cosmoz-omnitable-column-list-mixin.js
+++ b/cosmoz-omnitable-column-list-mixin.js
@@ -8,7 +8,8 @@ import {
  * @polymer
  * @mixinFunction
  */
-export const listColumnMixin = dedupingMixin(base =>	class extends base {
+// eslint-disable-next-line max-lines-per-function
+export const listColumnMixin = dedupingMixin(base => class extends base {
 	static get properties() {
 		return {
 			/**
@@ -91,7 +92,32 @@ export const listColumnMixin = dedupingMixin(base =>	class extends base {
 		return [];
 	}
 
-	_computeSource(values, valueProperty) {
+	_computeSource(values, valueProperty = this.valueProperty, textProperty = this.textProperty) {
+		if (!Array.isArray(values) && typeof values === 'object') {
+			const valProp = valueProperty ?? 'id',
+				textProp = textProperty ?? 'label';
+			if (valueProperty == null) {
+				this.valueProperty = valProp;
+			}
+			if (textProperty == null) {
+				this.textProperty = textProp;
+			}
+			return Object
+				.entries(values)
+				.map(([id, label]) => ({
+					[valProp]: id,
+					[textProp]: label
+				}))
+				.sort((a, b) => {
+					if (a[textProp] < b[textProp]) {
+						return -1;
+					}
+					if (a[textProp] > b[textProp]) {
+						return 1;
+					}
+					return 0;
+				});
+		}
 		return this._unique(values, valueProperty) || [];
 	}
 
@@ -102,11 +128,7 @@ export const listColumnMixin = dedupingMixin(base =>	class extends base {
 		);
 	}
 
-	_computeValue(
-		filters,
-		source = [],
-		valueProperty = this.valueProperty
-	) {
+	_computeValue(filters, source = [], valueProperty = this.valueProperty) {
 		if ((filters?.length || 0) < 1) {
 			return;
 		}

--- a/test/autocomplete.test.js
+++ b/test/autocomplete.test.js
@@ -42,26 +42,6 @@ const data = [{
 	</cosmoz-omnitable>
 `;
 
-suite('fit-dropdowns', () => {
-	let omnitable;
-
-	setup(async () => {
-		omnitable = await setupOmnitableFixture(basicFixture, data.slice(0));
-	});
-
-	test('sets iron-dropdown fitInto property', () => {
-		[
-			omnitable.$.groupOnSelector,
-			omnitable.$.sortOnSelector
-		]
-			.map(d => d.$.menuButton)
-			.concat([omnitable.$.bottomBar.$.menu])
-			.forEach(button => {
-				assert.equal(button.$.dropdown.fitInto, omnitable);
-			});
-	});
-});
-
 suite('autocomplete unit tests', () => {
 	let omnitable,
 		column;
@@ -272,5 +252,54 @@ suite('autocomplete unit tests', () => {
 			group: 'group1',
 			name: ' Item 3'
 		}]);
+	});
+	test('values based on data', () => {
+		assert.deepEqual(column.values, [0, 1, 2, 3]);
+		assert.deepEqual(column.values, column._source);
+	});
+	test('overridden values', () => {
+		column.externalValues = true;
+		column.values = [1, 2, 3, 4];
+		assert.deepEqual(column.values, column._source);
+		column.externalValues = false;
+	});
+	test('overridden key/value values', () => {
+		column.externalValues = true;
+		column.values = {
+			id2: 2,
+			id1: 1,
+			id3: 2
+		};
+		assert.deepEqual(column._source, [{
+			id: 'id1',
+			label: 1
+		}, {
+			id: 'id2',
+			label: 2
+		}, {
+			id: 'id3',
+			label: 2
+		}]);
+		column.externalValues = false;
+	});
+});
+
+suite('fit-dropdowns', () => {
+	let omnitable;
+
+	setup(async () => {
+		omnitable = await setupOmnitableFixture(basicFixture, data.slice(0));
+	});
+
+	test('sets iron-dropdown fitInto property', () => {
+		[
+			omnitable.$.groupOnSelector,
+			omnitable.$.sortOnSelector
+		]
+			.map(d => d.$.menuButton)
+			.concat([omnitable.$.bottomBar.$.menu])
+			.forEach(button => {
+				assert.equal(button.$.dropdown.fitInto, omnitable);
+			});
 	});
 });


### PR DESCRIPTION
To fix the issue with key names (key/value, id/label, value/text)
in object items, and optimize network payload size, suggestions
could be supplied as a key/value object.

It also automatically handles uniqueness.

We have some scenarios today where this happens and should move
more towards it. This enables support "natively" in omnitable
and allows us to drop enrichers/mappers.

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>