### PR TITLE
fix: list, only render spinner when loading #24260

### DIFF
--- a/cosmoz-omnitable-column-list.js
+++ b/cosmoz-omnitable-column-list.js
@@ -49,13 +49,14 @@ class OmnitableColumnList extends listColumnMixin(
 					on-focus="[[ _onFocus ]]"
 					on-text="[[ _onText ]]"
 				>
-					<paper-spinner-lite
-						style="width: 20px; height: 20px;"
-						suffix
-						slot="suffix"
-						active="[[ loading ]]"
-						hidden="[[ !loading ]]"
-					></paper-spinner-lite>
+					<template is="dom-if" if="[[ loading ]]">
+						<paper-spinner-lite
+							style="width: 20px; height: 20px;"
+							suffix
+							slot="suffix"
+							active="[[ loading ]]"
+						></paper-spinner-lite>
+					</template>
 				</cosmoz-autocomplete-ui>
 			</template>
 		`;


### PR DESCRIPTION
Check that the `cosmoz-omnitable-column-list` only shows the loading spinner animation when loading, otherwise the area should not be occupied.

For example the Assigned to... column in Open invoices in frontend.

RM:24260.
