### PR TITLE
fix(render): grouped list renders old items

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -663,6 +663,7 @@ class Omnitable extends mixin({ isEmpty }, translatable(PolymerElement)) {
 		if (hidden) {
 			return;
 		}
+		this.$.groupedList.$.list._render();
 		this._debounceAdjustColumns();
 	}
 


### PR DESCRIPTION
If the data has changed when the omnitable is not visible, then the list continues to render the old items (iron-list bails rendering if it's not visible).

Fixes #24702 (RM:24702)