### PR TITLE
fix(legacy-interop): match polymer property change events

### DIFF
--- a/lib/use-processed-items.js
+++ b/lib/use-processed-items.js
@@ -14,7 +14,7 @@ const
 
 		Object.entries(changes).forEach(([key, value]) => {
 			column[columnSymbol][key] = value;
-			column[columnSymbol].dispatchEvent(new CustomEvent(`${ kebab(key) }-changed`, { bubbles: true, value }));
+			column[columnSymbol].dispatchEvent(new CustomEvent(`${ kebab(key) }-changed`, { bubbles: true, detail: { value }}));
 		});
 	};
 


### PR DESCRIPTION
This fixes the filters not displaying suggestions bug.