### PR TITLE
feat(cosmoz-omnitable): renders totalAvailable in row stats

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -1585,7 +1585,7 @@ class Omnitable extends mixin({ isEmpty }, getEffectiveChildrenLegacyMixin(trans
 
 	_renderRowStats(numRows, totalAvailable) {
 		if (Number.isInteger(totalAvailable) && totalAvailable > numRows) {
-			return this.ngettext('{0} / {1} row', '{0} / {1} rows', numRows, totalAvailable);
+			return this.ngettext('{1} / {0} row', '{1} / {0} rows', totalAvailable, numRows);
 		}
 		return this.ngettext('{0} row', '{0} rows', numRows);
 	}

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -175,7 +175,7 @@ class Omnitable extends mixin({ isEmpty }, getEffectiveChildrenLegacyMixin(trans
 				</div>
 				<div class="footer-tableStats">
 					<span>[[ ngettext('{0} group', '{0} groups', _groupsCount, t) ]]</span>
-					<span>[[ ngettext('{0} row', '{0} rows', filteredItems.length, t) ]]</span>
+					<span>[[ _renderRowStats(filteredItems.length, totalAvailable, t) ]]</span>
 				</div>
 				<cosmoz-bottom-bar id="bottomBar" class="footer-actionBar" match-parent
 					on-action="_onAction" active$="[[ !isEmpty(selectedItems.length) ]]" computed-bar-height="{{ computedBarHeight }}">
@@ -1581,6 +1581,13 @@ class Omnitable extends mixin({ isEmpty }, getEffectiveChildrenLegacyMixin(trans
 
 	_debounce(name, fn, asyncModule = timeOut.after(0)) {
 		this.debouncers[name] = Debouncer.debounce(this.debouncers[name], asyncModule, fn);
+	}
+
+	_renderRowStats(numRows, totalAvailable) {
+		if (Number.isInteger(totalAvailable) && totalAvailable > numRows) {
+			return this.ngettext('{0} / {1} row', '{0} / {1} rows', numRows, totalAvailable);
+		}
+		return this.ngettext('{0} row', '{0} rows', numRows);
 	}
 }
 customElements.define(Omnitable.is, Omnitable);

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -5,6 +5,7 @@ import {
 
 import sinon from 'sinon';
 
+import '../demo/helpers/cosmoz-translations';
 import { setupOmnitableFixture } from './helpers/utils';
 import { generateTableDemoData } from '../demo/table-demo-helper';
 import { flush } from '@polymer/polymer/lib/utils/flush';
@@ -481,12 +482,32 @@ suite('render group function', () => {
 });
 
 suite('render row stats', () => {
-	test('renders totalAvailable', async () => {
+	test('renders row stats', async () => {
+		const omnitable = await setupOmnitableFixture(html`
+			<cosmoz-omnitable>
+				<cosmoz-omnitable-column name="name" value-path="name"></cosmoz-omnitable-column>
+				<cosmoz-translations locale="en"></cosmoz-translations>
+			</cosmoz-omnitable>`, generateTableDemoData(10, 10, 25));
+		assert.equal(omnitable.shadowRoot.querySelector('.footer-tableStats span:last-child').textContent, '100 rows');
+	});
+
+	test('renders totalAvailable stats', async () => {
 		const omnitable = await setupOmnitableFixture(html`
 			<cosmoz-omnitable .totalAvailable=${ 2000 }>
 				<cosmoz-omnitable-column name="name" value-path="name">
 				</cosmoz-omnitable-column>
+				<cosmoz-translations locale="en"></cosmoz-translations>
 			</cosmoz-omnitable>`, generateTableDemoData(10, 10, 25));
-		assert.equal(omnitable.shadowRoot.querySelector('.footer-tableStats span:last-child').textContent, '{0} / {1} rows');
+		assert.equal(omnitable.shadowRoot.querySelector('.footer-tableStats span:last-child').textContent, '100 / 2000 rows');
+	});
+
+	test('renders totalAvailable stat', async () => {
+		const omnitable = await setupOmnitableFixture(html`
+			<cosmoz-omnitable .totalAvailable=${ 250 }>
+				<cosmoz-omnitable-column name="name" value-path="name">
+				</cosmoz-omnitable-column>
+				<cosmoz-translations locale="en"></cosmoz-translations>
+			</cosmoz-omnitable>`, [{ name: 'Somename' }]);
+		assert.equal(omnitable.shadowRoot.querySelector('.footer-tableStats span:last-child').textContent, '1 / 250 rows');
 	});
 });

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -480,3 +480,13 @@ suite('render group function', () => {
 	});
 });
 
+suite('render row stats', () => {
+	test('renders totalAvailable', async () => {
+		const omnitable = await setupOmnitableFixture(html`
+			<cosmoz-omnitable .totalAvailable=${ 2000 }>
+				<cosmoz-omnitable-column name="name" value-path="name">
+				</cosmoz-omnitable-column>
+			</cosmoz-omnitable>`, generateTableDemoData(10, 10, 25));
+		assert.equal(omnitable.shadowRoot.querySelector('.footer-tableStats span:last-child').textContent, '{0} / {1} rows');
+	});
+});


### PR DESCRIPTION
Adds a `totalAvailable` property that is used to render the total available
number of items if greater than current data.
#230
