### PR TITLE
Fix render issue in cosmoz-data-nav

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - beta
   push:
     branches:
       - master

--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -23,7 +23,7 @@ import styles from './cosmoz-omnitable-styles';
 
 import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from '@polymer/polymer/lib/utils/html-tag';
-import { html as litHtml, render } from 'lit-html';
+import { html as litHtml } from 'lit-html';
 
 import { translatable } from '@neovici/cosmoz-i18next';
 import { mixin, hauntedPolymer } from '@neovici/cosmoz-utils';
@@ -275,8 +275,7 @@ class Omnitable extends hauntedPolymer(useOmnitable)(mixin({ isEmpty }, translat
 
 	static get observers() {
 		return [
-			'_selectedItemsChanged(selectedItems.*)',
-			'renderFastLayoutCss(layoutCss, $.layoutStyle)'
+			'_selectedItemsChanged(selectedItems.*)'
 		];
 	}
 
@@ -514,10 +513,6 @@ class Omnitable extends hauntedPolymer(useOmnitable)(mixin({ isEmpty }, translat
 			return this.ngettext('{1} / {0} row', '{1} / {0} rows', totalAvailable, numRows);
 		}
 		return this.ngettext('{0} row', '{0} rows', numRows);
-	}
-
-	renderFastLayoutCss(layoutCss, outlet) {
-		render(layoutCss, outlet);
 	}
 
 	_onCompleteValues(columns, type, value) { /* eslint-disable-next-line no-bitwise */

--- a/lib/use-fast-layout.js
+++ b/lib/use-fast-layout.js
@@ -1,10 +1,11 @@
-import { useMemo } from 'haunted';
+import { useEffect, useLayoutEffect, useMemo } from 'haunted';
 import { toCss } from './compute-layout';
 import { useResizableColumns } from './use-resizable-columns';
 import { useCanvasWidth } from './use-canvas-width';
 import { useTweenArray } from './use-tween-array';
 import { useLayout } from './use-layout';
 import { columnSymbol } from './normalize-settings';
+import { render } from 'lit-html';
 
 export const useFastLayout = ({ host, settings, setSettings, groupOnColumn, resizeSpeedFactor }) => {
 	const
@@ -26,8 +27,9 @@ export const useFastLayout = ({ host, settings, setSettings, groupOnColumn, resi
 
 	useResizableColumns({ host, canvasWidth, layout, setSettings: update => setSettings(update(settings)) });
 
+	useLayoutEffect(() => render(layoutCss, host.$.layoutStyle), [layoutCss]);
+
 	return {
-		layoutCss,
 		collapsedColumns
 	};
 };

--- a/lib/use-fast-layout.js
+++ b/lib/use-fast-layout.js
@@ -29,6 +29,23 @@ export const useFastLayout = ({ host, settings, setSettings, groupOnColumn, resi
 
 	useLayoutEffect(() => render(layoutCss, host.$.layoutStyle), [layoutCss]);
 
+	// force iron-list to render when the omnitable becomes visible
+	useEffect(() => {
+		let lastWidth = 0;
+
+		const
+			onResize = ([entry]) => {
+				if (lastWidth === 0) {
+					requestAnimationFrame(() => host.$.groupedList.$.list._render());
+				}
+				lastWidth = entry.contentRect?.width;
+			},
+			observer = new ResizeObserver(onResize);
+
+		observer.observe(host);
+		return () => observer.unobserve(host);
+	}, []);
+
 	return {
 		collapsedColumns
 	};


### PR DESCRIPTION
Caught during integration with Cosmoz frontend. When navigating a cosmoz-data-nav, the omnitables that are rendered off-screen do not properly render the list. The <iron-list> skips rendering if it is not connected.