### PR TITLE
fix(fallback): fallback value for text color is now coherent with Cos…

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -84,7 +84,7 @@ export default css`
 		flex-direction: column;
 		position: relative;
 		overflow: hidden;
-		color: var(--cosmoz-omnitable-text-color, rgb(0,0,0))
+		color: var(--cosmoz-omnitable-text-color, rgb(89, 102, 121));
 	}
 	:host a {
 		color: var(--primary-link-color, inherit);


### PR DESCRIPTION
…moz color scheme

Small fix on [AB#19255](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/19255) - having black as a default fallback would cause Visual tests in frontend [fail](https://github.com/Neovici/cosmoz-frontend/actions/runs/13792012393) because of a color mismatch.