### PR TITLE
fix: loading state when filtering

### DIFF
--- a/demo/helpers/x-page.js
+++ b/demo/helpers/x-page.js
@@ -1,17 +1,18 @@
-import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light';
+import '@neovici/cosmoz-utils/elements/cz-spinner';
+import '@neovici/cosmoz-viewinfo';
 import '@polymer/iron-icons/editor-icons';
 import '@polymer/iron-icons/iron-icons';
 import '@polymer/paper-button/paper-button';
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light';
 import '@polymer/paper-toggle-button/paper-toggle-button';
-import '@neovici/cosmoz-viewinfo';
 
 import '../../src/cosmoz-omnitable';
-import { generateTableDemoData } from '../table-demo-helper';
 import './cosmoz-translations';
 
-import { PolymerElement } from '@polymer/polymer/polymer-element';
-import { html } from '@polymer/polymer/lib/utils/html-tag';
 import { translatable } from '@neovici/cosmoz-i18next';
+import { html } from '@polymer/polymer/lib/utils/html-tag';
+import { PolymerElement } from '@polymer/polymer/polymer-element';
+import { generateTableDemoData } from '../table-demo-helper';
 
 import { html as lit } from 'lit-html';
 

--- a/src/cosmoz-omnitable-styles.js
+++ b/src/cosmoz-omnitable-styles.js
@@ -250,6 +250,9 @@ export default css`
 		position: relative;
 		flex: auto;
 	}
+	.tableContent:has(.tableContent-empty.spinner) {
+		opacity: 0.3;
+	}
 
 	/* Empty data set styling */
 	.tableContent-empty {
@@ -582,5 +585,15 @@ export default css`
 
 	:host([mini]) cosmoz-omnitable-settings::part(columns) {
 		display:none;
+	}
+
+	cz-spinner {
+		width: 48px;
+		height: 48px;
+		position: absolute;
+		top: 40%;
+		right: 50%;
+		border-color: rgba(0, 0, 0, 0.2);
+		border-top-color: #000;
 	}
 `;

--- a/src/lib/render-list.js
+++ b/src/lib/render-list.js
@@ -44,12 +44,19 @@ export const renderList = (header, list) => {
 				</div>`,
 		)}
 		${when(
-			loading,
+			loading && !processedItems.length,
 			() =>
 				html`<div class="tableContent-empty overlay">
 					<cosmoz-omnitable-skeleton
 						.settingsConfig=${settingsConfig}
 					></cosmoz-omnitable-skeleton>
+				</div>`,
+		)}
+		${when(
+			loading && processedItems.length,
+			() =>
+				html`<div class="tableContent-empty overlay spinner">
+					<cz-spinner></cz-spinner>
 				</div>`,
 		)}
 		${when(


### PR DESCRIPTION
Fixes issue where skeleton laid on top of rows during loading state when filtering, skeleton should only be shown during first render loading state.

[AB#15783](https://dev.azure.com/neovici/Cosmoz3/_workitems/edit/15783)
[https://neovici.slack.com/archives/C0APSNTPB/p1757591994641259](https://neovici.slack.com/archives/C0APSNTPB/p1757591994641259)