### PR TITLE
fix: external values stops working after column resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,3 @@ cosmoz-omnitable
 [![Maintainability](https://api.codeclimate.com/v1/badges/6b16292868f47977eee2/maintainability)](https://codeclimate.com/github/Neovici/cosmoz-omnitable/maintainability)
 [![codecov](https://codecov.io/gh/Neovici/cosmoz-omnitable/branch/master/graph/badge.svg?token=j46iVMxjcs)](https://codecov.io/gh/Neovici/cosmoz-omnitable)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-
-
-migration TODO:
-
-* check if dropping the visibility code has any adverse effect (might be related to hash-params)
-x add legacy ots compatibility layer: dispatch filter-changed and other similar events from the columns
-* verify each custom render function in FE
-x convert DOM columns to config
-x empty columns of all state
-x hash params
-x xlsx + csv export
-* test for source
-
-FE editable columns in:
-views/administration/accounting-model/dimension-values.html.js
-views/administration/periods/list.js
-
-FE column-item-changed in:
-views/administration/periods/list.js
-
-BUGS:
-* when navigating the queue, filters are not reset when view-core is reused
-* autocomplete columns without valueProperty might not work
-* treenode cells have show-max-nodes="undefined"
-* treenode source has empty texts

--- a/lib/normalize-settings.js
+++ b/lib/normalize-settings.js
@@ -1,7 +1,6 @@
 const byName = name => item => item.name === name;
 
 export const
-	columnSymbol = Symbol('column'),
 	normalizeSettings = (columns = [], settings = [], savedSettings = []) => {
 		const
 			cols = columns.filter(column => !settings.some(byName(column.name)) && !savedSettings.some(byName(column.name))),
@@ -20,8 +19,7 @@ export const
 					return {
 						...setting,
 						title: column.title,
-						minWidth: parseInt(column.minWidth, 10),
-						[columnSymbol]: column
+						minWidth: parseInt(column.minWidth, 10)
 					};
 				}),
 			...cols.map(column => {
@@ -32,8 +30,7 @@ export const
 					priority,
 					minWidth: parseInt(minWidth, 10),
 					width: parseInt(width, 10),
-					flex: parseInt(flex, 10),
-					[columnSymbol]: column
+					flex: parseInt(flex, 10)
 				};
 			})
 		];

--- a/lib/use-dom-columns.js
+++ b/lib/use-dom-columns.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'haunted';
 import { memooize } from './memoize';
-import { columnSymbol } from './normalize-settings';
 
 const
+	columnSymbol = Symbol('column'),
 	verifyColumnSetup = columns => {
 		let ok = true;
 		const columnNames = columns.map(c => c.name);
@@ -17,7 +17,7 @@ const
 		});
 
 		columns.forEach(column => {
-			if (columnNames.indexOf(name) === columnNames.lastIndexOf(name)) {
+			if (columnNames.indexOf(column.name) === columnNames.lastIndexOf(column.name)) {
 				return;
 			}
 			ok = false;
@@ -111,27 +111,33 @@ const
 
 			[columnSymbol]: column
 		}));
+	},
+
+	useDOMColumns = (host, { enabledColumns }) => {
+		const
+			[columns, setColumns] = useState(() => domColumnsToConfig(host, { enabledColumns }));
+
+		useEffect(() => {
+			const
+				slot = host.shadowRoot.querySelector('#columnsSlot'),
+				handler = () => {
+					host.suppressNextScrollReset();
+					setColumns(domColumnsToConfig(host, { enabledColumns }));
+				};
+
+			slot.addEventListener('slotchange', handler);
+			host.addEventListener('cosmoz-column-prop-changed', handler);
+			return () => {
+				slot.removeEventListener('slotchange', handler);
+				host.removeEventListener('cosmoz-column-prop-changed', handler);
+			};
+		}, []);
+
+		return columns;
 	};
 
