### PR TITLE
fix: revert text-align change for date-range-input

### DIFF
--- a/lib/cosmoz-omnitable-date-range-input.js
+++ b/lib/cosmoz-omnitable-date-range-input.js
@@ -15,7 +15,6 @@ class DateRangeInput extends dateInputMixin(
 				paper-dropdown-menu {
 					--iron-icon-width: 0;
 					display: block;
-					text-align: right;
 				}
 
 				.dropdown-content h3 {


### PR DESCRIPTION
Reverts text-align change for date-range-input

Ref: [https://neovici.slack.com/archives/C6LJQMJFM/p1757917311872779](https://neovici.slack.com/archives/C6LJQMJFM/p1757917311872779)