### PR TITLE
fix: autocomplete, only render spinner when loading #24260

### DIFF
--- a/cosmoz-omnitable-column-autocomplete.js
+++ b/cosmoz-omnitable-column-autocomplete.js
@@ -37,13 +37,14 @@ class OmnitableColumnAutocomplete extends listColumnMixin(columnMixin(PolymerEle
 				on-focus="[[ _onFocus ]]"
 				on-text="[[ _onText ]]"
 			>
-				<paper-spinner-lite
-					style="width: 20px; height: 20px;"
-					suffix
-					slot="suffix"
-					active="[[ loading ]]"
-					hidden="[[ !loading ]]"
-				></paper-spinner-lite>
+				<template is="dom-if" if="[[ loading ]]">
+					<paper-spinner-lite
+						style="width: 20px; height: 20px;"
+						suffix
+						slot="suffix"
+						active="[[ loading ]]"
+					></paper-spinner-lite>
+				</template>
 			</cosmoz-autocomplete-ui>
 		</template>
 `;


### PR DESCRIPTION
Check that the `cosmoz-omnitable-column-autocomplete` only shows the loading spinner animation when loading, otherwise the area should not be occupied.

RM:24260.
