### PR TITLE
fix(styles): prevent bottom bar stacking context

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -270,6 +270,7 @@ export default `<style>
 		display: flex;
 		align-items: center;
 		flex: auto;
+		isolation: isolate;
 	}
 
 	.footer-control {
@@ -384,6 +385,7 @@ export default `<style>
 		background-color: var(--cosmoz-omnitable-bottom-bar-color, #5f5a92);
 		color: white;
 		overflow: hidden;
+		z-index: auto;
 	}
 
 	cosmoz-bottom-bar::slotted(*) {


### PR DESCRIPTION
Prevents the creation of a new stacking context on the bottom bar in
some browsers because it is a child of flex container with non `auto`
z-index.

See https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context#the_stacking_context