### PR TITLE
fix: cosmoz-spinner 1.0.0 was not published correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@neovici/cosmoz-i18next": "^3.1.1",
         "@neovici/cosmoz-input": "^5.0.0",
         "@neovici/cosmoz-router": "^11.0.0",
-        "@neovici/cosmoz-spinner": "^1.0.0",
+        "@neovici/cosmoz-spinner": "^1.0.1",
         "@neovici/cosmoz-utils": "^6.14.2",
         "@neovici/nullxlsx": "^3.0.0",
         "@pionjs/pion": "^2.0.0",
@@ -1345,12 +1345,13 @@
       }
     },
     "node_modules/@neovici/cosmoz-spinner": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@neovici/cosmoz-spinner/-/cosmoz-spinner-1.0.0.tgz",
-      "integrity": "sha512-OhOWJKnRFc047bV6TsCAmG26RmzNotSPpk9Ad/yO39WuJdoxHAs+gZbBQ+YS24q7TtkGpAFgYFHPnvXg53aSYg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@neovici/cosmoz-spinner/-/cosmoz-spinner-1.0.1.tgz",
+      "integrity": "sha512-Hnk8a9KvQu+sxwqofz4FzWM80IB8MtaQ6JVP6JrKD3yHELUIjeMKBUr+5LahAQLwDSh/mWaBgvp5hzimeSjuHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pionjs/pion": "^2.5.2"
+        "@pionjs/pion": "^2.5.2",
+        "lit-html": "^3.3.1"
       }
     },
     "node_modules/@neovici/cosmoz-utils": {
@@ -16609,22 +16610,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/vite/node_modules/picomatch": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@neovici/cosmoz-i18next": "^3.1.1",
     "@neovici/cosmoz-input": "^5.0.0",
     "@neovici/cosmoz-router": "^11.0.0",
-    "@neovici/cosmoz-spinner": "^1.0.0",
+    "@neovici/cosmoz-spinner": "^1.0.1",
     "@neovici/cosmoz-utils": "^6.14.2",
     "@neovici/nullxlsx": "^3.0.0",
     "@pionjs/pion": "^2.0.0",


### PR DESCRIPTION
It included the element cz-spinner, not cosmoz-spinner. Fixed in https://github.com/Neovici/cosmoz-spinner/releases/tag/v1.0.1

Caused build issues downstream
https://github.com/Neovici/cosmoz-frontend/actions/runs/17794213142/job/50578103576?pr=8942