### PR TITLE
fix: emit event for when mini table is used

### DIFF
--- a/lib/use-omnitable.js
+++ b/lib/use-omnitable.js
@@ -60,6 +60,7 @@ export const useOmnitable = (host) => {
 		filters,
 		setFilterState,
 		selectedItems,
+		isMini,
 		...sortAndGroupOptions,
 	});
 

--- a/lib/use-public-interface.js
+++ b/lib/use-public-interface.js
@@ -87,20 +87,21 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 	useNotifyProperty('visibleData', visibleData);
 	useNotifyProperty(
 		'sortedFilteredGroupedItems',
-		api.sortedFilteredGroupedItems
+		api.sortedFilteredGroupedItems,
 	);
 	useNotifyProperty('selectedItems', api.selectedItems);
 	useNotifyProperty('sortOn', api.sortOn);
 	useNotifyProperty('descending', api.descending);
+	useNotifyProperty('isMini', api.isMini);
 
 	const filterValues = useMemo(
 		() =>
 			Object.fromEntries(
 				Object.entries(filters)
 					.filter(([, { filter }]) => filter !== undefined)
-					.map(([key, { filter }]) => [key, filter])
+					.map(([key, { filter }]) => [key, filter]),
 			),
-		[filters]
+		[filters],
 	);
 
 	useNotifyProperty('filters', filterValues, Object.values(filterValues));


### PR DESCRIPTION
Emit event with useNotifyProperty for when mini table is used.

[AB#17737](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/17737/)