### PR TITLE
fix(xlsx): error when date is malformed

### DIFF
--- a/lib/utils-date.js
+++ b/lib/utils-date.js
@@ -187,6 +187,9 @@ export const
 			return '';
 		}
 		const localDate = toDate(toLocalISOString(date));
+		if (!localDate) {
+			return '';
+		}
 		localDate.setHours(0, 0, 0, 0);
 		return localDate;
 	},


### PR DESCRIPTION
Encountered error when trying to export xlsx with 1/1/1 dates.