### PR TITLE
fix(resizable-columns): columns are hidden even if they could fit

### DIFF
--- a/lib/use-resizable-columns.js
+++ b/lib/use-resizable-columns.js
@@ -11,12 +11,13 @@ export const useResizableColumns = ({ host, canvasWidth, layout, config, setUser
 
 		for (let i = 0; i < layout.length; i++) {
 			newUserConfig[i] = {
-				width: oldUserConfig[i]?.width ?? layout[i],
+				width: oldUserConfig[i]?.width,
 				minWidth: config[i].minWidth,
 				priority: config[i].priority
 			};
 
 			if (i <= columnIndex && layout[i]) {
+				newUserConfig[i].width = layout[i];
 				newUserConfig[i].flex = 0;
 				newUserConfig[i].priority = maxPriority;
 			}
@@ -30,7 +31,7 @@ export const useResizableColumns = ({ host, canvasWidth, layout, config, setUser
 						return acc;
 					}, canvasWidth);
 
-				newUserConfig[i].width = Math.min(maxNewSize, Math.max(newUserConfig[i].width + delta, config[i].minWidth));
+				newUserConfig[i].width = Math.min(maxNewSize, Math.max(layout[i] + delta, config[i].minWidth));
 			}
 		}
 


### PR DESCRIPTION
This happens on the initial drag, due to the way the resize algorithm is initialized.