### PR TITLE
fix: cant resize the last column from right

### DIFF
--- a/lib/compute-layout.js
+++ b/lib/compute-layout.js
@@ -1,16 +1,33 @@
 import { layout } from './layout';
 
-const _toCss = (layout, config) =>
-	config
+const _toCss = (layout, config) => {
+	const lastVisibleIndex = layout.findLastIndex(
+		(width) => width != null && width > 0,
+	);
+
+	return config
 		.map((item, index) => {
 			const width = layout[index];
-			return width == null || width === 0
-				? `cosmoz-omnitable-resize-nub[name="${item.name}"], .cell[name="${item.name}"]{display:none}`
-				: `.cell[name="${item.name}"]{width: ${Math.floor(
-						width,
-					)}px;padding: 0 min(3px, ${width / 2}px)}`;
+			// Hidden columns
+			if (width == null || width === 0) {
+				return `cosmoz-omnitable-resize-nub[name="${item.name}"], .cell[name="${item.name}"]{display:none}`;
+			}
+
+			// Last visible column, show the cell but hide its resize nub
+			if (index === lastVisibleIndex) {
+				return `.cell[name="${item.name}"]{width: ${Math.floor(
+					width,
+				)}px;padding: 0 min(3px, ${width / 2}px)}
+							cosmoz-omnitable-resize-nub[name="${item.name}"]{display:none}`;
+			}
+
+			// Other visible columns
+			return `.cell[name="${item.name}"]{width: ${Math.floor(
+				width,
+			)}px;padding: 0 min(3px, ${width / 2}px)}`;
 		})
 		.join('\n');
+};
 
 export const computeLayout = (_columnConfigs, canvasWidth, numColumns) => {
 		const columnConfigs = _columnConfigs.filter((c) => !c.hidden),


### PR DESCRIPTION
ZenDesk: https://neovicihelp.zendesk.com/agent/tickets/23684
Slack Thread: https://neovici.slack.com/archives/CCU2R1Q3Y/p1738852734536449

We hide the last nub instead, since it was forced to be not draggable and the UX considerations in making the last column resizable from the end are too broad for this minor "issue".