### PR TITLE
fix(vars): graphical elements of omnitable need external control for …

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -116,6 +116,7 @@ export default css`
 		position: relative;
 		display: flex;
 		align-items: flex-end;
+		background-color: var(--cosmoz-omnitable-header-bg-color, inherit);
 	}
 
 	[hidden] {
@@ -449,7 +450,7 @@ export default css`
 	.itemRow:hover {
 		box-shadow: inset 1px 0 0 #dadce0, inset -1px 0 0 #dadce0,
 			0 1px 2px 0 rgb(60 64 67 / 30%), 0 1px 3px 1px rgb(60 64 67 / 15%);
-		/* background: var(--cosmoz-omnitable-hover-color); */
+		background-color: var(--cosmoz-omnitable-row-hover-color);
 	}
 	.groupRow:hover .checkbox:not(:checked):not(:hover),
 	.itemRow:hover .checkbox:not(:checked):not(:hover) {


### PR DESCRIPTION
…color themes

Fixes for [AB#19255](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/19255) - header and rows need styling to be accessible from the outside via CSS vars, to allow the implementation of different color themes.