### PR TITLE
feat(settings): initial settings drivers support

### DIFF
--- a/lib/settings/drivers/context.js
+++ b/lib/settings/drivers/context.js
@@ -1,0 +1,13 @@
+import { createContext, useContext, useMemo } from 'haunted';
+import local from './local';
+
+export const DriverContext = createContext(local),
+	useDriver = () => {
+		const driver = useContext(DriverContext);
+		return useMemo(() => driver(), [driver]);
+	},
+	registerProvider = () =>
+		customElements.define(
+			'omnitable-settings-driver-provider',
+			DriverContext.Provider
+		);

--- a/lib/settings/drivers/index.js
+++ b/lib/settings/drivers/index.js
@@ -1,0 +1,3 @@
+export * from './context';
+export { default as local } from './local';
+export { default as remote } from './remote';

--- a/lib/settings/drivers/local.js
+++ b/lib/settings/drivers/local.js
@@ -1,0 +1,29 @@
+export default ({ prefix = 'omnitable-' } = {}) => {
+	const read = async (settingsId) => {
+		if (!settingsId) {
+			return;
+		}
+		try {
+			return JSON.parse(localStorage.getItem(prefix + settingsId));
+		} catch (e) {
+			// eslint-disable-next-line no-console
+			console.error(e);
+		}
+	};
+	return {
+		write: async (settingsId, settings) => {
+			const key = prefix + settingsId;
+			try {
+				if (settings) {
+					localStorage.setItem(key, JSON.stringify(settings));
+				} else {
+					localStorage.removeItem(key);
+				}
+			} catch (e) {
+				// eslint-disable-next-line no-console
+				console.error(e);
+			}
+		},
+		read,
+	};
+};

