### PR TITLE
fix(removeItem): arrayDelete is undefined

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -1414,7 +1414,13 @@ class Omnitable extends mixin({ isEmpty }, translatable(PolymerElement)) {
 	 * @return {Object} item removed
 	 */
 	removeItem(item) {
-		const removed = this.arrayDelete('data', item);
+		const index = this.data.indexOf(item);
+
+		if (index < 0) {
+			return null;
+		}
+
+		const removed = this.splice('data', index, 1);
 		if (Array.isArray(removed) && removed.length > 0) {
 			return removed[0];
 		}

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -274,6 +274,23 @@ suite('item update effects', () => {
 		assert.isTrue(sortSpy.called, 'resorted');
 	});
 
+	test('removeItem removes a given item from the table', () => {
+		const
+			numItems = omnitable.data.length,
+			item = omnitable.data[2];
+
+		assert.equal(omnitable.data.indexOf(item), 2);
+
+		omnitable.removeItem(item);
+		assert.equal(omnitable.data.length, numItems - 1);
+		assert.equal(omnitable.data.indexOf(item), -1);
+	});
+
+	test('removeItem gracefully fails to remove a non-existing item from the table', () => {
+		assert.equal(omnitable.removeItem({}), null);
+		assert.equal(omnitable.removeItem(), null);
+	});
+
 	teardown(() => {
 		consoleErrorStub.restore();
 	});


### PR DESCRIPTION
Broken in https://github.com/Neovici/cosmoz-omnitable/pull/388: by dropping the use of `mixinBehaviors`, it inadvertently removed the arrayDelete method. `mixinBehaviors` applies Polymer's `LegacyElementMixin` under the hood, which includes the arrayDelete method.

Re https://github.com/Neovici/cosmoz-frontend/pull/2804