### PR TITLE
fix(styles): shim styles

### DIFF
--- a/cosmoz-omnitable.js
+++ b/cosmoz-omnitable.js
@@ -18,6 +18,7 @@ import styles from './cosmoz-omnitable-styles';
 
 import { html as polymerHtml } from '@polymer/polymer/lib/utils/html-tag';
 import { html } from 'lit-html';
+import { guard } from 'lit-html/directives/guard.js';
 
 import { useOmnitable } from './lib/use-omnitable';
 import { component } from 'haunted';
@@ -26,12 +27,14 @@ import { renderFooter } from './lib/render-footer';
 import { renderList } from './lib/render-list';
 import { notifyProperty } from '@neovici/cosmoz-utils/hooks/use-notify-property';
 
+const shimCSS = (s) => window.ShadyCSS?.ApplyShim?.transformCssText?.(s) || s;
+
 const Omnitable = (host) => {
 	const { header, list, footer } = useOmnitable(host);
 
 	return html`
 		<style>
-			${styles}
+			${guard([], () => shimCSS(styles))}
 		</style>
 		<div id="layoutStyle"></div>
 

--- a/lib/polymer-haunted-render-mixin.js
+++ b/lib/polymer-haunted-render-mixin.js
@@ -1,4 +1,3 @@
-
 import { html } from '@polymer/polymer';
 import { render } from 'lit-html';
 


### PR DESCRIPTION
Fix CSS not having Shaddy css shim applied.

Note: We should replace most Polymer components and drop the shim requirements.
Without it  content is not properly styled in some cases. 