-export const useDOMColumns = (host, { enabledColumns }) => {
-	const
-		[columns, setColumns] = useState(() => domColumnsToConfig(host, { enabledColumns }));
 
-	useEffect(() => {
-		const
-			slot = host.shadowRoot.querySelector('#columnsSlot'),
-			handler = () => {
-				host.suppressNextScrollReset();
-				setColumns(domColumnsToConfig(host, { enabledColumns }));
-			};
-
-		slot.addEventListener('slotchange', handler);
-		host.addEventListener('cosmoz-column-prop-changed', handler);
-		return () => {
-			slot.removeEventListener('slotchange', handler);
-			host.removeEventListener('cosmoz-column-prop-changed', handler);
-		};
-	}, []);
-
-	return columns;
+export {
+	columnSymbol,
+	useDOMColumns
 };

--- a/lib/use-fast-layout.js
+++ b/lib/use-fast-layout.js
@@ -4,7 +4,6 @@ import { useResizableColumns } from './use-resizable-columns';
 import { useCanvasWidth } from './use-canvas-width';
 import { useTweenArray } from './use-tween-array';
 import { useLayout } from './use-layout';
-import { columnSymbol } from './normalize-settings';
 import { render } from 'lit-html';
 
 export const useFastLayout = ({ host, settings, setSettings, groupOnColumn, resizeSpeedFactor }) => {
@@ -12,18 +11,7 @@ export const useFastLayout = ({ host, settings, setSettings, groupOnColumn, resi
 		canvasWidth = useCanvasWidth(host),
 		layout = useLayout({ canvasWidth, groupOnColumn, config: settings }),
 		tweenedlayout = useTweenArray(layout, resizeSpeedFactor),
-		layoutCss = useMemo(() => toCss(tweenedlayout, settings), [tweenedlayout]),
-
-		collapsedColumns = useMemo(() => Array.isArray(settings)
-			? settings.reduce((acc, column, index) =>
-				layout[index] != null
-					|| column.name === groupOnColumn?.name
-					|| column.disabled
-					? acc
-					: [...acc, column[columnSymbol]],
-			[])
-			: []
-		, [settings, layout]);
+		layoutCss = useMemo(() => toCss(tweenedlayout, settings), [tweenedlayout]);
 
 	useResizableColumns({ host, canvasWidth, layout, setSettings: update => setSettings(update(settings)) });
 
@@ -46,7 +34,5 @@ export const useFastLayout = ({ host, settings, setSettings, groupOnColumn, resi
 		return () => observer.unobserve(host);
 	}, []);
 
-	return {
-		collapsedColumns
-	};
+	return layout;
 };

--- a/lib/use-omnitable.js
+++ b/lib/use-omnitable.js
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'haunted';
-import { columnSymbol, normalizeSettings } from './normalize-settings';
+import { normalizeSettings } from './normalize-settings';
 import { useProcessedItems } from './use-processed-items';
 import { useFastLayout } from './use-fast-layout';
 import { useSavedSettings } from './use-saved-settings';
@@ -21,8 +21,18 @@ export const useOmnitable = host => {
 		[settings, setSettings] = useState([]),
 		{ savedSettings, onSettingsSave, onSettingsReset, hasChangedSettings } = useSavedSettings(settingsId, settings, setSettings),
 		normalizedSettings = useMemo(() => normalizeSettings(columns, settings, savedSettings), [columns, settings, savedSettings]),
-		normalizedColumns = useMemo(() => normalizedSettings.map(s => s[columnSymbol]), [columns, ...normalizedSettings.map(s => s.name)]),
-		{ layoutCss, collapsedColumns } = useFastLayout({ host, settings: normalizedSettings, setSettings, groupOnColumn, resizeSpeedFactor }),
+		normalizedColumns = useMemo(() => normalizedSettings.map(s => columns.find(c => c.name === s.name)), [columns, ...normalizedSettings.map(s => s.name)]),
+		layout = useFastLayout({ host, settings: normalizedSettings, setSettings, groupOnColumn, resizeSpeedFactor }),
+		collapsedColumns = useMemo(() => Array.isArray(settings)
+			? settings.reduce((acc, column, index) =>
+				layout[index] != null
+					|| column.name === groupOnColumn?.name
+					|| column.disabled
+					? acc
+					: [...acc, columns.find(c => c.name === column.name)],
+			[])
+			: []
+		, [columns, settings, layout]),
 		hasHiddenFilter = useMemo(
 			() => [groupOnColumn, ...collapsedColumns, ...normalizedSettings.filter(s => s.disabled)]
 				.some(column => column && Object.keys(filterFunctions).includes(column.name)),
@@ -34,7 +44,6 @@ export const useOmnitable = host => {
 
 		...sortAndGroupOptions,
 
-		layoutCss,
 		setSettings,
 		normalizedSettings,
 		normalizedColumns,

--- a/lib/use-processed-items.js
+++ b/lib/use-processed-items.js
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from 'haunted';
 import { genericSorter } from './generic-sorter';
 import { invoke } from './invoke';
-import { columnSymbol } from './normalize-settings';
+import { columnSymbol } from './use-dom-columns';
 import { useHashState } from './use-hash-state';
 
 const

--- a/lib/use-resizable-columns.js
+++ b/lib/use-resizable-columns.js
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from 'haunted';
-import { columnSymbol } from './normalize-settings';
 
 export const useResizableColumns = ({ host, canvasWidth, layout, setSettings }) => {
 	const onColumnResizeRef = useRef();
@@ -7,7 +6,7 @@ export const useResizableColumns = ({ host, canvasWidth, layout, setSettings }) 
 	onColumnResizeRef.current = ev => setSettings(config => {
 		const
 			{ detail: { newWidth, column }} = ev,
-			columnIndex = config.findIndex(c => c[columnSymbol] === column),
+			columnIndex = config.findIndex(c => c.name === column.name),
 			newConfig = [],
 			maxPriority = config.reduce((p, c) => Math.max(p, c.priority), -Infinity);
 

--- a/lib/utils-data.js
+++ b/lib/utils-data.js
@@ -1,5 +1,5 @@
 import { get, set } from '@polymer/polymer/lib/utils/path';
-import { columnSymbol } from './normalize-settings';
+import { columnSymbol } from './use-dom-columns';
 
 export const
 	valuesFrom = (data, valuePath) => data

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -13,7 +13,7 @@ import { flush } from '@polymer/polymer/lib/utils/flush';
 import '../cosmoz-omnitable.js';
 import '../cosmoz-omnitable-columns.js';
 import '@polymer/paper-toggle-button';
-import { columnSymbol } from '../lib/normalize-settings';
+import { columnSymbol } from '../lib/use-dom-columns';
 
 sinonAssert.expose(chai.assert, { prefix: '' });
 

--- a/test/boolean.test.js
+++ b/test/boolean.test.js
@@ -10,7 +10,7 @@ import '../cosmoz-omnitable-columns.js';
 import { computeItemValue, getString, toXlsxValue, onChange, deserializeFilter } from '../cosmoz-omnitable-column-boolean';
 import { onItemChange } from '../lib/utils-data';
 import { serializeFilter } from '../cosmoz-omnitable-column-mixin';
-import { columnSymbol } from '../lib/normalize-settings';
+import { columnSymbol } from '../lib/use-dom-columns';
 
 suite('boolean', () => {
 	test('initializes boolean column', async () => {

--- a/test/integration/templatize.test.js
+++ b/test/integration/templatize.test.js
@@ -7,7 +7,7 @@ import { flush as polymerFlush } from '@polymer/polymer/lib/utils/flush';
 
 import '../../cosmoz-omnitable.js';
 import '../helpers/fixtures/basic-column.js';
-import { columnSymbol } from '../../lib/normalize-settings';
+import { columnSymbol } from '../../lib/use-dom-columns';
 
 suite('Basic omnitable functionality', () => {
 	let omnitable;

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -4,9 +4,9 @@ import { setupOmnitableFixture } from './helpers/utils';
 
 import '../cosmoz-omnitable.js';
 import '../cosmoz-omnitable-columns.js';
-import { columnSymbol } from '../lib/normalize-settings';
 import { applySingleFilter } from '../cosmoz-omnitable-column-mixin';
 import { applyMultiFilter, getString } from '../cosmoz-omnitable-column-list-mixin';
+import { columnSymbol } from '../lib/use-dom-columns';
 
 suite('basic', () => {
 	let

--- a/test/range-amount.test.js
+++ b/test/range-amount.test.js
@@ -12,8 +12,8 @@ import { flush } from '@polymer/polymer/lib/utils/flush';
 
 import '../cosmoz-omnitable.js';
 import '../cosmoz-omnitable-columns.js';
-import { columnSymbol } from '../lib/normalize-settings';
 import { getComparableValue, toAmount, renderValue, getString, getCurrency } from '../lib/utils-amount';
+import { columnSymbol } from '../lib/use-dom-columns';
 
 const data = [{
 		age: 17,

--- a/test/range-date.test.js
+++ b/test/range-date.test.js
@@ -9,9 +9,9 @@ import { flush as polymerFlush } from '@polymer/polymer/lib/utils/flush';
 
 import '../cosmoz-omnitable.js';
 import '../cosmoz-omnitable-columns.js';
-import { columnSymbol } from '../lib/normalize-settings';
 import { getComparableValue, toDate, getString } from '../lib/utils-date';
 import { toLocalISOString } from '@neovici/cosmoz-utils/lib/date';
+import { columnSymbol } from '../lib/use-dom-columns';
 
 const data = [{
 		age: 17,

--- a/test/range-time.test.js
+++ b/test/range-time.test.js
@@ -8,9 +8,9 @@ import { setupOmnitableFixture } from './helpers/utils';
 import { flush as polymerFlush } from '@polymer/polymer/lib/utils/flush';
 
 import '../cosmoz-omnitable';
-import { columnSymbol } from '../lib/normalize-settings';
 import { getComparableValue, toDate, toHashString, toInputString } from '../lib/utils-time';
 import { toLocalISOString } from '@neovici/cosmoz-utils/lib/date';
+import { columnSymbol } from '../lib/use-dom-columns';
 
 const data = [{
 		age: 17,

--- a/test/range.test.js
+++ b/test/range.test.js
@@ -12,8 +12,8 @@ import { flush } from '@polymer/polymer/lib/utils/flush';
 
 import '../cosmoz-omnitable.js';
 import '../cosmoz-omnitable-columns.js';
-import { columnSymbol } from '../lib/normalize-settings';
 import { getComparableValue, getString, toNumber } from '../lib/utils-number';
+import { columnSymbol } from '../lib/use-dom-columns';
 
 const data = [{
 		age: 17,


### PR DESCRIPTION
The bug is caused by a stale reference to the column config
object, which causes the `values` property to always be
undefined after normalizing columns. Use of
`[columnSymbol]` is confusing. It turns out that
`[columnSymbol]` was repurposed during the development of
useDOMColumns, but it actually makes more sense to keep the
new usage and drop the old one. Refactored accordingly.

Fixes https://neovici.slack.com/archives/C6LJQMJFM/p1639645068158300?thread_ts=1639645019.158200&cid=C6LJQMJFM