### PR TITLE
fix: selected-items-changed is sent too late

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -24,6 +24,7 @@ import { component } from 'haunted';
 import { renderHeader } from './lib/render-header';
 import { renderFooter } from './lib/render-footer';
 import { renderList } from './lib/render-list';
+import { notifyProperty } from '@neovici/cosmoz-utils/hooks/use-notify-property';
 
 const Omnitable = (host) => {
 	const { header, list, footer } = useOmnitable(host);
@@ -48,9 +49,23 @@ const Omnitable = (host) => {
 
 customElements.define(
 	'cosmoz-omnitable',
-	component(Omnitable, {
-		observedAttributes: ['hash-param', 'sort-on', 'group-on', 'hide-select-all'],
-	})
+	class extends component(Omnitable, {
+		observedAttributes: [
+			'hash-param',
+			'sort-on',
+			'group-on',
+			'hide-select-all',
+		],
+	}) {
+		connectedCallback() {
+			super.connectedCallback();
+			notifyProperty(this, 'selectedItems', []);
+			notifyProperty(this, 'visibleData', []);
+			notifyProperty(this, 'sortedFilteredGroupedItems', []);
+			notifyProperty(this, 'sortOn', '');
+			notifyProperty(this, 'descending', false);
+		}
+	}
 );
 
 const tmplt = `

--- a/test/hash-param-read.test.js
+++ b/test/hash-param-read.test.js
@@ -50,14 +50,14 @@ suite('basic-read', () => {
 		location.hash = '#!/#test-sortOn=id';
 		await instantiate();
 		assert.equal(omnitable.sortOn, 'id');
-		assert.isUndefined(omnitable.descending);
+		assert.isFalse(omnitable.descending);
 	});
 
 	test('updates groupOn from url hash', async () => {
 		location.hash = '#!/#test-groupOn=group';
 		await instantiate();
 		assert.equal(omnitable.groupOn, 'group');
-		assert.isUndefined(omnitable.descending);
+		assert.isFalse(omnitable.descending);
 
 	});
 


### PR DESCRIPTION
This breaks Polymer views using two-way data-binding to read selectedItems.

Fixes https://neovici.slack.com/archives/C0515MVB8/p1666854100493349