### PR TITLE
fix(column-boolean): notify when clearing

### DIFF
--- a/cosmoz-omnitable-column-boolean.js
+++ b/cosmoz-omnitable-column-boolean.js
@@ -263,7 +263,7 @@ class OmnitableColumnBoolean extends columnMixin(PolymerElement) {
 	}
 
 	_onChange(selection) {
-		this.filter = selection?.[0]?.value;
+		this.filter = selection?.[0]?.value ?? null;
 	}
 
 	_onFocus(focused) {


### PR DESCRIPTION
When clearing the boolean value `filter` is set to `undefined`.
That does not actually notify about the update (clearing the value) so we have to set the `filter` to null. 