### PR TITLE
fix: added a minimum width to the status columns

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -53,9 +53,7 @@ const checkbox = css`
 	}
 
 	.checkbox:hover {
-		box-shadow:
-			0 0 0 2px rgba(0, 0, 0, 1) inset,
-			0 0 2px 6px #2021240f;
+		box-shadow: 0 0 0 2px rgba(0, 0, 0, 1) inset, 0 0 2px 6px #2021240f;
 	}
 
 	.checkbox:checked:hover {
@@ -521,5 +519,10 @@ export default css`
 	.header-cell :not(.sg) {
 		min-width: 0;
 		flex: auto;
+	}
+
+	[name='status'],
+	[name='invoiceStatus'] {
+		min-width: var(--cosmoz-status-min-width, 50px);
 	}
 `;


### PR DESCRIPTION
Feature AB#10366 - set a minimum width for the status columns in omnitable. 
![image](https://github.com/Neovici/cosmoz-omnitable/assets/122988480/e1e117f7-1d05-4d61-b113-addb370d6b0c)
