### PR TITLE
fix: boolean initial descending and groupDescending

### DIFF
--- a/lib/use-sort-and-group-options.js
+++ b/lib/use-sort-and-group-options.js
@@ -31,7 +31,7 @@ export const useSortAndGroupOptions = (
 				suffix: '-sortOn',
 			}),
 			[descending, setDescending] = useHashState(
-				settings.descending,
+				boolParam(settings.descending),
 				hashParam,
 				{
 					suffix: '-descending',
@@ -42,7 +42,7 @@ export const useSortAndGroupOptions = (
 				suffix: '-groupOn',
 			}),
 			[groupOnDescending, setGroupOnDescending] = useHashState(
-				settings.groupOnDescending,
+				boolParam(settings.groupOnDescending),
 				hashParam,
 				{ suffix: '-groupOnDescending', read: boolParam },
 			),


### PR DESCRIPTION
Pipe `initial` value thru `read` to make sure we encode it correctly.
