### PR TITLE
Refactor getComparableValue

### DIFF
--- a/cosmoz-omnitable-column-amount.js
+++ b/cosmoz-omnitable-column-amount.js
@@ -35,8 +35,8 @@ class OmnitableColumnAmount extends columnMixin(PolymerElement) {
 
 	getFilterFn(column, filter) {
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		if (min == null && max == null) {
 			return;
@@ -56,8 +56,8 @@ class OmnitableColumnAmount extends columnMixin(PolymerElement) {
 		return getString(column, item);
 	}
 
-	getComparableValue(item, valuePath, column) {
-		return getComparableValue(item, valuePath, column);
+	getComparableValue(column, item) {
+		return getComparableValue(column, item);
 	}
 
 	serializeFilter({ rates }, filter) {

--- a/cosmoz-omnitable-column-autocomplete.js
+++ b/cosmoz-omnitable-column-autocomplete.js
@@ -14,7 +14,7 @@ import {
 import { get } from '@polymer/polymer/lib/utils/path';
 
 export const
-	getComparableValue = (item, valuePath, { textProperty, valueProperty } = {}) => {
+	getComparableValue = ({ valuePath, textProperty, valueProperty }, item) => {
 		const property = textProperty ? strProp(textProperty) : prop(valueProperty),
 			values = array(valuePath && get(item, valuePath)).map(property);
 		return values.length > 1 ? values.filter(Boolean).join(',') : values[0];
@@ -63,8 +63,8 @@ class OmnitableColumnAutocomplete extends listColumnMixin(columnMixin(PolymerEle
 		>${ spinner }</cosmoz-autocomplete-ui>`;
 	}
 
-	getComparableValue(item, valuePath, column) {
-		return getComparableValue(item, valuePath, column);
+	getComparableValue(column, item) {
+		return getComparableValue(column, item);
 	}
 
 	computeSource(column, data) {

--- a/cosmoz-omnitable-column-date.js
+++ b/cosmoz-omnitable-column-date.js
@@ -27,8 +27,8 @@ class OmnitableColumnDate extends columnMixin(PolymerElement) {
 
 	getFilterFn(column, filter) {
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		if (min == null && max == null) {
 			return;
@@ -48,8 +48,8 @@ class OmnitableColumnDate extends columnMixin(PolymerElement) {
 		return getString(column, item);
 	}
 
-	getComparableValue(item, valuePath, column) {
-		return getComparableValue(item, valuePath, column);
+	getComparableValue(column, item) {
+		return getComparableValue(column, item);
 	}
 
 	serializeFilter(column, filter) {

--- a/cosmoz-omnitable-column-datetime.js
+++ b/cosmoz-omnitable-column-datetime.js
@@ -36,8 +36,8 @@ class OmnitableColumnDatetime extends columnMixin(PolymerElement) {
 
 	getFilterFn(column, filter) {
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		if (min == null && max == null) {
 			return;
@@ -57,8 +57,8 @@ class OmnitableColumnDatetime extends columnMixin(PolymerElement) {
 		return getString(column, item);
 	}
 
-	getComparableValue(item, valuePath, column) {
-		return getComparableValue(item, valuePath, column);
+	getComparableValue(column, item) {
+		return getComparableValue(column, item);
 	}
 
 	serializeFilter(column, filter) {

--- a/cosmoz-omnitable-column-list-mixin.js
+++ b/cosmoz-omnitable-column-list-mixin.js
@@ -130,7 +130,7 @@ const
 			return getString(column, item);
 		}
 
-		getComparableValue(item, valuePath, { valueProperty }) {
+		getComparableValue({ valuePath, valueProperty }, item) {
 			const value = get(item, valuePath);
 			if (valueProperty == null) {
 				return value;

--- a/cosmoz-omnitable-column-mixin.js
+++ b/cosmoz-omnitable-column-mixin.js
@@ -3,6 +3,7 @@ import { get } from '@polymer/polymer/lib/utils/path';
 export const
 	getString = ({ valuePath }, item) => get(item, valuePath),
 	toXlsxValue = getString,
+	getComparableValue = getString,
 
 	applySingleFilter = ({ valuePath }, filter) => item => {
 		const value = get(item, valuePath);
@@ -87,8 +88,8 @@ export const
 			return filter;
 		}
 
-		getComparableValue(item, valuePath) {
-			return get(item, valuePath);
+		getComparableValue(column, item) {
+			return getComparableValue(column, item);
 		}
 
 		computeSource(column, data) {

--- a/cosmoz-omnitable-column-mixin.js
+++ b/cosmoz-omnitable-column-mixin.js
@@ -91,8 +91,8 @@ export const
 			return get(item, valuePath);
 		}
 
-		computeSource() {
-			return null;
+		computeSource(column, data) {
+			return data;
 		}
 
 		_propertiesChanged(currentProps, changedProps, oldProps) {

--- a/cosmoz-omnitable-column-number.js
+++ b/cosmoz-omnitable-column-number.js
@@ -36,8 +36,8 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 
 	getFilterFn(column, filter) {
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		if (min == null && max == null) {
 			return;
@@ -57,8 +57,8 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 		return getString(column, item);
 	}
 
-	getComparableValue(item, valuePath, column) {
-		return getComparableValue(item, valuePath, column);
+	getComparableValue(column, item) {
+		return getComparableValue(column, item);
 	}
 
 	serializeFilter(column, filter) {

--- a/cosmoz-omnitable-column-time.js
+++ b/cosmoz-omnitable-column-time.js
@@ -38,8 +38,8 @@ class OmnitableColumnTime extends columnMixin(PolymerElement) {
 
 	getFilterFn(column, filter) {
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		if (min == null && max == null) {
 			return;
@@ -59,8 +59,8 @@ class OmnitableColumnTime extends columnMixin(PolymerElement) {
 		return getString(column, item);
 	}
 
-	getComparableValue(item, valuePath, column) {
-		return getComparableValue(item, valuePath, column);
+	getComparableValue(column, item) {
+		return getComparableValue(column, item);
 	}
 
 	serializeFilter(column, filter) {

--- a/lib/use-processed-items.js
+++ b/lib/use-processed-items.js
@@ -78,12 +78,12 @@ export const useProcessedItems = ({ data, columns, groupOnColumn, groupOnDescend
 		// todo: extract function
 		processedItems = useMemo(() => {
 			if (!groupOnColumn && sortOnColumn != null && sortOnColumn.sortOn != null) {
-				return filteredItems.slice().sort(sortBy(a => sortOnColumn.getComparableValue(a, sortOnColumn.sortOn, sortOnColumn), descending));
+				return filteredItems.slice().sort(sortBy(a => sortOnColumn.getComparableValue({ ...sortOnColumn, valuePath: sortOnColumn.sortOn }, a), descending));
 			}
 
 			if (groupOnColumn != null && groupOnColumn.groupOn != null) {
 				const groupedResults = filteredItems.reduce((acc, item) => {
-					const gval = groupOnColumn.getComparableValue(item, groupOnColumn.groupOn, groupOnColumn);
+					const gval = groupOnColumn.getComparableValue({ ...groupOnColumn, valuePath: groupOnColumn.groupOn }, item);
 
 					if (gval === undefined) {
 						return acc;
@@ -104,7 +104,8 @@ export const useProcessedItems = ({ data, columns, groupOnColumn, groupOnDescend
 					return acc;
 				}, []);
 
-				groupedResults.sort(sortBy(a => groupOnColumn.getComparableValue(a.items[0], groupOnColumn.groupOn, groupOnColumn), groupOnDescending));
+				groupedResults.sort(sortBy(
+					a => groupOnColumn.getComparableValue({ ...groupOnColumn, valuePath: groupOnColumn.groupOn }, a.items[0]), groupOnDescending));
 
 				if (!sortOnColumn) {
 					return groupedResults;
@@ -113,7 +114,7 @@ export const useProcessedItems = ({ data, columns, groupOnColumn, groupOnDescend
 				return groupedResults
 					.filter(group => Array.isArray(group.items))
 					.map(group => {
-						group.items.sort(sortBy(a => sortOnColumn.getComparableValue(a, sortOnColumn.sortOn, sortOnColumn), descending));
+						group.items.sort(sortBy(a => sortOnColumn.getComparableValue({ ...sortOnColumn, valuePath: sortOnColumn.sortOn }, a), descending));
 						return group;
 					});
 			}

--- a/lib/utils-amount.js
+++ b/lib/utils-amount.js
@@ -45,7 +45,7 @@ export const
 		return lNumber === valAmount ? amount : lAmount;
 	},
 
-	getComparableValue = (item, valuePath, { rates } = {}) => {
+	getComparableValue = ({ valuePath, rates }, item) => {
 		if (item == null) {
 			return;
 		}
@@ -70,15 +70,15 @@ export const
 	},
 
 	applySingleFilter = (column, filter) => item => {
-		const value = getComparableValue(item, column.valuePath, column);
+		const value = getComparableValue(column, item);
 
 		if (value == null) {
 			return false;
 		}
 
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		return !(value < min || value > max);
 	},

--- a/lib/utils-date.js
+++ b/lib/utils-date.js
@@ -56,11 +56,11 @@ export const
 	/**
 	 * Get comparable number from date
 	 *
-	 * @param	 {Object} item			 Item to be processed
 	 * @param	 {String} valuePath	 Property path
+	 * @param	 {Object} item			 Item to be processed
 	 * @returns {Number|void} Valid value or void
 	 */
-	getComparableValue = (item, valuePath) => {
+	getComparableValue = ({ valuePath }, item) => {
 		if (item == null) {
 			return;
 		}
@@ -100,8 +100,8 @@ export const
 			return date;
 		}
 
-		const comparableDate = getComparableValue(date),
-			comparableLDate = getComparableValue(lDate),
+		const comparableDate = getComparableValue({}, date),
+			comparableLDate = getComparableValue({}, lDate),
 			limitedValue = limitFunc(comparableDate, comparableLDate);
 		return limitedValue === comparableDate ? date : lDate;
 	},
@@ -188,15 +188,15 @@ export const
 	},
 
 	applySingleFilter = (column, filter) => item => {
-		const value = getComparableValue(item, column.valuePath, column);
+		const value = getComparableValue(column, item);
 
 		if (value == null) {
 			return false;
 		}
 
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		return !(value < min || value > max);
 	};

--- a/lib/utils-number.js
+++ b/lib/utils-number.js
@@ -50,7 +50,7 @@ export const
 		return string;
 	},
 
-	getComparableValue = (item, valuePath, { maximumFractionDigits } = {}) => {
+	getComparableValue = ({ valuePath, maximumFractionDigits }, item) => {
 		if (item == null) {
 			return;
 		}
@@ -98,15 +98,15 @@ export const
 	},
 
 	applySingleFilter = (column, filter) => item => {
-		const value = getComparableValue(item, column.valuePath, column);
+		const value = getComparableValue(column, item);
 
 		if (value == null) {
 			return false;
 		}
 
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		return !(value < min || value > max);
 	};

--- a/lib/utils-time.js
+++ b/lib/utils-time.js
@@ -67,7 +67,7 @@ export const
 		return toLocalISOString(date).slice(11, 19);
 	},
 
-	getComparableValue = (item, valuePath) => {
+	getComparableValue = ({ valuePath }, item) => {
 		if (item == null) {
 			return;
 		}
@@ -83,15 +83,15 @@ export const
 	},
 
 	applySingleFilter = (column, filter) => item => {
-		const value = getComparableValue(item, column.valuePath, column);
+		const value = getComparableValue(column, item);
 
 		if (value == null) {
 			return false;
 		}
 
 		const
-			min = getComparableValue(filter, 'min', column),
-			max = getComparableValue(filter, 'max', column);
+			min = getComparableValue({ ...column, valuePath: 'min' }, filter),
+			max = getComparableValue({ ...column, valuePath: 'max' }, filter);
 
 		return !(value < min || value > max);
 	},

--- a/test/autocomplete.test.js
+++ b/test/autocomplete.test.js
@@ -30,21 +30,21 @@ const data = [{
 
 suite('pure functions', () => {
 	test('getComparableValue returns the correct value, given a path', () => {
-		assert.equal(getComparableValue({
+		assert.equal(getComparableValue({ valuePath: 'id' }, {
 			id: 14,
 			group: 'group0',
 			name: 'Item 14'
-		}, 'id'), 14);
-		assert.equal(getComparableValue({
+		}), 14);
+		assert.equal(getComparableValue({ valuePath: 'id' }, {
 			id: 345,
 			group: 'group7',
 			name: 'Item 345'
-		}, 'id'), 345);
-		assert.equal(getComparableValue({
+		}), 345);
+		assert.equal(getComparableValue({ valuePath: 'name' }, {
 			id: 27,
 			group: 'group5',
 			name: 'Item 27'
-		}, 'name'), 'Item 27');
+		}), 'Item 27');
 	});
 
 	test('getString handles undefined valuePath parameter', () => {

--- a/test/range-amount.test.js
+++ b/test/range-amount.test.js
@@ -159,14 +159,14 @@ suite('amount', () => {
 	});
 
 	test('returns comparable value', () => {
-		assert.equal(getComparableValue(data[3], 'amount'), -8);
-		assert.equal(getComparableValue(data[4], 'amount'), 3450);
-		assert.equal(getComparableValue({
+		assert.equal(getComparableValue({ valuePath: 'amount' }, data[3]), -8);
+		assert.equal(getComparableValue({ valuePath: 'amount' }, data[4]), 3450);
+		assert.equal(getComparableValue({}, {
 			amount: '13',
 			currency: 'EUR'
 		}), 13);
-		assert.isUndefined(getComparableValue({}));
-		assert.isUndefined(getComparableValue([]));
+		assert.isUndefined(getComparableValue({}, {}));
+		assert.isUndefined(getComparableValue({}, []));
 	});
 
 	test('amount renders symbol and value', () => {
@@ -354,85 +354,85 @@ suite('currency rates', () => {
 	});
 
 	test('getComparableValue with rates returns value', () => {
-		assert.equal(getComparableValue({
+		assert.equal(getComparableValue({ rates }, {
 			amount: '10',
 			currency: 'EUR'
-		}, null, column), 10);
-		assert.equal(getComparableValue({
+		}), 10);
+		assert.equal(getComparableValue({ rates }, {
 			amount: -645,
 			currency: 'EUR'
-		}, null, column), -645);
-		assert.equal(getComparableValue({
+		}), -645);
+		assert.equal(getComparableValue({ rates }, {
 			amount: '10',
 			currency: 'USD'
-		}, null, column), 8.169982616);
-		assert.equal(getComparableValue({
+		}), 8.169982616);
+		assert.equal(getComparableValue({ rates }, {
 			amount: 10,
 			currency: 'GBP'
-		}, null, column), 11.347079368);
-		assert.equal(getComparableValue({
+		}), 11.347079368);
+		assert.equal(getComparableValue({ rates }, {
 			amount: 10,
 			currency: 'SEK'
-		}, null, column).toFixed(8), 1.01927144);
-		assert.equal(getComparableValue({
+		}).toFixed(8), 1.01927144);
+		assert.equal(getComparableValue({ rates }, {
 			amount: 678,
 			currency: 'AUD'
-		}, null, column).toFixed(8), 442.72228362);
-		assert.equal(getComparableValue({
+		}).toFixed(8), 442.72228362);
+		assert.equal(getComparableValue({ rates }, {
 			amount: '12.4',
 			currency: 'USD'
-		}, null, column).toFixed(8), 10.13077844);
+		}).toFixed(8), 10.13077844);
 	});
 
 	test('changing currency does not affect comparable value', async () => {
 		column.currency = 'USD';
 		await nextFrame();
-		assert.equal(getComparableValue({
+		assert.equal(getComparableValue({ rates }, {
 			amount: '-3147',
 			currency: 'EUR'
-		}, null, column), -3147);
-		assert.equal(getComparableValue({
+		}), -3147);
+		assert.equal(getComparableValue({ rates }, {
 			amount: '1000',
 			currency: 'USD'
-		}, null, column), 816.9982616);
+		}), 816.9982616);
 
 		column.currency = 'GBP';
 		await nextFrame();
-		assert.equal(getComparableValue({
+		assert.equal(getComparableValue({ rates }, {
 			amount: 333,
 			currency: 'EUR'
-		}, null, column), 333);
-		assert.equal(getComparableValue({
+		}), 333);
+		assert.equal(getComparableValue({ rates }, {
 			amount: -100,
 			currency: 'USD'
-		}, null, column), -81.69982616);
-		assert.equal(getComparableValue({
+		}), -81.69982616);
+		assert.equal(getComparableValue({ rates }, {
 			amount: 2534,
 			currency: 'SEK'
-		}, null, column).toFixed(8), 258.28338239);
+		}).toFixed(8), 258.28338239);
 	});
 
 	test('getComparableValue with default rate returns value', () => {
-		assert.equal(getComparableValue({
+		assert.equal(getComparableValue({ rates }, {
 			amount: '3450',
 			currency: 'DKK'
-		}, null, column), 3450);
-		assert.equal(getComparableValue({
+		}), 3450);
+		assert.equal(getComparableValue({ rates }, {
 			amount: -888,
 			currency: 'AED'
-		}, null, column), -888);
-		assert.equal(getComparableValue({
+		}), -888);
+		assert.equal(getComparableValue({ rates }, {
 			amount: 491,
 			currency: 'AED'
-		}, null, column), 491);
-		assert.equal(getComparableValue({
+		}), 491);
+		assert.equal(getComparableValue({ rates }, {
 			amount: 7321,
 			currency: 'CRC'
-		}, null, column), 7321);
-		assert.equal(getComparableValue({
+		}), 7321);
+		assert.equal(getComparableValue({ rates }, {
 			amount: 901,
 			currency: 'BHD'
-		}, null, column), 901);
+		}), 901);
 	});
 
 	test('toAmount limits the value with rates', () => {

--- a/test/range-date.test.js
+++ b/test/range-date.test.js
@@ -200,10 +200,10 @@ suite('date - pure functions', () => {
 	});
 
 	test('date returns comparable values', () => {
-		assert.typeOf(getComparableValue('2023-03-21T00:00:00Z'), 'number');
-		assert.typeOf(getComparableValue(new Date('2015-03-18T00:00:00Z')), 'number');
-		assert.typeOf(getComparableValue(new Date(86400000)), 'number');
-		assert.equal(getComparableValue(new Date('2010-01-08T12:04:01Z')), 1262952241000);
+		assert.typeOf(getComparableValue({}, '2023-03-21T00:00:00Z'), 'number');
+		assert.typeOf(getComparableValue({}, new Date('2015-03-18T00:00:00Z')), 'number');
+		assert.typeOf(getComparableValue({}, new Date(86400000)), 'number');
+		assert.equal(getComparableValue({}, new Date('2010-01-08T12:04:01Z')), 1262952241000);
 	});
 
 	test('getString returns formated date with locale en-US', () => {

--- a/test/range-time.test.js
+++ b/test/range-time.test.js
@@ -155,7 +155,7 @@ suite('time - pure functions', () => {
 	});
 
 	test('time getComparableValue returns right value', () => {
-		assert.equal(getComparableValue({ time: '2015-03-18T00:00:00Z' }, 'time'), 0);
+		assert.equal(getComparableValue({ valuePath: 'time' }, { time: '2015-03-18T00:00:00Z' }), 0);
 	});
 
 	test('time _toInputString returns local ISO string', () => {

--- a/test/range.test.js
+++ b/test/range.test.js
@@ -252,10 +252,10 @@ suite('number - pure functions', () => {
 	});
 
 	test('returns the value of an item', () => {
-		assert.strictEqual(getComparableValue({ age: '13' }, 'age'), 13);
-		assert.strictEqual(getComparableValue(13), 13);
-		assert.equal(getComparableValue(data[1], 'age'), null);
-		assert.strictEqual(getComparableValue(data[2], 'age'), -11);
+		assert.strictEqual(getComparableValue({ valuePath: 'age' }, { age: '13' }), 13);
+		assert.strictEqual(getComparableValue({}, 13), 13);
+		assert.equal(getComparableValue({ valuePath: 'age' }, data[1]), null);
+		assert.strictEqual(getComparableValue({ valuePath: 'age' }, data[2]), -11);
 	});
 
 	test('getString displays 46.768 as 46.77', () => {


### PR DESCRIPTION
The signature getComparableValue(item, valuePath, column) sticks out like a sore thumb. I refactored the function so it matches the other required functions, which use f(column, item).

BREAKING CHANGE: the signature is now getComparableValue(column, item)
