### PR TITLE
fix(use-hash-state): remove double encoding

### DIFF
--- a/cosmoz-omnitable-column-list-mixin.js
+++ b/cosmoz-omnitable-column-list-mixin.js
@@ -151,8 +151,7 @@ const
 		}
 
 		serializeFilter(column, filter) {
-			// TODO: drop the double-encoding
-			return filter.length === 0 ? null : encodeURIComponent(JSON.stringify(filter));
+			return filter.length === 0 ? null : JSON.stringify(filter);
 		}
 
 		deserializeFilter(column, filter) {

--- a/lib/use-hash-state.js
+++ b/lib/use-hash-state.js
@@ -40,8 +40,7 @@ const
 
 export const useHashState = (initial, param, { suffix = '', read, write, multi } = {}) => {
 	const
-		link = multi ? multiLink : singleLink,
-		parseHash = multi ? multiParse : singleParse,
+		[link, parseHash] = multi ? [multiLink, multiParse] : [singleLink, singleParse],
 		[state, _setState] = useState(() => param == null
 			? initial
 			: parseHash(param + suffix, read) ?? initial),

--- a/test/hash-param-write.test.js
+++ b/test/hash-param-write.test.js
@@ -91,7 +91,7 @@ suite('basic-write', () => {
 	test('updates location from filter', async () => {
 		omnitable.setFilterState('id', { filter: [0, 1]});
 		await nextFrame();
-		assert.equal(location.hash, '#!/#test-filter--id=%255B0%252C1%255D');
+		assert.equal(location.hash, '#!/#test-filter--id=%5B0%2C1%5D');
 
 		omnitable.setFilterState('id', { filter: null });
 		await nextFrame();


### PR DESCRIPTION
Removes the double encoding of filter params.

