### PR TITLE
fix(omnitable-column): link styling updated

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -85,10 +85,9 @@ export default css`
 	}
 	:host a {
 		color: var(--primary-link-color, inherit);
-		text-decoration: var(--cosmoz-omnitable-link-decoration, underline);
+		text-decoration: var(--cosmoz-omnitable-link-decoration, none);
 	}
 	:host a:hover {
-		color: var(--primary-link-color, inherit);
 		text-decoration: var(--cosmoz-omnitable-link-decoration, underline);
 	}
 	/* The wrapping div that contains the header, the table content and the footer */
@@ -136,7 +135,10 @@ export default css`
 			--paper-font-caption_-_line-height: 18px;
 		}
 		--paper-font-subhead_-_font-family: var(
-			--cosmoz-omnitable-header-font-family, 'Roboto', 'Noto', sans-serif
+			--cosmoz-omnitable-header-font-family,
+			'Roboto',
+			'Noto',
+			sans-serif
 		);
 		text-transform: var(--cosmoz-omnitable-header-text-transform, none);
 		--paper-font-subhead_-_font-weight: var(
@@ -152,7 +154,12 @@ export default css`
 	cosmoz-autocomplete-ui::part(input-label) {
 		text-transform: var(--cosmoz-omnitable-header-text-transform, none);
 		font-weight: var(--cosmoz-omnitable-header-font-weight, normal);
-		font-family: var(--cosmoz-omnitable-header-font-family, 'Roboto', 'Noto', sans-serif);
+		font-family: var(
+			--cosmoz-omnitable-header-font-family,
+			'Roboto',
+			'Noto',
+			sans-serif
+		);
 		font-size: var(--cosmoz-omnitable-header-font-size, 16px);
 	}
 	cosmoz-omnitable-header-row {

--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -85,9 +85,10 @@ export default css`
 	}
 	:host a {
 		color: var(--primary-link-color, inherit);
-		text-decoration: var(--cosmoz-omnitable-link-decoration, none);
+		text-decoration: var(--cosmoz-omnitable-link-decoration, underline);
 	}
 	:host a:hover {
+		color: var(--primary-link-color, inherit);
 		text-decoration: var(--cosmoz-omnitable-link-decoration, underline);
 	}
 	/* The wrapping div that contains the header, the table content and the footer */
@@ -135,10 +136,7 @@ export default css`
 			--paper-font-caption_-_line-height: 18px;
 		}
 		--paper-font-subhead_-_font-family: var(
-			--cosmoz-omnitable-header-font-family,
-			'Roboto',
-			'Noto',
-			sans-serif
+			--cosmoz-omnitable-header-font-family, 'Roboto', 'Noto', sans-serif
 		);
 		text-transform: var(--cosmoz-omnitable-header-text-transform, none);
 		--paper-font-subhead_-_font-weight: var(
@@ -154,12 +152,7 @@ export default css`
 	cosmoz-autocomplete-ui::part(input-label) {
 		text-transform: var(--cosmoz-omnitable-header-text-transform, none);
 		font-weight: var(--cosmoz-omnitable-header-font-weight, normal);
-		font-family: var(
-			--cosmoz-omnitable-header-font-family,
-			'Roboto',
-			'Noto',
-			sans-serif
-		);
+		font-family: var(--cosmoz-omnitable-header-font-family, 'Roboto', 'Noto', sans-serif);
 		font-size: var(--cosmoz-omnitable-header-font-size, 16px);
 	}
 	cosmoz-omnitable-header-row {

--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -90,7 +90,6 @@ export default css`
 	:host a:hover {
 		text-decoration: var(--cosmoz-omnitable-link-decoration, underline);
 	}
-	/* The wrapping div that contains the header, the table content and the footer */
 	.mainContainer {
 		background-color: #fff;
 		display: flex;


### PR DESCRIPTION
Feature [AB#9329](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/9329) - the underline on omnitable links is now visible only on hovering.