### PR TITLE
fix: use null for filter reset

### DIFF
--- a/cosmoz-omnitable-column.js
+++ b/cosmoz-omnitable-column.js
@@ -28,7 +28,7 @@ const
 		setState(state => ({ ...state, headerFocused: event.detail.value })),
 
 	resetFilter = setState => () =>
-		setState(state => ({ ...state, filter: undefined, inputValue: undefined })),
+		setState(state => ({ ...state, filter: null, inputValue: null })),
 
 	hasFilter = filter => filter != null && filter !== '';
 


### PR DESCRIPTION
Use null for filter reset so that Polymer trigger change notifications correctly.