### PR TITLE
fix(dependencies): new inputs needed in all their instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@neovici/cosmoz-dropdown": "^4.0.0",
 				"@neovici/cosmoz-grouped-list": "^8.0.0",
 				"@neovici/cosmoz-i18next": "^3.1.1",
-				"@neovici/cosmoz-input": "^4.0.0",
+				"@neovici/cosmoz-input": "^5.0.0",
 				"@neovici/cosmoz-router": "^11.0.0",
 				"@neovici/cosmoz-utils": "^6.5.0",
 				"@neovici/nullxlsx": "^3.0.0",
@@ -1143,6 +1143,16 @@
 				"lit-html": "^2.0.0 || ^3.0.0"
 			}
 		},
+		"node_modules/@neovici/cosmoz-autocomplete/node_modules/@neovici/cosmoz-input": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.3.3.tgz",
+			"integrity": "sha512-UZZxQ7QMV19nYUM5YuwSanD3GdCF1YrKCCzsoJFmCTrBRrdkRV/alrb1n65jmiVfOuPIEpEESiAJYJEKiQPPgg==",
+			"dependencies": {
+				"@neovici/cosmoz-utils": "^6.0.0",
+				"@pionjs/pion": "^2.0.0",
+				"lit-html": "^2.0.0 || ^3.0.0"
+			}
+		},
 		"node_modules/@neovici/cosmoz-bottom-bar": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-bottom-bar/-/cosmoz-bottom-bar-7.0.0.tgz",
@@ -1166,6 +1176,16 @@
 				"@neovici/cosmoz-input": "^4.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0"
+			}
+		},
+		"node_modules/@neovici/cosmoz-datetime-input/node_modules/@neovici/cosmoz-input": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.3.3.tgz",
+			"integrity": "sha512-UZZxQ7QMV19nYUM5YuwSanD3GdCF1YrKCCzsoJFmCTrBRrdkRV/alrb1n65jmiVfOuPIEpEESiAJYJEKiQPPgg==",
+			"dependencies": {
+				"@neovici/cosmoz-utils": "^6.0.0",
+				"@pionjs/pion": "^2.0.0",
+				"lit-html": "^2.0.0 || ^3.0.0"
 			}
 		},
 		"node_modules/@neovici/cosmoz-dropdown": {
@@ -1199,9 +1219,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-input": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.0.0.tgz",
-			"integrity": "sha512-c0ZkxOAOm3wPT9LEUAitNc7+a/meW3yhxGZrqDaLmodqcw7lIXRNZpiMN4E+ekdxHuq3RViM1TrWTUwqhiCxyA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-5.0.0.tgz",
+			"integrity": "sha512-/VgXn27TJ/dPJd3aUoyoso6NIMr4Q6duWR4chxPTc5m70g9fHLB1fTO7/Ph9rUYejYRNUZZ4ie+pNfTl0Cbneg==",
 			"dependencies": {
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
 			"version": "13.2.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@neovici/cosmoz-autocomplete": "^8.0.0",
+				"@neovici/cosmoz-autocomplete": "^8.7.1",
 				"@neovici/cosmoz-bottom-bar": "^7.0.0",
 				"@neovici/cosmoz-collapse": "^1.1.0",
-				"@neovici/cosmoz-datetime-input": "^4.0.0",
+				"@neovici/cosmoz-datetime-input": "^4.0.1",
 				"@neovici/cosmoz-dropdown": "^4.0.0",
 				"@neovici/cosmoz-grouped-list": "^8.0.0",
 				"@neovici/cosmoz-i18next": "^3.1.1",
@@ -1131,23 +1131,13 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-autocomplete": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-autocomplete/-/cosmoz-autocomplete-8.0.0.tgz",
-			"integrity": "sha512-JjYp+kZ3eB0y1lQhnh4zapDld8HNUZkqs7OqyG16SdT0WvPOmq8MAgbMGbVu+suj1IUg/VWqaQVjb8xeS6JbfQ==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-autocomplete/-/cosmoz-autocomplete-8.7.1.tgz",
+			"integrity": "sha512-HuNh5eGVsJbv3+Peg+Gj1Ifoo2IT2WpvV1qlpprMxJ68oXqJ5HG5FKJGhHacnJQCOTpBmM05vnCJgHy0vVGi1Q==",
 			"dependencies": {
 				"@lit-labs/virtualizer": "^2.0.0",
-				"@neovici/cosmoz-dropdown": "^4.0.0",
-				"@neovici/cosmoz-input": "^4.0.0",
-				"@neovici/cosmoz-utils": "^6.0.0",
-				"@pionjs/pion": "^2.0.0",
-				"lit-html": "^2.0.0 || ^3.0.0"
-			}
-		},
-		"node_modules/@neovici/cosmoz-autocomplete/node_modules/@neovici/cosmoz-input": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.3.3.tgz",
-			"integrity": "sha512-UZZxQ7QMV19nYUM5YuwSanD3GdCF1YrKCCzsoJFmCTrBRrdkRV/alrb1n65jmiVfOuPIEpEESiAJYJEKiQPPgg==",
-			"dependencies": {
+				"@neovici/cosmoz-dropdown": "^4.4.0",
+				"@neovici/cosmoz-input": "^5.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0",
 				"lit-html": "^2.0.0 || ^3.0.0"
@@ -1169,33 +1159,24 @@
 			"integrity": "sha512-m+FMz2WW9RYrkBILNA5EE+CDTvo+YqxR7fvZb62Qab9bFScJwTxk/DbmMEL/Dsawr76YjrIfX76Z5DcvEZ468w=="
 		},
 		"node_modules/@neovici/cosmoz-datetime-input": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-datetime-input/-/cosmoz-datetime-input-4.0.0.tgz",
-			"integrity": "sha512-9TI7dx5IULZqegknugCLhfwLnsFPuTl7hFpNW2i6JSeVZqw/8EWQkOodXrb+rs6ecCl9JD8dsqSkxN9EqFk69Q==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-datetime-input/-/cosmoz-datetime-input-4.0.1.tgz",
+			"integrity": "sha512-8btpNJqTqkKEwCBwjXNThQFurvABJv/WsX86osN7m0RE9UYwY8Ndxrq/jdkL73705Vc2vdelP1C5hLh/faFq7A==",
 			"dependencies": {
-				"@neovici/cosmoz-input": "^4.0.0",
+				"@neovici/cosmoz-input": "^5.0.0",
 				"@neovici/cosmoz-utils": "^6.0.0",
 				"@pionjs/pion": "^2.0.0"
 			}
 		},
