### PR TITLE
fix(use-settings): error when removing columns

### DIFF
--- a/lib/settings/use-settings.js
+++ b/lib/settings/use-settings.js
@@ -33,9 +33,9 @@ export default ({ settingsId, initial: ini, ...thru }) => {
 		),
 		normalizedColumns = useMemo(
 			() =>
-				normalizedSettings.columns.map((s) =>
-					columns.find((c) => c.name === s.name)
-				),
+				normalizedSettings.columns
+					.map((s) => columns.find((c) => c.name === s.name))
+					.filter(Boolean),
 			[columns, ...normalizedSettings.columns.map((s) => s.name)]
 		);
 


### PR DESCRIPTION
An error occurs when columns with custom settings (size, order, etc) are dropped from the columns list.

Fixes https://neovici.slack.com/archives/C6LJQMJFM/p1664996455187809?thread_ts=1664913886.064969&cid=C6LJQMJFM