### PR TITLE
fix(layout): layout is broken when grouping

### DIFF
--- a/lib/layout.js
+++ b/lib/layout.js
@@ -4,7 +4,7 @@ const finite = num => Number.isFinite(num) ? num : 0;
 export const layout = (columns, container) => {
 	const result = [];
 	let [basisSum, lots] = columns.reduce(
-			([basisSum, lots], [basis, , grow]) => [
+			([basisSum, lots], { basis, grow }) => [
 				basisSum + basis,
 				lots + grow
 			],
@@ -18,7 +18,7 @@ export const layout = (columns, container) => {
 
 	// first pass: apply and drop lots with minWidth
 	for (let i = 0; i < columns.length; i++) {
-		const [basis, minWidth, grow] = columns[i],
+		const { basis, minWidth, grow } = columns[i],
 			adjustment = freeRealEstate >= 0
 				? lotSize * grow
 				: basis * freeRealEstate / basisSum;
@@ -44,7 +44,7 @@ export const layout = (columns, container) => {
 			continue;
 		}
 
-		const [basis, , grow] = columns[i],
+		const { basis, grow } = columns[i],
 			adjustment = freeRealEstate >= 0
 				? lotSize * grow
 				: basis * freeRealEstate / basisSum;

--- a/lib/use-fast-layout.js
+++ b/lib/use-fast-layout.js
@@ -5,8 +5,11 @@ import {
 import { layout } from './layout';
 
 const
-	computeLayout = (columnConfigs, canvasWidth, numColumns) => {
-		const totalWidths = columnConfigs.reduce((sum, [totalWidths]) => sum + totalWidths, 0);
+	computeLayout = (_columnConfigs, canvasWidth, numColumns) => {
+		const columnConfigs = _columnConfigs.map(({ hidden, ...config }) =>
+				hidden ? { ...config, basis: 0, minWidth: 0, grow: 0 } : config
+			),
+			totalWidths = columnConfigs.reduce((sum, { basis }) => sum + basis, 0);
 
 		if (columnConfigs.length > 1 && totalWidths > canvasWidth) {
 			// drop a column
@@ -15,8 +18,8 @@ const
 
 		const widths = layout(columnConfigs, Math.max(canvasWidth, totalWidths));
 
-		return widths.reduce((sorted, width, index) => {
-			sorted[columnConfigs[index][3]] = width;
+		return widths.reduce((sorted, width, i) => {
+			sorted[columnConfigs[i].index] = width;
 			return sorted;
 		}, new Array(numColumns).fill(undefined));
 	},
@@ -52,11 +55,18 @@ export const useFastLayout = host => {
 			}
 
 			const columnConfigs = columns
-				.filter(column => column !== groupOnColumn)
-				.map(column => [parseInt(column.width, 10), parseInt(column.minWidth, 10), parseInt(column.flex, 10), column.columnIndex, column.priority])
-				.sort(([, , , aIndex, aPriority], [, , , bIndex, bPriority]) => aPriority === bPriority
-					? bIndex - aIndex
-					: aPriority - bPriority);
+				.map(column => ({
+					basis: parseInt(column.width, 10),
+					minWidth: parseInt(column.minWidth, 10),
+					grow: parseInt(column.flex, 10),
+					index: column.columnIndex,
+					priority: column.priority,
+					hidden: column === groupOnColumn
+				}))
+				.sort(({ index: aIndex, priority: aPriority }, { index: bIndex, priority: bPriority }) =>
+					aPriority === bPriority
+						? bIndex - aIndex
+						: aPriority - bPriority);
 
 			return computeLayout(columnConfigs, canvasWidth, columnConfigs.length);
 		}, [columns, canvasWidth, groupOnColumn]),

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -1,6 +1,7 @@
 import { assert } from '@open-wc/testing';
 import { layout } from '../lib/layout';
 
+const toObj = ([basis, minWidth, grow]) => ({ basis, minWidth, grow });
 
 suite('layout algorithm', () => {
 	test('it works', () => {
@@ -14,6 +15,11 @@ suite('layout algorithm', () => {
 				[[100, 50, 1], [100, 50, 1]],
 				200,
 				[100, 100]
+			],
+			[
+				[[100, 50, 1], [0, 0, 0], [100, 50, 1]],
+				200,
+				[100, 0, 100]
 			],
 			[
 				[[50, 50, 1], [50, 50, 1]],
@@ -111,9 +117,8 @@ suite('layout algorithm', () => {
 				[479, 272, 100, 55, 75, 125]
 			]
 		];
-
 		cases.forEach(([columns, container, result]) => {
-			assert.deepEqual(layout(columns, container), result);
+			assert.deepEqual(layout(columns.map(toObj), container), result);
 		});
 	});
 });


### PR DESCRIPTION
In certain situations, columns are not hidden correctly, when the table is grouped. 

Fixes #437