-		"node_modules/@neovici/cosmoz-datetime-input/node_modules/@neovici/cosmoz-input": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-input/-/cosmoz-input-4.3.3.tgz",
-			"integrity": "sha512-UZZxQ7QMV19nYUM5YuwSanD3GdCF1YrKCCzsoJFmCTrBRrdkRV/alrb1n65jmiVfOuPIEpEESiAJYJEKiQPPgg==",
-			"dependencies": {
-				"@neovici/cosmoz-utils": "^6.0.0",
-				"@pionjs/pion": "^2.0.0",
-				"lit-html": "^2.0.0 || ^3.0.0"
-			}
-		},
 		"node_modules/@neovici/cosmoz-dropdown": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-dropdown/-/cosmoz-dropdown-4.0.0.tgz",
-			"integrity": "sha512-Wsnst+JFB1giIhUPuHrnTiN2eIozMBx4icnJWaPMxwrKE+CQAWLdfMOQ9FTVTIIjR8QCurJUqT2zYP8ASmVS+w==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-dropdown/-/cosmoz-dropdown-4.4.0.tgz",
+			"integrity": "sha512-OV2w2mhlFQmGCufxTVlO59R9KeU/bln6iY4ml986VTaXa0OIaO8zF2JtwHNiL3KZP6pr8UTSdzMB6XEvCcauJg==",
 			"dependencies": {
-				"@neovici/cosmoz-utils": "^6.0.0",
-				"@pionjs/pion": "^2.0.0",
-				"position.js": "^0.3.0"
+				"@neovici/cosmoz-utils": "^6.8.1",
+				"@pionjs/pion": "^2.5.2",
+				"lit-html": "^3.1.2",
+				"position.js": "^1.1.0"
 			}
 		},
 		"node_modules/@neovici/cosmoz-grouped-list": {
@@ -1237,9 +1218,9 @@
 			}
 		},
 		"node_modules/@neovici/cosmoz-utils": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-6.5.0.tgz",
-			"integrity": "sha512-JADH1RKYhcKpH1N2MGraX53E2mmXcNqHOaqaXwa2koLvOzKMAPdH8AjmlErnkxvWfGRPEE41L6ondj3DhWIkBQ==",
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-6.8.1.tgz",
+			"integrity": "sha512-scJI3CWAB0qImeukSOxJXgKGCD54h39tYPm9mMYecog8cmlpUjl0my53MTLufz+KX0NrYeio4fu2i+esgoDkVg==",
 			"dependencies": {
 				"@pionjs/pion": "^2.0.0"
 			}
@@ -11919,9 +11900,9 @@
 			}
 		},
 		"node_modules/position.js": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/position.js/-/position.js-0.3.0.tgz",
-			"integrity": "sha512-dPTc3vxorMzXDViK8mTL5ShqLKGNr3pjdbbiq+6Pud1sVCD/SMuGV/UtQ/acg0gsgJHGg5RxUwtd0v2U4rXBjQ=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/position.js/-/position.js-1.1.0.tgz",
+			"integrity": "sha512-h/GJiK6nxrZOhmLgUYfGZhjvbpuocyL55Ggv8+k4BR/RHqmXGVIHwhYMeZh+J8HfXNLUtr2RbjOK+4LpTwV7vg=="
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -59,10 +59,10 @@
 		}
 	},
 	"dependencies": {
-		"@neovici/cosmoz-autocomplete": "^8.0.0",
+		"@neovici/cosmoz-autocomplete": "^8.7.1",
 		"@neovici/cosmoz-bottom-bar": "^7.0.0",
 		"@neovici/cosmoz-collapse": "^1.1.0",
-		"@neovici/cosmoz-datetime-input": "^4.0.0",
+		"@neovici/cosmoz-datetime-input": "^4.0.1",
 		"@neovici/cosmoz-dropdown": "^4.0.0",
 		"@neovici/cosmoz-grouped-list": "^8.0.0",
 		"@neovici/cosmoz-i18next": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"@neovici/cosmoz-dropdown": "^4.0.0",
 		"@neovici/cosmoz-grouped-list": "^8.0.0",
 		"@neovici/cosmoz-i18next": "^3.1.1",
-		"@neovici/cosmoz-input": "^4.0.0",
+		"@neovici/cosmoz-input": "^5.0.0",
 		"@neovici/cosmoz-router": "^11.0.0",
 		"@neovici/cosmoz-utils": "^6.5.0",
 		"@neovici/nullxlsx": "^3.0.0",


### PR DESCRIPTION
About Feature [AB#11519](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/11519) - latest cosmoz-input release (v5.0.0) needs to be installed in all the components using it.