### PR TITLE
fix(resizable-columns): undefined priorities break the layout when resizing columns

### DIFF
--- a/lib/use-layout-config.js
+++ b/lib/use-layout-config.js
@@ -9,7 +9,7 @@ export const useLayoutConfig = columns => {
 				minWidth: parseInt(column.minWidth, 10),
 				width: parseInt(column.width, 10),
 				flex: parseInt(column.flex, 10),
-				priority: column.priority,
+				priority: column.priority ?? 0,
 				index: column.columnIndex
 			})), [columns]),
 


### PR DESCRIPTION
Set a default value for `priority`.