### PR TITLE
CSS Vars reset in Omnitable Header styling

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -132,25 +132,24 @@ export default css`
 			--paper-font-caption_-_line-height: 18px;
 		}
 		--paper-font-subhead_-_font-family: var(
-			--cosmoz-omnitable-header-font-family,
-			'Inter' sans-serif
+			--cosmoz-omnitable-header-font-family, 'Roboto', 'Noto', sans-serif
 		);
-		text-transform: var(--cosmoz-omnitable-header-text-transform, uppercase);
+		text-transform: var(--cosmoz-omnitable-header-text-transform, none);
 		--paper-font-subhead_-_font-weight: var(
 			--cosmoz-omnitable-header-font-weight,
-			bold
+			normal
 		);
 		--paper-font-subhead_-_font-size: var(
 			--cosmoz-omnitable-header-font-size,
-			14pt
+			16px
 		);
 	}
 
 	cosmoz-autocomplete-ui::part(input-label) {
-		text-transform: var(--cosmoz-omnitable-header-text-transform, uppercase);
-		font-weight: var(--cosmoz-omnitable-header-font-weight, bold);
-		font-family: var(--cosmoz-omnitable-header-font-family, 'Inter' sans-serif);
-		font-size: var(--cosmoz-omnitable-header-font-size, 14pt);
+		text-transform: var(--cosmoz-omnitable-header-text-transform, none);
+		font-weight: var(--cosmoz-omnitable-header-font-weight, normal);
+		font-family: var(--cosmoz-omnitable-header-font-family, 'Roboto', 'Noto', sans-serif);
+		font-size: var(--cosmoz-omnitable-header-font-size, 16px);
 	}
 	cosmoz-omnitable-header-row {
 		white-space: nowrap;


### PR DESCRIPTION
Re [AB#9162](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/9162) - Follow-up of a previous [pull request](https://github.com/Neovici/cosmoz-omnitable/pull/564)- the styling settings in the omnitable folder are reset to previous defaults, but they are made modifiable with the usage of CSS vars.

The screenshot shows the desired outcome:
![image](https://user-images.githubusercontent.com/122988480/220286518-2bc3e256-115b-4d38-92f1-cc0468be1bdd.png)
