### PR TITLE
fix(settings): close button in ios

### DIFF
--- a/lib/settings/cosmoz-omnitable-settings.js
+++ b/lib/settings/cosmoz-omnitable-settings.js
@@ -72,7 +72,14 @@ const placement = ['bottom-right', ...defaultPlacement],
 				</style>
 				<div class="headline">
 					${_('Sort and filter')}
-					<button class="close" @click=${(e) => e.currentTarget?.blur()}>
+					<button
+						class="close"
+						@click=${(e) => {
+							const tg = e.currentTarget;
+							tg?.focus();
+							tg?.blur();
+						}}
+					>
 						${close}
 					</button>
 				</div>

--- a/lib/settings/style.css.js
+++ b/lib/settings/style.css.js
@@ -17,14 +17,15 @@ export default css`
 		font-weight: 500;
 		font-size: 16px;
 		line-height: 0.95;
-		padding: 12px 14px 11px 14px;
+		padding: 10px 14px;
 		display: flex;
+		align-items: center
 	}
 	.close {
 		border: none;
 		background: none;
 		cursor: pointer;
-		padding: 0;
+		padding: 2.5px 6px;
 		margin-left: auto;
 	}
 
@@ -56,6 +57,7 @@ export default css`
 	}
 	.heading svg {
 		margin-left: auto;
+		margin-right: 4px;
 	}
 	.heading[data-opened] svg {
 		transform: scaleY(-1);
@@ -147,6 +149,7 @@ export default css`
 		padding: 14px;
 	}
 	.sg {
+		color: inherit;
 		border: 1px solid rgba(0, 0, 0, 0.2);
 		border-radius: 2px;
 		font-size: 13px;


### PR DESCRIPTION
On ios the close button must be focused and then blurred to close
omnitable settings
Fixes also small layout inconsistencies.