### PR TITLE
fix(bar): overflow bar to prevent auto scrolling

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -301,6 +301,7 @@ container.innerHTML = `<dom-module id="cosmoz-omnitable-styles">
 			cosmoz-bottom-bar {
 				background-color: var(--cosmoz-omnitable-bottom-bar-color, #5f5a92);
 				color: white;
+				overflow: hidden;
 			}
 
 			cosmoz-bottom-bar::slotted(*) {


### PR DESCRIPTION
If initialized in a hidden tab or somehow not visible at create
the cosmoz-omnitable element will scroll internally because of the overflow
of its cosmoz-bottom-bar element
This sets overflow: hidden on the bar preventing the bug.