### PR TITLE
fix(footer): remove unused logic for setting max toolbar items

### DIFF
--- a/lib/render-footer.js
+++ b/lib/render-footer.js
@@ -4,7 +4,6 @@ import { saveAsCsvAction } from './save-as-csv-action';
 import { saveAsXlsxAction } from './save-as-xlsx-action';
 import { isEmpty } from '@neovici/cosmoz-utils/template';
 
-// eslint-disable-next-line max-lines-per-function
 export const renderFooter = ({
 	columns,
 	selectedItems,
@@ -12,12 +11,10 @@ export const renderFooter = ({
 	xlsxFilename,
 	xlsxSheetname,
 	topPlacement,
-	maxToolbarItems,
 }) =>
 	html`<cosmoz-bottom-bar
 		id="bottomBar"
 		?active=${!isEmpty(selectedItems.length)}
-		?max-toolbar-items=${!isEmpty(maxToolbarItems)}
 	>
 		<slot name="info" slot="info">
 			${ngettext(

--- a/lib/use-footer.js
+++ b/lib/use-footer.js
@@ -7,7 +7,6 @@ export const useFooter = ({ host, ...rest }) => {
 		xlsxFilename = 'omnitable.xlsx',
 		xlsxSheetname = 'Omnitable',
 		topPlacement = _defaultPlacement,
-		maxToolbarItems,
 	} = host;
 
 	return {
@@ -15,7 +14,6 @@ export const useFooter = ({ host, ...rest }) => {
 		xlsxFilename,
 		xlsxSheetname,
 		topPlacement,
-		maxToolbarItems,
 		...rest,
 	};
 };

--- a/lib/use-omnitable.js
+++ b/lib/use-omnitable.js
@@ -8,7 +8,6 @@ import { useHeader } from './use-header';
 import { useList } from './use-list';
 import { useFooter } from './use-footer';
 
-// eslint-disable-next-line max-lines-per-function
 export const useOmnitable = (host) => {
 	const {
 			hashParam,
@@ -48,7 +47,6 @@ export const useOmnitable = (host) => {
 			resizeSpeedFactor,
 			sortAndGroupOptions,
 		}),
-		maxToolbarItems = isMini ? '0' : undefined,
 		dataIsValid = data && Array.isArray(data) && data.length > 0,
 		[selectedItems, setSelectedItems] = useState([]);
 
@@ -96,7 +94,6 @@ export const useOmnitable = (host) => {
 			host,
 			selectedItems,
 			columns,
-			maxToolbarItems,
 		}),
 	};
 };


### PR DESCRIPTION
Remove unused logic for setting max toolbar items, controlling this from cosmoz-bottom-bar instead ([PR#166](https://github.com/Neovici/cosmoz-bottom-bar/pull/166))

[AB#17737](https://dev.azure.com/neovici/Cosmoz3/_backlogs/backlog/UX/Stories/?workitem=17737)