### PR TITLE
fix: upgrade to latest bottom-bar

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -37,6 +37,7 @@ import { Debouncer } from '@polymer/polymer/lib/utils/debounce';
 import { FlattenedNodesObserver } from '@polymer/polymer/lib/utils/flattened-nodes-observer';
 import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from '@polymer/polymer/lib/utils/html-tag';
+import { html as litHtml } from 'lit-html';
 
 import { translatable } from '@neovici/cosmoz-i18next';
 import { mixin } from '@neovici/cosmoz-utils';
@@ -181,10 +182,10 @@ class Omnitable extends mixin({ isEmpty }, translatable(PolymerElement)) {
 					on-action="_onAction" active$="[[ !isEmpty(selectedItems.length) ]]" computed-bar-height="{{ computedBarHeight }}">
 					<div slot="info">[[ ngettext('{0} selected item', '{0} selected items', selectedItems.length, t) ]]</div>
 					<slot name="actions" id="actions"></slot>
-					<!-- These slots are neened by cosmoz-bottom-bar
+					<!-- These slots are needed by cosmoz-bottom-bar
 						as it might change the slot of the actions to distribute them in the menu -->
-					<slot name="bottom-bar-toolbar"></slot>
-					<slot name="bottom-bar-menu"></slot>
+					<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
+					<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>
 					<paper-menu-button id="extraMenu" slot="extra" no-animations
 						vertical-offset="[[ computedBarHeight ]]" vertical-align="bottom" horizontal-align="right">
 						<paper-icon-button id="dropdownExtraButton" class="dropdown-trigger" slot="dropdown-trigger" icon="file-download" toggles raised>
@@ -1575,3 +1576,13 @@ class Omnitable extends mixin({ isEmpty }, translatable(PolymerElement)) {
 	}
 }
 customElements.define(Omnitable.is, Omnitable);
+
+const tmplt = `
+	<slot name="actions" slot="actions"></slot>
+	<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
+	<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>
+`;
+
+export const
+	actionSlots = litHtml([tmplt]),
+	actionSlotsPolymer = html([tmplt]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,12 +1374,12 @@
 			}
 		},
 		"@neovici/cosmoz-bottom-bar": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-3.1.4.tgz",
-			"integrity": "sha512-vCQ+9UyaBlcsDkkBIaf8tYoentgK7+BXOTzdph3t1aC8nN2te840hgnD5f3CXek96gM/kLrTKl0RKndWRZQj2w==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-4.0.1.tgz",
+			"integrity": "sha512-cVmR9r0MIN5GEp/oEn0mi8LBE58cPgqivG7A5v9k4k4ujP/2+iRG+zG3XC8TdiCzG7s9ZFqIrYuC6F5FC1pDBQ==",
 			"requires": {
 				"@neovici/cosmoz-utils": "^3.12.0",
-				"@neovici/cosmoz-viewinfo": "^3.1.1",
+				"@neovici/cosmoz-viewinfo": "^3.1.3",
 				"@polymer/iron-icons": "^3.0.1",
 				"@polymer/iron-selector": "^3.0.0",
 				"@polymer/paper-icon-button": "^3.0.0",
@@ -1441,11 +1441,10 @@
 			}
 		},
 		"@neovici/cosmoz-viewinfo": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-viewinfo/-/cosmoz-viewinfo-3.1.2.tgz",
-			"integrity": "sha512-Ip0sI9ULCpsidWTfgYYPPY2THDXbjKz0kYwUm4IsOALWZHafznjT2N74xwqFlkxMPSrpKPZJwmK3A8+FFU2wrA==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-viewinfo/-/cosmoz-viewinfo-3.1.3.tgz",
+			"integrity": "sha512-pFqh53DcWB/kl7QlToeardK6ZE2XnXbchL3aqSqivIHkIBqoEWVlM6inBro++alvRVboriMf1vRzXwYEV1mYQg==",
 			"requires": {
-				"@polymer/iron-resizable-behavior": "^3.0.0",
 				"@polymer/polymer": "^3.2.0",
 				"haunted": "^4.7.0"
 			}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	},
 	"dependencies": {
 		"@neovici/cosmoz-autocomplete": "^2.4.9",
-		"@neovici/cosmoz-bottom-bar": "^3.1.4",
+		"@neovici/cosmoz-bottom-bar": "^4.0.1",
 		"@neovici/cosmoz-datetime-input": "^3.0.3",
 		"@neovici/cosmoz-grouped-list": "^3.1.0",
 		"@neovici/cosmoz-i18next": "^3.1.1",
@@ -78,12 +78,13 @@
 		"@polymer/paper-spinner": "^3.0.0",
 		"@polymer/polymer": "^3.3.1",
 		"@webcomponents/shadycss": "^1.10.0",
-		"file-saver": "github:plumelo/FileSaver.js"
+		"file-saver": "github:plumelo/FileSaver.js",
+		"lit-html": "^1.3.0"
 	},
 	"devDependencies": {
 		"@commitlint/cli": "^11.0.0",
 		"@commitlint/config-conventional": "^11.0.0",
-		"@neovici/cosmoz-viewinfo": "^3.1.2",
+		"@neovici/cosmoz-viewinfo": "^3.1.3",
 		"@neovici/eslint-config": "^1.3.0",
 		"@open-wc/testing": "^2.5.28",
 		"@open-wc/testing-karma": "^3.4.8",
@@ -100,7 +101,6 @@
 		"karma": "^5.2.0",
 		"karma-firefox-launcher": "^1.3.0",
 		"karma-sauce-launcher": "^4.1.5",
-		"lit-html": "^1.3.0",
 		"semantic-release": "^17.1.0",
 		"sinon": "^9.1.0",
 		"web-animations-js": "^2.3.2"


### PR DESCRIPTION
Includes https://github.com/Neovici/cosmoz-bottom-bar/pull/89 breaking change.

BREAKING CHANGE: If your component allows adding content to the omnitable via the actions slot,
then you have to also make sure you also export `bottom-bar-toolbar` and `bottom-bar-menu`,
otherwise the actions will not show up.

Re #24802 (RM:24802)

TODO:

- [x] upgrade bottom-bar after new release