### PR TITLE
fix(settings): drag and drop columns on ios

### DIFF
--- a/lib/settings/use-settings-ui.js
+++ b/lib/settings/use-settings-ui.js
@@ -47,6 +47,7 @@ export default (host) => {
 				meta.handle = null;
 				e.dataTransfer.effectAllowed = 'move';
 				e.dataTransfer.setData('omnitable/sort-index', index);
+				e.dataTransfer.setData('text/plain', index);
 				setTimeout(() => target.classList.add('drag'), 0);
 				target.addEventListener(
 					'dragend',


### PR DESCRIPTION
Safari iOS requires setting some `text/plain` data in the dataTransfer to allow native HTML5 drag and drop.
