### PR TITLE
fix(css): styling of omnitable accessible from outside via vars

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -84,6 +84,7 @@ export default css`
 		flex-direction: column;
 		position: relative;
 		overflow: hidden;
+		color: var(--cosmoz-omnitable-text-color, rgb(0,0,0))
 	}
 	:host a {
 		color: var(--primary-link-color, inherit);
@@ -98,7 +99,7 @@ export default css`
 	}
 	/* The wrapping div that contains the header, the table content and the footer */
 	.mainContainer {
-		background-color: #fff;
+		background-color: var(--cosmoz-omnitable-bg-color, rgb(255, 255, 255));
 		display: flex;
 		flex-direction: column;
 		flex: auto;


### PR DESCRIPTION
Feat [AB#19255](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/19255) - styling variables in omnitable to allow conditional styling in frontend. Main use case will be the distinction between dark and light theme