### PR TITLE
fix: replace iron-resizable-behavior with a ResizeObserver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,20 +1188,41 @@
 			}
 		},
 		"@neovici/cosmoz-bottom-bar": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-3.0.10.tgz",
-			"integrity": "sha512-TIIXdNcxXrc73TvhUPGPl6omF12ri4ur6+3OISrE5yDHsLGO3VeUg2PFO0f52W1gvjyb90SYHVVQR+mJKUpvrA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-3.1.4.tgz",
+			"integrity": "sha512-vCQ+9UyaBlcsDkkBIaf8tYoentgK7+BXOTzdph3t1aC8nN2te840hgnD5f3CXek96gM/kLrTKl0RKndWRZQj2w==",
 			"requires": {
-				"@neovici/cosmoz-viewinfo": "^3.0.2",
-				"@polymer/iron-flex-layout": "^3.0.0",
-				"@polymer/iron-icons": "^3.0.0",
-				"@polymer/iron-resizable-behavior": "^3.0.0",
+				"@neovici/cosmoz-utils": "^3.12.0",
+				"@neovici/cosmoz-viewinfo": "^3.1.1",
+				"@polymer/iron-icons": "^3.0.1",
 				"@polymer/iron-selector": "^3.0.0",
 				"@polymer/paper-icon-button": "^3.0.0",
 				"@polymer/paper-listbox": "^3.0.0",
 				"@polymer/paper-menu-button": "^3.0.0",
-				"@polymer/polymer": "^3.0.0",
-				"@webcomponents/shadycss": "^1.9.1"
+				"@polymer/polymer": "^3.3.1",
+				"@webcomponents/shadycss": "^1.9.6",
+				"haunted": "^4.7.0",
+				"lit-html": "^1.2.1"
+			},
+			"dependencies": {
+				"@neovici/cosmoz-utils": {
+					"version": "3.13.0",
+					"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-3.13.0.tgz",
+					"integrity": "sha512-Ui/6/8PNFDlMl4BXjPMsi3ysU/+Ll7SGM+DFAdGZ2b6PsS6k7GUcdfmkW5D6zFcWws0e9aFBWlwgZlPzy/Dk9Q==",
+					"requires": {
+						"haunted": "^4.0.0"
+					}
+				},
+				"@neovici/cosmoz-viewinfo": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/@neovici/cosmoz-viewinfo/-/cosmoz-viewinfo-3.1.2.tgz",
+					"integrity": "sha512-Ip0sI9ULCpsidWTfgYYPPY2THDXbjKz0kYwUm4IsOALWZHafznjT2N74xwqFlkxMPSrpKPZJwmK3A8+FFU2wrA==",
+					"requires": {
+						"@polymer/iron-resizable-behavior": "^3.0.0",
+						"@polymer/polymer": "^3.2.0",
+						"haunted": "^4.7.0"
+					}
+				}
 			}
 		},
 		"@neovici/cosmoz-datetime-input": {
@@ -1257,6 +1278,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-viewinfo/-/cosmoz-viewinfo-3.0.2.tgz",
 			"integrity": "sha512-Q7y7RpFQoqICMOHsQYuHg3hpekO94UOtTcj3MagMpQbA5LSAV2pnRgSNDMbGhVguWkrxUaeLIKU0BDXY84LYfA==",
+			"dev": true,
 			"requires": {
 				"@polymer/iron-resizable-behavior": "^3.0.0",
 				"@polymer/polymer": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
 		"@polymer/iron-icon": "^3.0.0",
 		"@polymer/iron-icons": "^3.0.0",
 		"@polymer/iron-label": "^3.0.0",
-		"@polymer/iron-resizable-behavior": "^3.0.0",
 		"@polymer/paper-button": "^3.0.0",
 		"@polymer/paper-checkbox": "^3.0.0",
 		"@polymer/paper-dropdown-menu": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	},
 	"dependencies": {
 		"@neovici/cosmoz-autocomplete": "^2.4.6",
-		"@neovici/cosmoz-bottom-bar": "^3.0.10",
+		"@neovici/cosmoz-bottom-bar": "^3.1.4",
 		"@neovici/cosmoz-datetime-input": "^3.0.3",
 		"@neovici/cosmoz-grouped-list": "^3.1.0",
 		"@neovici/cosmoz-i18next": "^3.1.1",

--- a/shell.nix
+++ b/shell.nix
@@ -3,14 +3,22 @@
 with import
   (
     builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/467ce5a.tar.gz";
-      sha256 = "0qz7wgi61pdb335n18xm8rfwddckwv0vg8n7fii5abrrx47vnqcj";
+      url = "https://github.com/NixOS/nixpkgs/archive/daaa0e33505082716beb52efefe3064f0332b521.tar.gz";
+      sha256 = "15vprzpbllp9hy5md36ch1llzhxhd44d291kawcslgrzibw51f95";
     }
-  ) { };
+  )
+{ };
 mkShell {
-  buildInputs = [ nodejs-12_x python3 firefox ];
+  buildInputs = [ nodejs-12_x python3 firefox jre azure-storage-azcopy google-chrome ];
   shellHook = ''
     export CHROME_BIN=${google-chrome}/bin/google-chrome-stable
     export PATH=$(npm bin):$PATH
+
+    link_selenium () {
+      if [ -d "./node_modules" ]; then
+        ln -sfnv "${chromedriver}/bin/chromedriver" "$(find "./node_modules" -path '**/chromedriver/*-chromedriver')"
+        ln -sfnv "${geckodriver}/bin/geckodriver" "$(find "./node_modules" -path '**/geckodriver/*-geckodriver')"
+      fi
+    }
   '';
 }


### PR DESCRIPTION
 Replaces `iron-resizable-behavior` with a `ResizeObserver`.
Should provide a small performance increase.

fixes #387 