### PR TITLE
fix: add js.map to dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 	},
 	"files": [
 		"dist/**/*.js",
+		"dist/**/*.js.map",
 		"dist/**/*.d.ts",
 		"dist/**/*.d.ts.map"
 	],


### PR DESCRIPTION
without it js maps are only locally but not published

Fixes #734