--- a/lib/settings/drivers/remote.js
+++ b/lib/settings/drivers/remote.js
@@ -1,9 +1,9 @@
 export default ({ prefix = '', get$, post$ } = {}) => {
 	const read = async (settingsId) => {
 		try {
-			// eslint-disable-next-line no-console
 			return await get$(prefix + settingsId);
 		} catch (e) {
+			// eslint-disable-next-line no-console
 			console.error(e);
 		}
 	};

--- a/lib/settings/drivers/remote.js
+++ b/lib/settings/drivers/remote.js
@@ -1,19 +1,19 @@
-export default ({ storagePrefix = 'omnitable-', get$, post$ } = {}) => {
+export default ({ prefix = '', get$, post$ } = {}) => {
 	const read = async (settingsId) => {
 		if (!settingsId) {
 			return [];
 		}
 		try {
-			await get$(settingsId);
+			await get$(prefix + settingsId);
 		} catch (e) {
 			return [];
 		}
 	};
 	return {
 		write: async (settingsId, settings) => {
-			const key = storagePrefix + settingsId;
+			const key = prefix + settingsId;
 			try {
-				await post$(key, settings)
+				await post$(key, settings);
 			} catch (e) {
 				// eslint-disable-next-line no-console
 				console.error(e);

--- a/lib/settings/drivers/remote.js
+++ b/lib/settings/drivers/remote.js
@@ -1,0 +1,24 @@
+export default ({ storagePrefix = 'omnitable-', get$, post$ } = {}) => {
+	const read = async (settingsId) => {
+		if (!settingsId) {
+			return [];
+		}
+		try {
+			await get$(settingsId);
+		} catch (e) {
+			return [];
+		}
+	};
+	return {
+		write: async (settingsId, settings) => {
+			const key = storagePrefix + settingsId;
+			try {
+				await post$(key, settings)
+			} catch (e) {
+				// eslint-disable-next-line no-console
+				console.error(e);
+			}
+		},
+		read,
+	};
+};

--- a/lib/settings/drivers/remote.js
+++ b/lib/settings/drivers/remote.js
@@ -1,12 +1,10 @@
 export default ({ prefix = '', get$, post$ } = {}) => {
 	const read = async (settingsId) => {
-		if (!settingsId) {
-			return [];
-		}
 		try {
-			await get$(prefix + settingsId);
+			// eslint-disable-next-line no-console
+			return await get$(prefix + settingsId);
 		} catch (e) {
-			return [];
+			console.error(e);
 		}
 	};
 	return {

--- a/lib/settings/use-saved-settings.js
+++ b/lib/settings/use-saved-settings.js
@@ -1,62 +1,44 @@
-import { useCallback, useMemo, useState } from 'haunted';
+import { useCallback, useEffect, useState } from 'haunted';
 import { normalizeStore } from './normalize';
+import {useDriver} from './drivers';
 
-const storagePrefix = 'omnitable-',
-	read = (settingsId) => {
-		if (!settingsId) {
-			return [];
-		}
-		try {
-			return JSON.parse(localStorage.getItem(storagePrefix + settingsId)) ?? [];
-		} catch (e) {
-			return [];
-		}
-	};
 // eslint-disable-next-line max-lines-per-function
 export default (settingsId, settings, setSettings, onReset) => {
-	const [counter, setCounter] = useState(0),
-		savedSettings = useMemo(() => read(settingsId), [settingsId, counter]);
+	const [savedSettings, setSavedSettings] = useState(),
+		{read, write} = useDriver();
+
+	useEffect(async () => {
+		if (!settingsId) {
+			return;
+		}
+		setSavedSettings(await read(settingsId));
+	}, [settingsId]);
 
 	return {
 		settingsId,
 		savedSettings,
 
-		onSave: useCallback(() => {
+		onSave: useCallback(async () => {
 			if (!settingsId) {
 				return;
 			}
-
-			try {
-				const current = read(settingsId);
-				localStorage.setItem(
-					storagePrefix + settingsId,
-					JSON.stringify(normalizeStore(settings, current))
-				);
-				setSettings();
-				setCounter((counter) => counter + 1);
-			} catch (e) {
-				// eslint-disable-next-line no-console
-				console.error(e);
-			}
-		}, [settings]),
+			const newSettings = normalizeStore(settings, savedSettings);
+			await write(settingsId, newSettings);
+			setSettings();
+			setSavedSettings(newSettings);
+		}, [settings, savedSettings]),
 
 		onReset: useCallback(
-			(e) => {
+			async (e) => {
 				setSettings();
-
 				if (e.shiftKey) {
-					try {
-						localStorage.removeItem(storagePrefix + settingsId);
-						setCounter((counter) => counter + 1);
-					} catch (err) {
-						// ignore error
-					}
+					await write(settingsId);
+					setSavedSettings();
 				}
 				onReset?.();
 			},
 			[onReset]
 		),
-
 		hasChanges: settings != null,
 	};
 };

--- a/lib/settings/use-saved-settings.js
+++ b/lib/settings/use-saved-settings.js
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from 'haunted';
 import { normalizeStore } from './normalize';
-import {useDriver} from './drivers';
+import { useDriver } from './drivers';
 
 // eslint-disable-next-line max-lines-per-function
 export default (settingsId, settings, setSettings, onReset) => {
 	const [savedSettings, setSavedSettings] = useState(),
-		{read, write} = useDriver();
+		{ read, write } = useDriver();
 
 	useEffect(async () => {
 		if (!settingsId) {

--- a/lib/settings/use-saved-settings.js
+++ b/lib/settings/use-saved-settings.js
@@ -12,7 +12,7 @@ export default (settingsId, settings, setSettings, onReset) => {
 			return;
 		}
 		setSavedSettings(await read(settingsId));
-	}, [settingsId]);
+	}, [settingsId, read]);
 
 	return {
 		settingsId,


### PR DESCRIPTION
Allow passing different omnitable settings drivers via context.
Adds 2 drivers:
 1. local  - saves and reads data from localStorage
 2. remote - save and reads data via get$ & post$ fns

