### PR TITLE
feat: don't init notify sort/descending

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -62,8 +62,6 @@ customElements.define(
 			notifyProperty(this, 'selectedItems', []);
 			notifyProperty(this, 'visibleData', []);
 			notifyProperty(this, 'sortedFilteredGroupedItems', []);
-			notifyProperty(this, 'sortOn', '');
-			notifyProperty(this, 'descending', false);
 		}
 	}
 );

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -239,6 +239,7 @@ suite('render header function', () => {
 	});
 
 	test('custom headers can set filters', async () => {
+		await nextFrame();
 		assert.isFalse(getRows().every(row => parseInt(row.textContent.replace(',', ''), 10) >= 9000));
 
 		await toggle();

--- a/test/hash-param-read.test.js
+++ b/test/hash-param-read.test.js
@@ -50,14 +50,14 @@ suite('basic-read', () => {
 		location.hash = '#!/#test-sortOn=id';
 		await instantiate();
 		assert.equal(omnitable.sortOn, 'id');
-		assert.isFalse(omnitable.descending);
+		assert.isUndefined(omnitable.descending);
 	});
 
 	test('updates groupOn from url hash', async () => {
 		location.hash = '#!/#test-groupOn=group';
 		await instantiate();
 		assert.equal(omnitable.groupOn, 'group');
-		assert.isFalse(omnitable.descending);
+		assert.isUndefined(omnitable.descending);
 
 	});
 


### PR DESCRIPTION
We don't need to notify sort/descending on init.