### PR TITLE
fix(legacy): column.filter to internal state mapping

### DIFF
--- a/cosmoz-omnitable-column-mixin.js
+++ b/cosmoz-omnitable-column-mixin.js
@@ -27,6 +27,7 @@ export const
 				title: { type: String },
 				valuePath: { type: String, notify: true },
 				values: { type: Array, notify: true },
+				filter: { type: Object },
 				/**
 			 * If the column should be disabled until enabled with enabledColumns
 			 */
@@ -59,6 +60,21 @@ export const
 				renderEditCell: { type: Function },
 				renderGroup: { type: Function }
 			};
+		}
+
+		static get observers() {
+			return ['notifyFilterChange(filter)'];
+		}
+
+		notifyFilterChange(filter) {
+			if (this.__ownChange) {
+				return;
+			}
+			this.dispatchEvent(new CustomEvent('legacy-filter-changed', { detail: { name: this.name, state: this.legacyFilterToState(filter) }, bubbles: true }));
+		}
+
+		legacyFilterToState(filter) {
+			return { filter };
 		}
 
 		/**

--- a/cosmoz-omnitable-column.js
+++ b/cosmoz-omnitable-column.js
@@ -75,5 +75,9 @@ class OmnitableColumn extends columnMixin(PolymerElement) {
 			<cosmoz-clear-button suffix slot="suffix" ?visible=${ hasFilter(filter) } light @click=${ resetFilter(setState) }></cosmoz-clear-button>
 		</paper-input>`;
 	}
+
+	legacyFilterToState(filter) {
+		return { filter, inputValue: filter };
+	}
 }
 customElements.define('cosmoz-omnitable-column', OmnitableColumn);

--- a/lib/use-omnitable.js
+++ b/lib/use-omnitable.js
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'haunted';
+import { useCallback, useMemo, useState, useEffect } from 'haunted';
 import { normalizeSettings } from './normalize-settings';
 import { useProcessedItems } from './use-processed-items';
 import { useFastLayout } from './use-fast-layout';
@@ -73,6 +73,12 @@ export const useOmnitable = host => {
 				].some(column => column && Object.keys(filterFunctions).includes(column.name)),
 			[filterFunctions, normalizedSettings, collapsedColumns]
 		);
+
+	useEffect(() => {
+		const handler = ev => setFilterState(ev.detail.name, state => ({ ...state, ...ev.detail.state }));
+		host.addEventListener('legacy-filter-changed', handler);
+		return () => host.removeEventListener('legacy-filter-changed', handler);
+	}, []);
 
 	return {
 		columns,

--- a/lib/use-processed-items.js
+++ b/lib/use-processed-items.js
@@ -13,7 +13,9 @@ const
 		}
 
 		Object.entries(changes).forEach(([key, value]) => {
+			column[columnSymbol].__ownChange = true;
 			column[columnSymbol][key] = value;
+			column[columnSymbol].__ownChange = false;
 			column[columnSymbol].dispatchEvent(new CustomEvent(`${ kebab(key) }-changed`, { bubbles: true, detail: { value }}));
 		});
 	};


### PR DESCRIPTION
There are places where the app sets the `filter` value directly on the column. This used to work.
To make this work again, I have added some compatibility code that updates the internal filter
state when the filter prop is set by third-party code.

Fixes https://neovici.slack.com/archives/CCU2R1Q3Y/p1642752170065000
Fixes RM:27755