### PR TITLE
fix(mini): check for null and undefined mini attribute

### DIFF
--- a/lib/use-mini.js
+++ b/lib/use-mini.js
@@ -10,11 +10,12 @@ export const useMini = ({ host, canvasWidth, columns: _columns }) => {
 		() =>
 			isMiniSize
 				? _columns
-						?.filter((c) => c.mini !== null)
+						?.filter((c) => c.mini != null)
 						.sort((a, b) => (a.mini ?? 0) - (b.mini ?? 0))
 				: [],
 		[_columns, isMiniSize],
 	);
+
 	const [miniColumn, ...miniColumns] = columns ?? [];
 
 	useEffect(() => {


### PR DESCRIPTION
Check for null and undefined mini attribute when checking if a column is
enabled in mini mode.
