### PR TITLE
fix(column-autocomplete): handle numbers in getComparableValue

### DIFF
--- a/cosmoz-omnitable-column-autocomplete.js
+++ b/cosmoz-omnitable-column-autocomplete.js
@@ -8,6 +8,9 @@ import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 
 import { columnMixin } from './cosmoz-omnitable-column-mixin.js';
 import { listColumnMixin } from './cosmoz-omnitable-column-list-mixin';
+import {
+	prop, strProp, array
+} from '@neovici/cosmoz-autocomplete/lib/utils';
 
 /**
  * @polymer
@@ -72,7 +75,9 @@ class OmnitableColumnAutocomplete extends listColumnMixin(columnMixin(PolymerEle
 		};
 	}
 	getComparableValue(item, valuePath = this.valuePath) {
-		return this.getString(item, valuePath);
+		const property = this.textProperty ? strProp(this.textProperty) : prop(this.valueProperty),
+			values = array(valuePath && this.get(valuePath, item)).map(property);
+		return values.length > 1 ? values.filter(Boolean).join(',') : values[0];
 	}
 }
 customElements.define(OmnitableColumnAutocomplete.is, OmnitableColumnAutocomplete);


### PR DESCRIPTION
Updated the `getComparableValue` fn in `autocomplete` column to handle textProperty and valueProperty.
If the cell value is not an array it returns the value as it is.
Because of that numeric sort should just work.

Fixes #408  but doesn't need to add the attribute.