### PR TITLE
Fix/ab19255 omnitable theme vars

### DIFF
--- a/cosmoz-omnitable-styles.js
+++ b/cosmoz-omnitable-styles.js
@@ -37,7 +37,8 @@ const checkbox = css`
 		box-sizing: content-box;
 		width: 5px;
 		height: 10px;
-		border: 2.4px solid #fff;
+		border: 2.4px solid
+			var(--cosmoz-omnitable-checkbox-checked-tick-color, #fff);
 		border-top: none;
 		border-left: none;
 		transform-origin: 5px 10px;


### PR DESCRIPTION
Fixes [AB#19255](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/19255) - addition of a further CSS var to allow the styling of the checkbox tick of omnitable, since it's needed to have it in different colors throughout the several color themes.