### PR TITLE
fix(sort-and-group-options):  fallback descending/groupByDescending

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -134,7 +134,7 @@ class Omnitable extends hauntedPolymer(useOmnitable)(mixin({ isEmpty }, translat
 						label="[[ _('Group on', t) ]] [[ _computeSortDirection(groupOnDescending, t) ]]" placeholder="[[ _('No grouping', t) ]]"
 						source="[[ _onCompleteValues(columns, 'groupOn', groupOnColumn) ]]" value="[[ groupOnColumn ]]" limit="1" text-property="title"
 						always-float-label item-height="48" item-limit="8"
-						class="footer-control" on-change="[[ _onCompleteChange('groupOn') ]]" default-index="-1" show-single show-selection
+						class="footer-control" on-select="[[ _onCompleteChange('groupOn') ]]" default-index="-1" show-single
 					>
 						<svg slot="suffix" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false" width="24" fill="currentColor"><path d="M7 10l5 5 5-5z"></path></svg>
 					</cosmoz-autocomplete>
@@ -142,7 +142,7 @@ class Omnitable extends hauntedPolymer(useOmnitable)(mixin({ isEmpty }, translat
 						label="[[ _('Sort on', t) ]] [[ _computeSortDirection(descending, t) ]]" placeholder="[[ _('No sorting', t) ]]"
 						source="[[ _onCompleteValues(columns, 'sortOn', sortOnColumn) ]]" value="[[ sortOnColumn ]]" limit="1" text-property="title"
 						always-float-label item-height="48" item-limit="8"
-						class="footer-control" on-change="[[ _onCompleteChange('sortOn') ]]" default-index="-1" show-single show-selection
+						class="footer-control" on-select="[[ _onCompleteChange('sortOn') ]]" default-index="-1" show-single
 					>
 						<svg slot="suffix" viewBox="0 0 24 24" preserveAspectRatio="xMidYMid meet" focusable="false" width="24" fill="currentColor"><path d="M7 10l5 5 5-5z"></path></svg>
 					</cosmoz-autocomplete>
@@ -521,7 +521,7 @@ class Omnitable extends hauntedPolymer(useOmnitable)(mixin({ isEmpty }, translat
 	}
 
 	_onCompleteChange(type) {
-		return (val, close) => {
+		return (val, {setClosed}) => {
 			const value = (val[0] ?? val)?.name ?? '',
 				setter = type === 'groupOn' ? this.setGroupOn : this.setSortOn,
 				directionSetter = type === 'groupOn' ? this.setGroupOnDescending : this.setDescending;
@@ -535,7 +535,7 @@ class Omnitable extends hauntedPolymer(useOmnitable)(mixin({ isEmpty }, translat
 				return value;
 			});
 
-			value && close(); /* eslint-disable-line no-unused-expressions */
+			value && setClosed(true); /* eslint-disable-line no-unused-expressions */
 		};
 	}
 

--- a/lib/use-omnitable.js
+++ b/lib/use-omnitable.js
@@ -14,8 +14,7 @@ export const useOmnitable = host => {
 		sortAndGroupOptions = useSortAndGroupOptions(
 			columns,
 			hashParam,
-			host.sortOn,
-			host.groupOn
+			host
 		),
 		{ groupOnColumn, groupOnDescending, sortOnColumn, descending } = sortAndGroupOptions,
 		{ data, resizeSpeedFactor, settingsId } = host,

--- a/lib/use-sort-and-group-options.js
+++ b/lib/use-sort-and-group-options.js
@@ -3,14 +3,14 @@ import { useHashState } from './use-hash-state';
 
 const
 	parseBool = bool => [true, 'true', 1, 'yes', 'on'].includes(bool),
-	boolParam = p => p === '' || parseBool(p);
+	boolParam = p =>p === '' || p == null ? undefined : parseBool(p);
 
-export const useSortAndGroupOptions = (columns, hashParam, initialSortOn, initialGroupOn) => {
+export const useSortAndGroupOptions = (columns, hashParam, initial) => {
 	const
-		[sortOn, setSortOn] = useHashState(initialSortOn, hashParam, { suffix: '-sortOn' }),
-		[descending, setDescending] = useHashState(false, hashParam, { suffix: '-descending', read: boolParam }),
-		[groupOn, setGroupOn] = useHashState(initialGroupOn, hashParam, { suffix: '-groupOn' }),
-		[groupOnDescending, setGroupOnDescending] = useHashState(false, hashParam, { suffix: '-groupOnDescending', read: boolParam }),
+		[sortOn, setSortOn] = useHashState(initial.sortOn, hashParam, { suffix: '-sortOn' }),
+		[descending, setDescending] = useHashState(initial.descending, hashParam, { suffix: '-descending', read: boolParam }),
+		[groupOn, setGroupOn] = useHashState(initial.groupOn, hashParam, { suffix: '-groupOn' }),
+		[groupOnDescending, setGroupOnDescending] = useHashState(initial.groupOnDescending, hashParam, { suffix: '-groupOnDescending', read: boolParam }),
 		sortOnColumn = useMemo(() => columns.find(column => column.name === sortOn), [columns, sortOn]),
 		groupOnColumn = useMemo(() => columns.find(column => column.name === groupOn), [columns, groupOn]);
 

--- a/lib/use-sort-and-group-options.js
+++ b/lib/use-sort-and-group-options.js
@@ -1,18 +1,33 @@
 import { useMemo } from 'haunted';
 import { useHashState } from './use-hash-state';
 
-const
-	parseBool = bool => [true, 'true', 1, 'yes', 'on'].includes(bool),
-	boolParam = p =>p === '' || p == null ? undefined : parseBool(p);
+const parseBool = (bool) => [true, 'true', 1, 'yes', 'on'].includes(bool),
+	boolParam = (p) => p === '' || (p == null ? undefined : parseBool(p));
 
 export const useSortAndGroupOptions = (columns, hashParam, initial) => {
-	const
-		[sortOn, setSortOn] = useHashState(initial.sortOn, hashParam, { suffix: '-sortOn' }),
-		[descending, setDescending] = useHashState(initial.descending, hashParam, { suffix: '-descending', read: boolParam }),
-		[groupOn, setGroupOn] = useHashState(initial.groupOn, hashParam, { suffix: '-groupOn' }),
-		[groupOnDescending, setGroupOnDescending] = useHashState(initial.groupOnDescending, hashParam, { suffix: '-groupOnDescending', read: boolParam }),
-		sortOnColumn = useMemo(() => columns.find(column => column.name === sortOn), [columns, sortOn]),
-		groupOnColumn = useMemo(() => columns.find(column => column.name === groupOn), [columns, groupOn]);
+	const [sortOn, setSortOn] = useHashState(initial.sortOn, hashParam, {
+			suffix: '-sortOn',
+		}),
+		[descending, setDescending] = useHashState(initial.descending, hashParam, {
+			suffix: '-descending',
+			read: boolParam,
+		}),
+		[groupOn, setGroupOn] = useHashState(initial.groupOn, hashParam, {
+			suffix: '-groupOn',
+		}),
+		[groupOnDescending, setGroupOnDescending] = useHashState(
+			initial.groupOnDescending,
+			hashParam,
+			{ suffix: '-groupOnDescending', read: boolParam }
+		),
+		sortOnColumn = useMemo(
+			() => columns.find((column) => column.name === sortOn),
+			[columns, sortOn]
+		),
+		groupOnColumn = useMemo(
+			() => columns.find((column) => column.name === groupOn),
+			[columns, groupOn]
+		);
 
 	return {
 		groupOn,
@@ -25,6 +40,6 @@ export const useSortAndGroupOptions = (columns, hashParam, initial) => {
 		setSortOn,
 		sortOnColumn,
 		descending,
-		setDescending
+		setDescending,
 	};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "8.5.1",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@neovici/cosmoz-autocomplete": "^3.0.0",
+				"@neovici/cosmoz-autocomplete": "^3.1.0",
 				"@neovici/cosmoz-bottom-bar": "^5.0.0",
 				"@neovici/cosmoz-datetime-input": "^3.0.3",
 				"@neovici/cosmoz-dropdown": "^1.5.0",
@@ -861,9 +861,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-autocomplete": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-autocomplete/-/cosmoz-autocomplete-3.0.0.tgz",
-			"integrity": "sha512-3xb4R2IY1mzzC8tSRI6vXb2F4IBpGVrR5RKvzZARnt4gMoKryHdp+lvibLZH5cMS1NOxJEVfn6TkHjkANdUa8Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-autocomplete/-/cosmoz-autocomplete-3.1.0.tgz",
+			"integrity": "sha512-oPAodN6xXK7mSeNWaRrcU/yWEsS3/Jev0mPuENfzx6fD+ufet4xUx30uZuQp7b08kz0HgeA+GN1S151hH86l4g==",
 			"dependencies": {
 				"@neovici/cosmoz-input": "^1.5.0",
 				"@neovici/cosmoz-utils": "^3.20.0",
@@ -945,9 +945,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-utils": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-3.28.0.tgz",
-			"integrity": "sha512-D1VEyW+fPDlx931ih2/AYAndFNcX72Slb/VsFW+xyiq7uy4BkGx1m8jztVfYYr8+ccz0qRN4u3Mlyfg5TB5r6g==",
+			"version": "3.29.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-3.29.0.tgz",
+			"integrity": "sha512-EYVT9WUvu+sMLWREaY6ThkMwXbe2f1MKIMMzqNxUcJ1f1Dbk1irEn8ONENs6/rvHBUVyR/pjS6BX26eHoAM+cw==",
 			"dependencies": {
 				"haunted": "^4.8.0"
 			}
@@ -13753,9 +13753,9 @@
 			}
 		},
 		"@neovici/cosmoz-autocomplete": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-autocomplete/-/cosmoz-autocomplete-3.0.0.tgz",
-			"integrity": "sha512-3xb4R2IY1mzzC8tSRI6vXb2F4IBpGVrR5RKvzZARnt4gMoKryHdp+lvibLZH5cMS1NOxJEVfn6TkHjkANdUa8Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-autocomplete/-/cosmoz-autocomplete-3.1.0.tgz",
+			"integrity": "sha512-oPAodN6xXK7mSeNWaRrcU/yWEsS3/Jev0mPuENfzx6fD+ufet4xUx30uZuQp7b08kz0HgeA+GN1S151hH86l4g==",
 			"requires": {
 				"@neovici/cosmoz-input": "^1.5.0",
 				"@neovici/cosmoz-utils": "^3.20.0",
@@ -13837,9 +13837,9 @@
 			}
 		},
 		"@neovici/cosmoz-utils": {
-			"version": "3.28.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-3.28.0.tgz",
-			"integrity": "sha512-D1VEyW+fPDlx931ih2/AYAndFNcX72Slb/VsFW+xyiq7uy4BkGx1m8jztVfYYr8+ccz0qRN4u3Mlyfg5TB5r6g==",
+			"version": "3.29.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-3.29.0.tgz",
+			"integrity": "sha512-EYVT9WUvu+sMLWREaY6ThkMwXbe2f1MKIMMzqNxUcJ1f1Dbk1irEn8ONENs6/rvHBUVyR/pjS6BX26eHoAM+cw==",
 			"requires": {
 				"haunted": "^4.8.0"
 			}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		]
 	},
 	"dependencies": {
-		"@neovici/cosmoz-autocomplete": "^3.0.0",
+		"@neovici/cosmoz-autocomplete": "^3.1.0",
 		"@neovici/cosmoz-bottom-bar": "^5.0.0",
 		"@neovici/cosmoz-datetime-input": "^3.0.3",
 		"@neovici/cosmoz-dropdown": "^1.5.0",


### PR DESCRIPTION
Uses the `descending` and `groupByDescending` defined on the host when
the hash param are empty.
