### PR TITLE
feat: add disabled-filtering attribute to columns and omnitable

### DIFF
--- a/src/cosmoz-omnitable-column-amount.js
+++ b/src/cosmoz-omnitable-column-amount.js
@@ -4,20 +4,20 @@ import './ui-helpers/cosmoz-clear-button';
 import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from 'lit-html';
 
+import { get } from '@polymer/polymer/lib/utils/path';
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
-import { defaultComputeSource } from './lib/utils-data';
 import './lib/cosmoz-omnitable-amount-range-input';
 import {
+	applySingleFilter,
+	fromHashString,
 	getComparableValue,
 	getCurrency,
-	applySingleFilter,
-	getString,
 	getInputString,
+	getString,
 	toAmount,
 	toHashString,
-	fromHashString,
 } from './lib/utils-amount';
-import { get } from '@polymer/polymer/lib/utils/path';
+import { defaultComputeSource } from './lib/utils-data';
 
 /**
  * @polymer
@@ -125,6 +125,7 @@ class OmnitableColumnAmount extends columnMixin(PolymerElement) {
 			currency,
 			autoupdate,
 			autodetect,
+			disabledFiltering,
 		},
 		{ filter },
 		setState,
@@ -132,6 +133,7 @@ class OmnitableColumnAmount extends columnMixin(PolymerElement) {
 	) {
 		return html`<cosmoz-omnitable-amount-range-input
 			.title=${title}
+			?disabled=${disabledFiltering}
 			.filter=${filter}
 			.values=${source}
 			.rates=${rates}

--- a/src/cosmoz-omnitable-column-autocomplete-excluding.js
+++ b/src/cosmoz-omnitable-column-autocomplete-excluding.js
@@ -111,6 +111,7 @@ class OmnitableColumnAutocomplete extends listColumnMixin(
 	renderHeader(column, { filter, query }, setState, source) {
 		return html`<cosmoz-autocomplete-excluding
 			class="external-values-${column.externalValues}"
+			?disabled=${column.disabledFiltering}
 			?keep-opened=${column.keepOpened}
 			?keep-query=${column.keepQuery}
 			?show-single=${column.showSingle}

--- a/src/cosmoz-omnitable-column-autocomplete.js
+++ b/src/cosmoz-omnitable-column-autocomplete.js
@@ -80,6 +80,7 @@ class OmnitableColumnAutocomplete extends listColumnMixin(
 	renderHeader(column, { filter, query }, setState, source) {
 		return html`<cosmoz-autocomplete-ui
 			class="external-values-${column.externalValues}"
+			?disabled=${column.disabledFiltering}
 			?keep-opened=${column.keepOpened}
 			?keep-query=${column.keepQuery}
 			?show-single=${column.showSingle}

--- a/src/cosmoz-omnitable-column-autocomplete.js
+++ b/src/cosmoz-omnitable-column-autocomplete.js
@@ -18,23 +18,6 @@ import { columnMixin, getString } from './cosmoz-omnitable-column-mixin.js';
 import { get } from '@polymer/polymer/lib/utils/path';
 import { columnSymbol } from './lib/use-dom-columns';
 
-const getDisplayText = (filter, source, textProperty) => {
-	if (!filter) return '';
-	const items = Array.isArray(filter) ? filter : [filter];
-	return items
-		.map((item) => {
-			if (typeof item === 'object' && item !== null) {
-				return String(item[textProperty] ?? '');
-			}
-			const found = source?.find((s) => s.value === item);
-			return found
-				? String(found.text ?? found[textProperty] ?? '')
-				: String(item ?? '');
-		})
-		.filter(Boolean)
-		.join(', ');
-};
-
 export const getComparableValue = (
 	{ valuePath, textProperty, valueProperty },
 	item,
@@ -95,14 +78,6 @@ class OmnitableColumnAutocomplete extends listColumnMixin(
 	}
 
 	renderHeader(column, { filter, query }, setState, source) {
-		if (column.disabledFiltering) {
-			const displayText = getDisplayText(filter, source, column.textProperty);
-			return html`<cosmoz-input
-				disabled
-				label=${column.title}
-				.value=${displayText}
-			></cosmoz-input>`;
-		}
 		return html`<cosmoz-autocomplete-ui
 			class="external-values-${column.externalValues}"
 			?disabled=${column.disabledFiltering}

--- a/src/cosmoz-omnitable-column-autocomplete.js
+++ b/src/cosmoz-omnitable-column-autocomplete.js
@@ -18,6 +18,23 @@ import { columnMixin, getString } from './cosmoz-omnitable-column-mixin.js';
 import { get } from '@polymer/polymer/lib/utils/path';
 import { columnSymbol } from './lib/use-dom-columns';
 
+const getDisplayText = (filter, source, textProperty) => {
+	if (!filter) return '';
+	const items = Array.isArray(filter) ? filter : [filter];
+	return items
+		.map((item) => {
+			if (typeof item === 'object' && item !== null) {
+				return String(item[textProperty] ?? '');
+			}
+			const found = source?.find((s) => s.value === item);
+			return found
+				? String(found.text ?? found[textProperty] ?? '')
+				: String(item ?? '');
+		})
+		.filter(Boolean)
+		.join(', ');
+};
+
 export const getComparableValue = (
 	{ valuePath, textProperty, valueProperty },
 	item,
@@ -78,6 +95,14 @@ class OmnitableColumnAutocomplete extends listColumnMixin(
 	}
 
 	renderHeader(column, { filter, query }, setState, source) {
+		if (column.disabledFiltering) {
+			const displayText = getDisplayText(filter, source, column.textProperty);
+			return html`<cosmoz-input
+				disabled
+				label=${column.title}
+				.value=${displayText}
+			></cosmoz-input>`;
+		}
 		return html`<cosmoz-autocomplete-ui
 			class="external-values-${column.externalValues}"
 			?disabled=${column.disabledFiltering}

--- a/src/cosmoz-omnitable-column-boolean.js
+++ b/src/cosmoz-omnitable-column-boolean.js
@@ -107,6 +107,7 @@ class OmnitableColumnBoolean extends columnMixin(PolymerElement) {
 
 	renderHeader(column, { filter, query }, setState, source) {
 		return html`<cosmoz-autocomplete-ui
+			?disabled=${column.disabledFiltering}
 			.label=${column.title}
 			.title=${computeItemTooltip(
 				column.title,

--- a/src/cosmoz-omnitable-column-boolean.js
+++ b/src/cosmoz-omnitable-column-boolean.js
@@ -3,7 +3,6 @@ import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
 
 import '@neovici/cosmoz-autocomplete';
-import '@neovici/cosmoz-input';
 import { memooize } from '@neovici/cosmoz-utils/memoize';
 import { get } from '@polymer/polymer/lib/utils/path';
 import { html } from 'lit-html';
@@ -107,15 +106,6 @@ class OmnitableColumnBoolean extends columnMixin(PolymerElement) {
 	}
 
 	renderHeader(column, { filter, query }, setState, source) {
-		if (column.disabledFiltering) {
-			const filterText =
-				filter != null ? computeTooltip('', filter, source) : '';
-			return html`<cosmoz-input
-				disabled
-				label=${column.title}
-				.value=${filterText}
-			></cosmoz-input>`;
-		}
 		return html`<cosmoz-autocomplete-ui
 			?disabled=${column.disabledFiltering}
 			.label=${column.title}

--- a/src/cosmoz-omnitable-column-boolean.js
+++ b/src/cosmoz-omnitable-column-boolean.js
@@ -3,6 +3,7 @@ import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
 
 import '@neovici/cosmoz-autocomplete';
+import '@neovici/cosmoz-input';
 import { memooize } from '@neovici/cosmoz-utils/memoize';
 import { get } from '@polymer/polymer/lib/utils/path';
 import { html } from 'lit-html';
@@ -106,6 +107,15 @@ class OmnitableColumnBoolean extends columnMixin(PolymerElement) {
 	}
 
 	renderHeader(column, { filter, query }, setState, source) {
+		if (column.disabledFiltering) {
+			const filterText =
+				filter != null ? computeTooltip('', filter, source) : '';
+			return html`<cosmoz-input
+				disabled
+				label=${column.title}
+				.value=${filterText}
+			></cosmoz-input>`;
+		}
 		return html`<cosmoz-autocomplete-ui
 			?disabled=${column.disabledFiltering}
 			.label=${column.title}

--- a/src/cosmoz-omnitable-column-date.js
+++ b/src/cosmoz-omnitable-column-date.js
@@ -1,21 +1,21 @@
-import { html } from 'lit-html';
-import { PolymerElement } from '@polymer/polymer/polymer-element';
 import '@neovici/cosmoz-input';
+import { PolymerElement } from '@polymer/polymer/polymer-element';
+import { html } from 'lit-html';
 
-import './ui-helpers/cosmoz-clear-button';
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
 import './lib/cosmoz-omnitable-date-range-input';
 import { defaultComputeSource } from './lib/utils-data';
 import {
-	getString,
+	applySingleFilter,
+	fromInputString,
 	getComparableValue,
+	getInputString,
+	getString,
 	toDate,
 	toHashString,
 	toXlsxValue,
-	applySingleFilter,
-	getInputString,
-	fromInputString,
 } from './lib/utils-date';
+import './ui-helpers/cosmoz-clear-button';
 
 class OmnitableColumnDate extends columnMixin(PolymerElement) {
 	static get properties() {
@@ -101,13 +101,14 @@ class OmnitableColumnDate extends columnMixin(PolymerElement) {
 	}
 
 	renderHeader(
-		{ title, min, max, limits, locale },
+		{ title, min, max, limits, locale, disabledFiltering },
 		{ filter },
 		setState,
 		source,
 	) {
 		return html`<cosmoz-omnitable-date-range-input
 			.title=${title}
+			?disabled=${disabledFiltering}
 			.filter=${filter}
 			.values=${source}
 			.min=${min}

--- a/src/cosmoz-omnitable-column-datetime.js
+++ b/src/cosmoz-omnitable-column-datetime.js
@@ -1,23 +1,23 @@
 import '@neovici/cosmoz-datetime-input';
 import './ui-helpers/cosmoz-clear-button';
 
-import { columnMixin } from './cosmoz-omnitable-column-mixin';
 import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from 'lit-html';
-import {
-	fromHashString,
-	getString,
-	toHashString,
-	toXlsxValue,
-} from './lib/utils-datetime';
+import { columnMixin } from './cosmoz-omnitable-column-mixin';
+import './lib/cosmoz-omnitable-datetime-range-input';
+import { defaultComputeSource } from './lib/utils-data';
 import {
 	applySingleFilter,
 	fromInputString,
 	getComparableValue,
 	toDate,
 } from './lib/utils-date';
-import { defaultComputeSource } from './lib/utils-data';
-import './lib/cosmoz-omnitable-datetime-range-input';
+import {
+	fromHashString,
+	getString,
+	toHashString,
+	toXlsxValue,
+} from './lib/utils-datetime';
 
 /**
  * @polymer
@@ -111,13 +111,14 @@ class OmnitableColumnDatetime extends columnMixin(PolymerElement) {
 	}
 
 	renderHeader(
-		{ title, min, max, limits, locale, filterStep },
+		{ title, min, max, limits, locale, filterStep, disabledFiltering },
 		{ filter },
 		setState,
 		source,
 	) {
 		return html`<cosmoz-omnitable-datetime-range-input
 			.title=${title}
+			?disabled=${disabledFiltering}
 			.filter=${filter}
 			.values=${source}
 			.min=${min}

--- a/src/cosmoz-omnitable-column-list-horizontal.js
+++ b/src/cosmoz-omnitable-column-list-horizontal.js
@@ -58,6 +58,7 @@ class OmnitableColumnListHorizontal extends listColumnMixin(
 	renderHeader(column, { filter, query }, setState, source) {
 		return html`<cosmoz-autocomplete-ui
 			class="external-values-${column.externalValues}"
+			?disabled=${column.disabledFiltering}
 			.label=${column.title}
 			.source=${source}
 			.textProperty=${column.textProperty}

--- a/src/cosmoz-omnitable-column-list.js
+++ b/src/cosmoz-omnitable-column-list.js
@@ -5,6 +5,7 @@ import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 
 import '@neovici/cosmoz-autocomplete';
+import '@neovici/cosmoz-input';
 import {
 	getString,
 	getTexts,
@@ -15,6 +16,23 @@ import {
 } from './cosmoz-omnitable-column-list-mixin';
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
 import { columnSymbol } from './lib/use-dom-columns';
+
+const getDisplayText = (filter, source, textProperty) => {
+	if (!filter || (Array.isArray(filter) && filter.length === 0)) return '';
+	const items = Array.isArray(filter) ? filter : [filter];
+	return items
+		.map((item) => {
+			if (typeof item === 'object' && item !== null) {
+				return String(item[textProperty] ?? '');
+			}
+			const found = source?.find((s) => s.value === item);
+			return found
+				? String(found.text ?? found[textProperty] ?? '')
+				: String(item ?? '');
+		})
+		.filter(Boolean)
+		.join(', ');
+};
 
 /**
  * @polymer
@@ -59,6 +77,14 @@ class OmnitableColumnList extends listColumnMixin(columnMixin(PolymerElement)) {
 	}
 
 	renderHeader(column, { filter, query }, setState, source) {
+		if (column.disabledFiltering) {
+			const displayText = getDisplayText(filter, source, column.textProperty);
+			return html`<cosmoz-input
+				disabled
+				label=${column.title}
+				.value=${displayText}
+			></cosmoz-input>`;
+		}
 		return html`<cosmoz-autocomplete-ui
 			class="external-values-${column.externalValues}"
 			?disabled=${column.disabledFiltering}

--- a/src/cosmoz-omnitable-column-list.js
+++ b/src/cosmoz-omnitable-column-list.js
@@ -61,6 +61,7 @@ class OmnitableColumnList extends listColumnMixin(columnMixin(PolymerElement)) {
 	renderHeader(column, { filter, query }, setState, source) {
 		return html`<cosmoz-autocomplete-ui
 			class="external-values-${column.externalValues}"
+			?disabled=${column.disabledFiltering}
 			?keep-opened=${column.keepOpened}
 			?keep-query=${column.keepQuery}
 			.textual=${column.textual}

--- a/src/cosmoz-omnitable-column-list.js
+++ b/src/cosmoz-omnitable-column-list.js
@@ -5,7 +5,6 @@ import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 
 import '@neovici/cosmoz-autocomplete';
-import '@neovici/cosmoz-input';
 import {
 	getString,
 	getTexts,
@@ -16,23 +15,6 @@ import {
 } from './cosmoz-omnitable-column-list-mixin';
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
 import { columnSymbol } from './lib/use-dom-columns';
-
-const getDisplayText = (filter, source, textProperty) => {
-	if (!filter || (Array.isArray(filter) && filter.length === 0)) return '';
-	const items = Array.isArray(filter) ? filter : [filter];
-	return items
-		.map((item) => {
-			if (typeof item === 'object' && item !== null) {
-				return String(item[textProperty] ?? '');
-			}
-			const found = source?.find((s) => s.value === item);
-			return found
-				? String(found.text ?? found[textProperty] ?? '')
-				: String(item ?? '');
-		})
-		.filter(Boolean)
-		.join(', ');
-};
 
 /**
  * @polymer
@@ -77,14 +59,6 @@ class OmnitableColumnList extends listColumnMixin(columnMixin(PolymerElement)) {
 	}
 
 	renderHeader(column, { filter, query }, setState, source) {
-		if (column.disabledFiltering) {
-			const displayText = getDisplayText(filter, source, column.textProperty);
-			return html`<cosmoz-input
-				disabled
-				label=${column.title}
-				.value=${displayText}
-			></cosmoz-input>`;
-		}
 		return html`<cosmoz-autocomplete-ui
 			class="external-values-${column.externalValues}"
 			?disabled=${column.disabledFiltering}

--- a/src/cosmoz-omnitable-column-mixin.js
+++ b/src/cosmoz-omnitable-column-mixin.js
@@ -55,6 +55,10 @@ export const getString = ({ valuePath }, item) => get(item, valuePath),
 					 * If true, the column cannot be sorted
 					 */
 					noSort: { type: Boolean, value: false },
+					/**
+					 * If true, the column header filter input is disabled
+					 */
+					disabledFiltering: { type: Boolean, value: false },
 					width: { type: String, value: '75px' },
 					minWidth: { type: String, value: '40px' },
 					flex: { type: String, value: '1' },

--- a/src/cosmoz-omnitable-column-number.js
+++ b/src/cosmoz-omnitable-column-number.js
@@ -6,6 +6,7 @@ import { html } from 'lit-html';
 
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
 
+import { get } from '@polymer/polymer/lib/utils/path';
 import './lib/cosmoz-omnitable-number-range-input';
 import { defaultComputeSource } from './lib/utils-data';
 import {
@@ -16,7 +17,6 @@ import {
 	toHashString,
 	toNumber,
 } from './lib/utils-number';
-import { get } from '@polymer/polymer/lib/utils/path';
 
 /**
  * @polymer
@@ -122,6 +122,7 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 			maximumFractionDigits,
 			minimumFractionDigits,
 			autoupdate,
+			disabledFiltering,
 		},
 		{ filter },
 		setState,
@@ -129,6 +130,7 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 	) {
 		return html`<cosmoz-omnitable-number-range-input
 			.title=${title}
+			?disabled=${disabledFiltering}
 			.filter=${filter}
 			.values=${source}
 			.min=${min}

--- a/src/cosmoz-omnitable-column-time.js
+++ b/src/cosmoz-omnitable-column-time.js
@@ -6,17 +6,17 @@ import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from 'lit-html';
 
 import { columnMixin } from './cosmoz-omnitable-column-mixin';
-import {
-	getComparableValue,
-	getString,
-	toXlsxValue,
-	applySingleFilter,
-	toDate,
-	toHashString,
-	fromHashString,
-} from './lib/utils-time';
 import './lib/cosmoz-omnitable-time-range-input';
 import { defaultComputeSource } from './lib/utils-data';
+import {
+	applySingleFilter,
+	fromHashString,
+	getComparableValue,
+	getString,
+	toDate,
+	toHashString,
+	toXlsxValue,
+} from './lib/utils-time';
 
 /**
  * @polymer
@@ -105,13 +105,14 @@ class OmnitableColumnTime extends columnMixin(PolymerElement) {
 	}
 
 	renderHeader(
-		{ title, min, max, locale, filterStep },
+		{ title, min, max, locale, filterStep, disabledFiltering },
 		{ filter },
 		setState,
 		source,
 	) {
 		return html`<cosmoz-omnitable-time-range-input
 			.title=${title}
+			?disabled=${disabledFiltering}
 			.filter=${filter}
 			.values=${source}
 			.min=${min}

--- a/src/cosmoz-omnitable-column.js
+++ b/src/cosmoz-omnitable-column.js
@@ -1,13 +1,13 @@
 import '@neovici/cosmoz-input';
 import './ui-helpers/cosmoz-clear-button';
 
+import { PolymerElement } from '@polymer/polymer/polymer-element';
+import { html } from 'lit-html';
 import {
 	applySingleFilter,
 	columnMixin,
 	getString,
 } from './cosmoz-omnitable-column-mixin';
-import { PolymerElement } from '@polymer/polymer/polymer-element';
-import { html } from 'lit-html';
 
 const onChange = (setState) => (event) =>
 		setState((state) => {
@@ -75,6 +75,7 @@ class OmnitableColumn extends columnMixin(PolymerElement) {
 	renderHeader(column, { filter, inputValue, headerFocused }, setState) {
 		return html`<cosmoz-input
 			label=${column.title}
+			?disabled=${column.disabledFiltering}
 			.value=${inputValue ?? filter}
 			@value-changed=${onChange(setState)}
 			focused=${headerFocused}
@@ -86,6 +87,7 @@ class OmnitableColumn extends columnMixin(PolymerElement) {
 				suffix
 				slot="suffix"
 				?visible=${hasFilter(filter)}
+				?disabled=${column.disabledFiltering}
 				light
 				@click=${resetFilter(setState)}
 			></cosmoz-clear-button>

--- a/src/cosmoz-omnitable-column.js
+++ b/src/cosmoz-omnitable-column.js
@@ -3,6 +3,7 @@ import './ui-helpers/cosmoz-clear-button';
 
 import { PolymerElement } from '@polymer/polymer/polymer-element';
 import { html } from 'lit-html';
+import { when } from 'lit-html/directives/when.js';
 import {
 	applySingleFilter,
 	columnMixin,
@@ -83,14 +84,17 @@ class OmnitableColumn extends columnMixin(PolymerElement) {
 			@keydown=${onKeyDown(setState)}
 			@blur=${onBlur(setState)}
 		>
-			<cosmoz-clear-button
-				suffix
-				slot="suffix"
-				?visible=${hasFilter(filter)}
-				?disabled=${column.disabledFiltering}
-				light
-				@click=${resetFilter(setState)}
-			></cosmoz-clear-button>
+			${when(
+				!column.disabledFiltering,
+				() =>
+					html`<cosmoz-clear-button
+						suffix
+						slot="suffix"
+						?visible=${hasFilter(filter)}
+						light
+						@click=${resetFilter(setState)}
+					></cosmoz-clear-button>`,
+			)}
 		</cosmoz-input>`;
 	}
 

--- a/src/cosmoz-omnitable-styles.js
+++ b/src/cosmoz-omnitable-styles.js
@@ -195,6 +195,12 @@ export default css`
 		--cosmoz-input-disabled-opacity: 1;
 	}
 
+	.header-cell cosmoz-input[disabled]::part(line),
+	.header-cell cosmoz-autocomplete-ui[disabled]::part(line),
+	.header-cell cosmoz-autocomplete-excluding[disabled]::part(line) {
+		border-bottom-style: solid;
+	}
+
 	cosmoz-omnitable-header-row {
 		white-space: nowrap;
 	}

--- a/src/cosmoz-omnitable-styles.js
+++ b/src/cosmoz-omnitable-styles.js
@@ -196,9 +196,15 @@ export default css`
 	}
 
 	.header-cell cosmoz-input[disabled]::part(line),
-	.header-cell cosmoz-autocomplete-ui[disabled]::part(line),
-	.header-cell cosmoz-autocomplete-excluding[disabled]::part(line) {
+	.header-cell cosmoz-autocomplete-ui[disabled]::part(input-line),
+	.header-cell cosmoz-autocomplete-excluding[disabled]::part(input-line) {
 		border-bottom-style: solid;
+	}
+
+	cosmoz-omnitable-dropdown-input[disabled],
+	.header-cell cosmoz-omnitable-dropdown-input[disabled] {
+		pointer-events: none;
+		cursor: default;
 	}
 
 	cosmoz-omnitable-header-row {

--- a/src/cosmoz-omnitable-styles.js
+++ b/src/cosmoz-omnitable-styles.js
@@ -187,6 +187,14 @@ export default css`
 		--cosmoz-input-focused-color: var(--cosmoz-omnitable-header-line-focused-color);
 	}
 
+	.header-cell cosmoz-input[disabled],
+	.header-cell cosmoz-autocomplete-ui[disabled],
+	.header-cell cosmoz-autocomplete-excluding[disabled] {
+		pointer-events: none;
+		cursor: default;
+		--cosmoz-input-disabled-opacity: 1;
+	}
+
 	cosmoz-omnitable-header-row {
 		white-space: nowrap;
 	}

--- a/src/cosmoz-omnitable.js
+++ b/src/cosmoz-omnitable.js
@@ -59,6 +59,7 @@ customElements.define(
 			'no-local',
 			'no-local-sort',
 			'no-local-filter',
+			'disabled-filtering',
 			'loading',
 			'mini-breakpoint',
 		],

--- a/src/lib/cosmoz-omnitable-amount-range-input.js
+++ b/src/lib/cosmoz-omnitable-amount-range-input.js
@@ -2,6 +2,7 @@ import '@neovici/cosmoz-input';
 import { PolymerElement } from '@polymer/polymer';
 import { t } from 'i18next';
 import { html } from 'lit-html';
+import { when } from 'lit-html/directives/when.js';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
 import { rangeInputMixin } from './cosmoz-omnitable-range-input-mixin';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
@@ -67,11 +68,14 @@ class AmountRangeInput extends rangeInputMixin(
 					background: var(--cosmoz-omnitable-amount-input-background, #ffffff);
 				}
 			</style>
-			<cosmoz-clear-button
-				@click=${() => this.resetFilter()}
-				?visible=${this.hasFilter()}
-			></cosmoz-clear-button>
-
+			${when(
+				!this.disabled,
+				() =>
+					html`<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>`,
+			)}
 			${renderDropdown({
 				title: this.title,
 				tooltip: this._tooltip,

--- a/src/lib/cosmoz-omnitable-amount-range-input.js
+++ b/src/lib/cosmoz-omnitable-amount-range-input.js
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import './cosmoz-omnitable-dropdown-input';
 import { rangeInputMixin } from './cosmoz-omnitable-range-input-mixin';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
@@ -76,49 +77,59 @@ class AmountRangeInput extends rangeInputMixin(
 						?visible=${this.hasFilter()}
 					></cosmoz-clear-button>`,
 			)}
-			${renderDropdown({
-				title: this.title,
-				tooltip: this._tooltip,
-				filterText: this._filterText,
-				disabled: this.disabled,
-				externalValues: this.externalValues,
-				onOpenedChanged,
-				content: html`
-					<h3 style="margin: 0;">${this.title}</h3>
-					<cosmoz-input
-						class=${this._fromClasses}
-						type="number"
-						title=${t('Minimum amount')}
-						label=${t('Min amount')}
-						.value=${this._filterInput?.min}
-						@value-changed=${(event) => {
-							this.set('_filterInput.min', event.detail.value);
-						}}
-						@blur=${(event) => this._onBlur(event)}
-						@keydown=${(event) => this._onKeyDown(event)}
-						min=${this._toInputStringAmount(this._limit.fromMin)}
-						max=${this._toInputStringAmount(this._limit.fromMax)}
-					>
-						<div slot="suffix" suffix>${this.filter?.min?.currency}</div>
-					</cosmoz-input>
-					<cosmoz-input
-						class=${this._toClasses}
-						type="number"
-						title=${t('Maximum amount')}
-						label=${t('Max amount')}
-						.value=${this._filterInput?.max}
-						@value-changed=${(event) => {
-							this.set('_filterInput.max', event.detail.value);
-						}}
-						@blur=${(event) => this._onBlur(event)}
-						@keydown=${(event) => this._onKeyDown(event)}
-						min=${this._toInputStringAmount(this._limit.toMin)}
-						max=${this._toInputStringAmount(this._limit.toMax)}
-					>
-						<div slot="suffix" suffix>${this.filter?.max?.currency}</div>
-					</cosmoz-input>
+			${when(
+				this.disabled,
+				() => html`
+					<cosmoz-omnitable-dropdown-input
+						disabled
+						.label=${this.title}
+						.value=${this._filterText ?? ''}
+					></cosmoz-omnitable-dropdown-input>
 				`,
-			})}
+				() =>
+					renderDropdown({
+						title: this.title,
+						tooltip: this._tooltip,
+						filterText: this._filterText,
+						externalValues: this.externalValues,
+						onOpenedChanged,
+						content: html`
+							<h3 style="margin: 0;">${this.title}</h3>
+							<cosmoz-input
+								class=${this._fromClasses}
+								type="number"
+								title=${t('Minimum amount')}
+								label=${t('Min amount')}
+								.value=${this._filterInput?.min}
+								@value-changed=${(event) => {
+									this.set('_filterInput.min', event.detail.value);
+								}}
+								@blur=${(event) => this._onBlur(event)}
+								@keydown=${(event) => this._onKeyDown(event)}
+								min=${this._toInputStringAmount(this._limit.fromMin)}
+								max=${this._toInputStringAmount(this._limit.fromMax)}
+							>
+								<div slot="suffix" suffix>${this.filter?.min?.currency}</div>
+							</cosmoz-input>
+							<cosmoz-input
+								class=${this._toClasses}
+								type="number"
+								title=${t('Maximum amount')}
+								label=${t('Max amount')}
+								.value=${this._filterInput?.max}
+								@value-changed=${(event) => {
+									this.set('_filterInput.max', event.detail.value);
+								}}
+								@blur=${(event) => this._onBlur(event)}
+								@keydown=${(event) => this._onKeyDown(event)}
+								min=${this._toInputStringAmount(this._limit.toMin)}
+								max=${this._toInputStringAmount(this._limit.toMax)}
+							>
+								<div slot="suffix" suffix>${this.filter?.max?.currency}</div>
+							</cosmoz-input>
+						`,
+					}),
+			)}
 		`;
 	}
 

--- a/src/lib/cosmoz-omnitable-amount-range-input.js
+++ b/src/lib/cosmoz-omnitable-amount-range-input.js
@@ -70,14 +70,6 @@ class AmountRangeInput extends rangeInputMixin(
 				}
 			</style>
 			${when(
-				!this.disabled,
-				() =>
-					html`<cosmoz-clear-button
-						@click=${() => this.resetFilter()}
-						?visible=${this.hasFilter()}
-					></cosmoz-clear-button>`,
-			)}
-			${when(
 				this.disabled,
 				() => html`
 					<cosmoz-omnitable-dropdown-input
@@ -86,8 +78,12 @@ class AmountRangeInput extends rangeInputMixin(
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
 				`,
-				() =>
-					renderDropdown({
+				() => html`
+					<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>
+					${renderDropdown({
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
@@ -128,7 +124,8 @@ class AmountRangeInput extends rangeInputMixin(
 								<div slot="suffix" suffix>${this.filter?.max?.currency}</div>
 							</cosmoz-input>
 						`,
-					}),
+					})}
+				`,
 			)}
 		`;
 	}

--- a/src/lib/cosmoz-omnitable-amount-range-input.js
+++ b/src/lib/cosmoz-omnitable-amount-range-input.js
@@ -1,10 +1,10 @@
-import { t } from 'i18next';
-import { PolymerElement } from '@polymer/polymer';
-import { html } from 'lit-html';
 import '@neovici/cosmoz-input';
+import { PolymerElement } from '@polymer/polymer';
+import { t } from 'i18next';
+import { html } from 'lit-html';
+import { renderDropdown } from './cosmoz-omnitable-dropdown';
 import { rangeInputMixin } from './cosmoz-omnitable-range-input-mixin';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
-import { renderDropdown } from './cosmoz-omnitable-dropdown';
 
 class AmountRangeInput extends rangeInputMixin(
 	polymerHauntedRender(PolymerElement),
@@ -76,6 +76,7 @@ class AmountRangeInput extends rangeInputMixin(
 				title: this.title,
 				tooltip: this._tooltip,
 				filterText: this._filterText,
+				disabled: this.disabled,
 				externalValues: this.externalValues,
 				onOpenedChanged,
 				content: html`

--- a/src/lib/cosmoz-omnitable-date-range-input.js
+++ b/src/lib/cosmoz-omnitable-date-range-input.js
@@ -2,6 +2,7 @@ import '@neovici/cosmoz-input';
 import { PolymerElement } from '@polymer/polymer';
 import { t } from 'i18next';
 import { html } from 'lit-html';
+import { when } from 'lit-html/directives/when.js';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
@@ -36,11 +37,14 @@ class DateRangeInput extends dateInputMixin(
 				}
 			</style>
 
-			<cosmoz-clear-button
-				@click=${() => this.resetFilter()}
-				?visible=${this.hasFilter()}
-			></cosmoz-clear-button>
-
+			${when(
+				!this.disabled,
+				() =>
+					html`<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>`,
+			)}
 			${renderDropdown({
 				title: this.title,
 				tooltip: this._tooltip,

--- a/src/lib/cosmoz-omnitable-date-range-input.js
+++ b/src/lib/cosmoz-omnitable-date-range-input.js
@@ -39,14 +39,6 @@ class DateRangeInput extends dateInputMixin(
 			</style>
 
 			${when(
-				!this.disabled,
-				() =>
-					html`<cosmoz-clear-button
-						@click=${() => this.resetFilter()}
-						?visible=${this.hasFilter()}
-					></cosmoz-clear-button>`,
-			)}
-			${when(
 				this.disabled,
 				() => html`
 					<cosmoz-omnitable-dropdown-input
@@ -55,8 +47,12 @@ class DateRangeInput extends dateInputMixin(
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
 				`,
-				() =>
-					renderDropdown({
+				() => html`
+					<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>
+					${renderDropdown({
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
@@ -83,7 +79,8 @@ class DateRangeInput extends dateInputMixin(
 									this.set('_filterInput.max', event.detail.value)}
 							></cosmoz-input>
 						`,
-					}),
+					})}
+				`,
 			)}
 		`;
 	}

--- a/src/lib/cosmoz-omnitable-date-range-input.js
+++ b/src/lib/cosmoz-omnitable-date-range-input.js
@@ -5,6 +5,7 @@ import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import './cosmoz-omnitable-dropdown-input';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
 class DateRangeInput extends dateInputMixin(
@@ -45,35 +46,45 @@ class DateRangeInput extends dateInputMixin(
 						?visible=${this.hasFilter()}
 					></cosmoz-clear-button>`,
 			)}
-			${renderDropdown({
-				title: this.title,
-				tooltip: this._tooltip,
-				filterText: this._filterText,
-				disabled: this.disabled,
-				externalValues: this.externalValues,
-				onOpenedChanged,
-				content: html`
-					<h3 style="margin: 0;">${this.title}</h3>
-					<cosmoz-input
-						type="date"
-						label=${t('From date')}
-						min=${this._toInputString(this._limit.fromMin)}
-						max=${this._toInputString(this._limit.fromMax)}
-						.value=${this._filterInput?.min}
-						@value-changed=${(event) =>
-							this.set('_filterInput.min', event.detail.value)}
-					></cosmoz-input>
-					<cosmoz-input
-						type="date"
-						label=${t('Until date')}
-						min=${this._toInputString(this._limit.toMin)}
-						max=${this._toInputString(this._limit.toMax)}
-						.value=${this._filterInput?.max}
-						@value-changed=${(event) =>
-							this.set('_filterInput.max', event.detail.value)}
-					></cosmoz-input>
+			${when(
+				this.disabled,
+				() => html`
+					<cosmoz-omnitable-dropdown-input
+						disabled
+						.label=${this.title}
+						.value=${this._filterText ?? ''}
+					></cosmoz-omnitable-dropdown-input>
 				`,
-			})}
+				() =>
+					renderDropdown({
+						title: this.title,
+						tooltip: this._tooltip,
+						filterText: this._filterText,
+						externalValues: this.externalValues,
+						onOpenedChanged,
+						content: html`
+							<h3 style="margin: 0;">${this.title}</h3>
+							<cosmoz-input
+								type="date"
+								label=${t('From date')}
+								min=${this._toInputString(this._limit.fromMin)}
+								max=${this._toInputString(this._limit.fromMax)}
+								.value=${this._filterInput?.min}
+								@value-changed=${(event) =>
+									this.set('_filterInput.min', event.detail.value)}
+							></cosmoz-input>
+							<cosmoz-input
+								type="date"
+								label=${t('Until date')}
+								min=${this._toInputString(this._limit.toMin)}
+								max=${this._toInputString(this._limit.toMax)}
+								.value=${this._filterInput?.max}
+								@value-changed=${(event) =>
+									this.set('_filterInput.max', event.detail.value)}
+							></cosmoz-input>
+						`,
+					}),
+			)}
 		`;
 	}
 

--- a/src/lib/cosmoz-omnitable-date-range-input.js
+++ b/src/lib/cosmoz-omnitable-date-range-input.js
@@ -1,10 +1,10 @@
-import { t } from 'i18next';
-import { PolymerElement } from '@polymer/polymer';
-import { html } from 'lit-html';
 import '@neovici/cosmoz-input';
+import { PolymerElement } from '@polymer/polymer';
+import { t } from 'i18next';
+import { html } from 'lit-html';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
-import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
 class DateRangeInput extends dateInputMixin(
 	polymerHauntedRender(PolymerElement),
@@ -45,6 +45,7 @@ class DateRangeInput extends dateInputMixin(
 				title: this.title,
 				tooltip: this._tooltip,
 				filterText: this._filterText,
+				disabled: this.disabled,
 				externalValues: this.externalValues,
 				onOpenedChanged,
 				content: html`

--- a/src/lib/cosmoz-omnitable-datetime-range-input.js
+++ b/src/lib/cosmoz-omnitable-datetime-range-input.js
@@ -4,6 +4,7 @@ import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import './cosmoz-omnitable-dropdown-input';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
 class DatetimeRangeInput extends dateInputMixin(
@@ -44,37 +45,47 @@ class DatetimeRangeInput extends dateInputMixin(
 						?visible=${this.hasFilter()}
 					></cosmoz-clear-button>`,
 			)}
-			${renderDropdown({
-				title: this.title,
-				tooltip: this._tooltip,
-				filterText: this._filterText,
-				disabled: this.disabled,
-				externalValues: this.externalValues,
-				onOpenedChanged,
-				content: html`
-					<h3 style="margin: 0;">${this.title}</h3>
-					<cosmoz-datetime-input
-						date-label=${t('From date')}
-						time-label=${t('From time')}
-						min=${this._toInputString(this._limit.fromMin)}
-						max=${this._toInputString(this._limit.fromMax)}
-						step=${this.filterStep}
-						.value=${this._filterInput?.min}
-						@value-changed=${(event) =>
-							this.set('_filterInput.min', event.detail.value)}
-					></cosmoz-datetime-input>
-					<cosmoz-datetime-input
-						date-label=${t('To date')}
-						time-label=${t('To time')}
-						min=${this._toInputString(this._limit.toMin)}
-						max=${this._toInputString(this._limit.toMax)}
-						step=${this.filterStep}
-						.value=${this._filterInput?.max}
-						@value-changed=${(event) =>
-							this.set('_filterInput.max', event.detail.value)}
-					></cosmoz-datetime-input>
+			${when(
+				this.disabled,
+				() => html`
+					<cosmoz-omnitable-dropdown-input
+						disabled
+						.label=${this.title}
+						.value=${this._filterText ?? ''}
+					></cosmoz-omnitable-dropdown-input>
 				`,
-			})}
+				() =>
+					renderDropdown({
+						title: this.title,
+						tooltip: this._tooltip,
+						filterText: this._filterText,
+						externalValues: this.externalValues,
+						onOpenedChanged,
+						content: html`
+							<h3 style="margin: 0;">${this.title}</h3>
+							<cosmoz-datetime-input
+								date-label=${t('From date')}
+								time-label=${t('From time')}
+								min=${this._toInputString(this._limit.fromMin)}
+								max=${this._toInputString(this._limit.fromMax)}
+								step=${this.filterStep}
+								.value=${this._filterInput?.min}
+								@value-changed=${(event) =>
+									this.set('_filterInput.min', event.detail.value)}
+							></cosmoz-datetime-input>
+							<cosmoz-datetime-input
+								date-label=${t('To date')}
+								time-label=${t('To time')}
+								min=${this._toInputString(this._limit.toMin)}
+								max=${this._toInputString(this._limit.toMax)}
+								step=${this.filterStep}
+								.value=${this._filterInput?.max}
+								@value-changed=${(event) =>
+									this.set('_filterInput.max', event.detail.value)}
+							></cosmoz-datetime-input>
+						`,
+					}),
+			)}
 		`;
 	}
 

--- a/src/lib/cosmoz-omnitable-datetime-range-input.js
+++ b/src/lib/cosmoz-omnitable-datetime-range-input.js
@@ -1,6 +1,7 @@
 import { PolymerElement } from '@polymer/polymer';
 import { t } from 'i18next';
 import { html } from 'lit-html';
+import { when } from 'lit-html/directives/when.js';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
@@ -35,11 +36,14 @@ class DatetimeRangeInput extends dateInputMixin(
 				}
 			</style>
 
-			<cosmoz-clear-button
-				@click=${() => this.resetFilter()}
-				?visible=${this.hasFilter()}
-			></cosmoz-clear-button>
-
+			${when(
+				!this.disabled,
+				() =>
+					html`<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>`,
+			)}
 			${renderDropdown({
 				title: this.title,
 				tooltip: this._tooltip,

--- a/src/lib/cosmoz-omnitable-datetime-range-input.js
+++ b/src/lib/cosmoz-omnitable-datetime-range-input.js
@@ -1,9 +1,9 @@
-import { t } from 'i18next';
 import { PolymerElement } from '@polymer/polymer';
+import { t } from 'i18next';
 import { html } from 'lit-html';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
-import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
 class DatetimeRangeInput extends dateInputMixin(
 	polymerHauntedRender(PolymerElement),
@@ -44,6 +44,7 @@ class DatetimeRangeInput extends dateInputMixin(
 				title: this.title,
 				tooltip: this._tooltip,
 				filterText: this._filterText,
+				disabled: this.disabled,
 				externalValues: this.externalValues,
 				onOpenedChanged,
 				content: html`

--- a/src/lib/cosmoz-omnitable-datetime-range-input.js
+++ b/src/lib/cosmoz-omnitable-datetime-range-input.js
@@ -38,14 +38,6 @@ class DatetimeRangeInput extends dateInputMixin(
 			</style>
 
 			${when(
-				!this.disabled,
-				() =>
-					html`<cosmoz-clear-button
-						@click=${() => this.resetFilter()}
-						?visible=${this.hasFilter()}
-					></cosmoz-clear-button>`,
-			)}
-			${when(
 				this.disabled,
 				() => html`
 					<cosmoz-omnitable-dropdown-input
@@ -54,8 +46,12 @@ class DatetimeRangeInput extends dateInputMixin(
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
 				`,
-				() =>
-					renderDropdown({
+				() => html`
+					<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>
+					${renderDropdown({
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
@@ -84,7 +80,8 @@ class DatetimeRangeInput extends dateInputMixin(
 									this.set('_filterInput.max', event.detail.value)}
 							></cosmoz-datetime-input>
 						`,
-					}),
+					})}
+				`,
 			)}
 		`;
 	}

--- a/src/lib/cosmoz-omnitable-dropdown-input.js
+++ b/src/lib/cosmoz-omnitable-dropdown-input.js
@@ -58,6 +58,10 @@ const style = css`
 		pointer-events: none;
 		cursor: default;
 	}
+
+	:host([disabled])::part(line) {
+		border-bottom-style: solid;
+	}
 `;
 
 const DropdownInput = (host) => {

--- a/src/lib/cosmoz-omnitable-dropdown-input.js
+++ b/src/lib/cosmoz-omnitable-dropdown-input.js
@@ -57,9 +57,10 @@ const style = css`
 	:host([disabled]) {
 		pointer-events: none;
 		cursor: default;
+		--cosmoz-input-disabled-opacity: 1;
 	}
 
-	:host([disabled])::part(line) {
+	:host([disabled]) .line {
 		border-bottom-style: solid;
 	}
 `;

--- a/src/lib/cosmoz-omnitable-dropdown-input.js
+++ b/src/lib/cosmoz-omnitable-dropdown-input.js
@@ -56,7 +56,7 @@ const style = css`
 
 	:host([disabled]) {
 		pointer-events: none;
-		opacity: 0.5;
+		cursor: default;
 	}
 `;
 

--- a/src/lib/cosmoz-omnitable-dropdown-input.js
+++ b/src/lib/cosmoz-omnitable-dropdown-input.js
@@ -1,8 +1,14 @@
+import { styles as inputStyles, render } from '@neovici/cosmoz-input';
 import { component, css } from '@pionjs/pion';
 import { html } from 'lit-html';
-import { render, styles as inputStyles } from '@neovici/cosmoz-input';
 
-const observedAttributes = ['label', 'value', 'slot', 'always-float-label'];
+const observedAttributes = [
+	'label',
+	'value',
+	'slot',
+	'always-float-label',
+	'disabled',
+];
 
 const style = css`
 	${inputStyles}
@@ -46,6 +52,11 @@ const style = css`
 
 	:host(:not([always-float-label])) label {
 		transform: none !important;
+	}
+
+	:host([disabled]) {
+		pointer-events: none;
+		opacity: 0.5;
 	}
 `;
 

--- a/src/lib/cosmoz-omnitable-dropdown.js
+++ b/src/lib/cosmoz-omnitable-dropdown.js
@@ -1,12 +1,13 @@
+import '@neovici/cosmoz-dropdown';
 import { html } from 'lit-html';
 import { classMap } from 'lit-html/directives/class-map.js';
-import '@neovici/cosmoz-dropdown';
 import './cosmoz-omnitable-dropdown-input';
 
 export const renderDropdown = ({
 	title,
 	tooltip = '',
 	filterText = '',
+	disabled = false,
 	onOpenedChanged,
 	content,
 	horizontalAlign = 'left',
@@ -83,6 +84,7 @@ export const renderDropdown = ({
 			@focus=${onOpenedChanged}
 			class=${`${classMap(classes)} dropdown`}
 			title=${tooltip || ''}
+			?disabled=${disabled}
 		>
 			<cosmoz-omnitable-dropdown-input
 				class="input"
@@ -92,6 +94,7 @@ export const renderDropdown = ({
 				.value=${filterText ?? ''}
 				text-align=${horizontalAlign}
 				?always-float-label=${filterText?.length > 0}
+				?disabled=${disabled}
 			></cosmoz-omnitable-dropdown-input>
 			<div class="dropdown-content">${content}</div>
 		</cosmoz-dropdown>

--- a/src/lib/cosmoz-omnitable-dropdown.js
+++ b/src/lib/cosmoz-omnitable-dropdown.js
@@ -15,6 +15,7 @@ export const renderDropdown = ({
 }) => {
 	const classes = {
 		filtered: Boolean(filterText),
+		disabled,
 		...(externalValues != null && {
 			[`external-values-${externalValues}`]: true,
 		}),
@@ -27,6 +28,10 @@ export const renderDropdown = ({
 			}
 			.dropdown:focus-within .input {
 				--focused: focused;
+			}
+			.dropdown.disabled::part(button) {
+				pointer-events: none;
+				cursor: default;
 			}
 
 			.dropdown::part(button) {
@@ -82,7 +87,7 @@ export const renderDropdown = ({
 
 		<cosmoz-dropdown
 			@focus=${onOpenedChanged}
-			class=${`${classMap(classes)} dropdown`}
+			class=${classMap({ ...classes, dropdown: true })}
 			title=${tooltip || ''}
 			?disabled=${disabled}
 		>

--- a/src/lib/cosmoz-omnitable-dropdown.js
+++ b/src/lib/cosmoz-omnitable-dropdown.js
@@ -23,14 +23,17 @@ export const renderDropdown = ({
 
 	return html`
 		<style>
+			.dropdown-wrapper {
+				display: block;
+			}
+			.dropdown-wrapper[disabled] {
+				pointer-events: none;
+			}
 			.dropdown {
 				outline: none;
 			}
 			.dropdown:focus-within .input {
 				--focused: focused;
-			}
-			.dropdown.disabled {
-				pointer-events: none;
 			}
 			.dropdown.disabled::part(button) {
 				cursor: default;
@@ -103,23 +106,25 @@ export const renderDropdown = ({
 			}
 		</style>
 
-		<cosmoz-dropdown
-			@focus=${onOpenedChanged}
-			class=${classMap({ ...classes, dropdown: true })}
-			title=${tooltip || ''}
-			?disabled=${disabled}
-		>
-			<cosmoz-omnitable-dropdown-input
-				class="input"
-				slot="button"
-				.label=${title}
-				.placeholder=${title}
-				.value=${filterText ?? ''}
-				text-align=${horizontalAlign}
-				?always-float-label=${filterText?.length > 0}
+		<div class="dropdown-wrapper" ?disabled=${disabled}>
+			<cosmoz-dropdown
+				@focus=${onOpenedChanged}
+				class=${classMap({ ...classes, dropdown: true })}
+				title=${tooltip || ''}
 				?disabled=${disabled}
-			></cosmoz-omnitable-dropdown-input>
-			<div class="dropdown-content" ?disabled=${disabled}>${content}</div>
-		</cosmoz-dropdown>
+			>
+				<cosmoz-omnitable-dropdown-input
+					class="input"
+					slot="button"
+					.label=${title}
+					.placeholder=${title}
+					.value=${filterText ?? ''}
+					text-align=${horizontalAlign}
+					?always-float-label=${filterText?.length > 0}
+					?disabled=${disabled}
+				></cosmoz-omnitable-dropdown-input>
+				<div class="dropdown-content" ?disabled=${disabled}>${content}</div>
+			</cosmoz-dropdown>
+		</div>
 	`;
 };

--- a/src/lib/cosmoz-omnitable-dropdown.js
+++ b/src/lib/cosmoz-omnitable-dropdown.js
@@ -29,8 +29,10 @@ export const renderDropdown = ({
 			.dropdown:focus-within .input {
 				--focused: focused;
 			}
-			.dropdown.disabled::part(button) {
+			.dropdown.disabled {
 				pointer-events: none;
+			}
+			.dropdown.disabled::part(button) {
 				cursor: default;
 			}
 
@@ -83,6 +85,22 @@ export const renderDropdown = ({
 					0 4px 24px 0 rgba(0, 0, 0, 0.18),
 					0 1.5px 6px 0 rgba(0, 0, 0, 0.1);
 			}
+
+			.dropdown-content[disabled] cosmoz-omnitable-dropdown-input,
+			.dropdown-content[disabled] cosmoz-input,
+			.dropdown-content[disabled] cosmoz-autocomplete-ui,
+			.dropdown-content[disabled] cosmoz-autocomplete-excluding {
+				pointer-events: none;
+				cursor: default;
+			}
+
+			.dropdown-content[disabled] cosmoz-omnitable-dropdown-input::part(line),
+			.dropdown-content[disabled] cosmoz-input::part(line),
+			.dropdown-content[disabled] cosmoz-autocomplete-ui::part(input-line),
+			.dropdown-content[disabled]
+				cosmoz-autocomplete-excluding::part(input-line) {
+				border-bottom-style: solid;
+			}
 		</style>
 
 		<cosmoz-dropdown
@@ -101,7 +119,7 @@ export const renderDropdown = ({
 				?always-float-label=${filterText?.length > 0}
 				?disabled=${disabled}
 			></cosmoz-omnitable-dropdown-input>
-			<div class="dropdown-content">${content}</div>
+			<div class="dropdown-content" ?disabled=${disabled}>${content}</div>
 		</cosmoz-dropdown>
 	`;
 };

--- a/src/lib/cosmoz-omnitable-dropdown.js
+++ b/src/lib/cosmoz-omnitable-dropdown.js
@@ -7,7 +7,6 @@ export const renderDropdown = ({
 	title,
 	tooltip = '',
 	filterText = '',
-	disabled = false,
 	onOpenedChanged,
 	content,
 	horizontalAlign = 'left',
@@ -15,7 +14,6 @@ export const renderDropdown = ({
 }) => {
 	const classes = {
 		filtered: Boolean(filterText),
-		disabled,
 		...(externalValues != null && {
 			[`external-values-${externalValues}`]: true,
 		}),
@@ -23,20 +21,11 @@ export const renderDropdown = ({
 
 	return html`
 		<style>
-			.dropdown-wrapper {
-				display: block;
-			}
-			.dropdown-wrapper[disabled] {
-				pointer-events: none;
-			}
 			.dropdown {
 				outline: none;
 			}
 			.dropdown:focus-within .input {
 				--focused: focused;
-			}
-			.dropdown.disabled::part(button) {
-				cursor: default;
 			}
 
 			.dropdown::part(button) {
@@ -88,43 +77,23 @@ export const renderDropdown = ({
 					0 4px 24px 0 rgba(0, 0, 0, 0.18),
 					0 1.5px 6px 0 rgba(0, 0, 0, 0.1);
 			}
-
-			.dropdown-content[disabled] cosmoz-omnitable-dropdown-input,
-			.dropdown-content[disabled] cosmoz-input,
-			.dropdown-content[disabled] cosmoz-autocomplete-ui,
-			.dropdown-content[disabled] cosmoz-autocomplete-excluding {
-				pointer-events: none;
-				cursor: default;
-			}
-
-			.dropdown-content[disabled] cosmoz-omnitable-dropdown-input::part(line),
-			.dropdown-content[disabled] cosmoz-input::part(line),
-			.dropdown-content[disabled] cosmoz-autocomplete-ui::part(input-line),
-			.dropdown-content[disabled]
-				cosmoz-autocomplete-excluding::part(input-line) {
-				border-bottom-style: solid;
-			}
 		</style>
 
-		<div class="dropdown-wrapper" ?disabled=${disabled}>
-			<cosmoz-dropdown
-				@focus=${onOpenedChanged}
-				class=${classMap({ ...classes, dropdown: true })}
-				title=${tooltip || ''}
-				?disabled=${disabled}
-			>
-				<cosmoz-omnitable-dropdown-input
-					class="input"
-					slot="button"
-					.label=${title}
-					.placeholder=${title}
-					.value=${filterText ?? ''}
-					text-align=${horizontalAlign}
-					?always-float-label=${filterText?.length > 0}
-					?disabled=${disabled}
-				></cosmoz-omnitable-dropdown-input>
-				<div class="dropdown-content" ?disabled=${disabled}>${content}</div>
-			</cosmoz-dropdown>
-		</div>
+		<cosmoz-dropdown
+			@focus=${onOpenedChanged}
+			class=${classMap({ ...classes, dropdown: true })}
+			title=${tooltip || ''}
+		>
+			<cosmoz-omnitable-dropdown-input
+				class="input"
+				slot="button"
+				.label=${title}
+				.placeholder=${title}
+				.value=${filterText ?? ''}
+				text-align=${horizontalAlign}
+				?always-float-label=${filterText?.length > 0}
+			></cosmoz-omnitable-dropdown-input>
+			<div class="dropdown-content">${content}</div>
+		</cosmoz-dropdown>
 	`;
 };

--- a/src/lib/cosmoz-omnitable-number-range-input.js
+++ b/src/lib/cosmoz-omnitable-number-range-input.js
@@ -2,6 +2,7 @@ import '@neovici/cosmoz-input';
 import { PolymerElement } from '@polymer/polymer';
 import { t } from 'i18next';
 import { html } from 'lit-html';
+import { when } from 'lit-html/directives/when.js';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
 import { rangeInputMixin } from './cosmoz-omnitable-range-input-mixin';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
@@ -56,11 +57,14 @@ class NumberRangeInput extends rangeInputMixin(
 				}
 			</style>
 
-			<cosmoz-clear-button
-				@click=${() => this.resetFilter()}
-				?visible=${this.hasFilter()}
-			></cosmoz-clear-button>
-
+			${when(
+				!this.disabled,
+				() =>
+					html`<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>`,
+			)}
 			${renderDropdown({
 				title: this.title,
 				tooltip: this._tooltip,

--- a/src/lib/cosmoz-omnitable-number-range-input.js
+++ b/src/lib/cosmoz-omnitable-number-range-input.js
@@ -1,10 +1,10 @@
-import { PolymerElement } from '@polymer/polymer';
-import { html } from 'lit-html';
-import { t } from 'i18next';
 import '@neovici/cosmoz-input';
+import { PolymerElement } from '@polymer/polymer';
+import { t } from 'i18next';
+import { html } from 'lit-html';
+import { renderDropdown } from './cosmoz-omnitable-dropdown';
 import { rangeInputMixin } from './cosmoz-omnitable-range-input-mixin';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
-import { renderDropdown } from './cosmoz-omnitable-dropdown';
 
 class NumberRangeInput extends rangeInputMixin(
 	polymerHauntedRender(PolymerElement),
@@ -65,6 +65,7 @@ class NumberRangeInput extends rangeInputMixin(
 				title: this.title,
 				tooltip: this._tooltip,
 				filterText: this._filterText,
+				disabled: this.disabled,
 				horizontalAlign: 'right',
 				externalValues: this.externalValues,
 				onOpenedChanged,

--- a/src/lib/cosmoz-omnitable-number-range-input.js
+++ b/src/lib/cosmoz-omnitable-number-range-input.js
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import './cosmoz-omnitable-dropdown-input';
 import { rangeInputMixin } from './cosmoz-omnitable-range-input-mixin';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
@@ -65,44 +66,54 @@ class NumberRangeInput extends rangeInputMixin(
 						?visible=${this.hasFilter()}
 					></cosmoz-clear-button>`,
 			)}
-			${renderDropdown({
-				title: this.title,
-				tooltip: this._tooltip,
-				filterText: this._filterText,
-				disabled: this.disabled,
-				horizontalAlign: 'right',
-				externalValues: this.externalValues,
-				onOpenedChanged,
-				content: html`
-					<h3>${this.title}</h3>
-					<cosmoz-input
-						class=${this._fromClasses}
-						type="number"
-						label=${t('From')}
-						.value=${this._filterInput?.min}
-						@value-changed=${(event) => {
-							this.set('_filterInput.min', event.detail.value);
-						}}
-						@blur=${(event) => this._onBlur(event)}
-						@keydown=${(event) => this._onKeyDown(event)}
-						min=${this._toInputString(this._limit.fromMin)}
-						max=${this._toInputString(this._limit.fromMax)}
-					></cosmoz-input>
-					<cosmoz-input
-						class=${this._toClasses}
-						type="number"
-						label=${t('To')}
-						.value=${this._filterInput?.max}
-						@value-changed=${(event) => {
-							this.set('_filterInput.max', event.detail.value);
-						}}
-						@blur=${(event) => this._onBlur(event)}
-						@keydown=${(event) => this._onKeyDown(event)}
-						min=${this._toInputString(this._limit.toMin)}
-						max=${this._toInputString(this._limit.toMax)}
-					></cosmoz-input>
+			${when(
+				this.disabled,
+				() => html`
+					<cosmoz-omnitable-dropdown-input
+						disabled
+						.label=${this.title}
+						.value=${this._filterText ?? ''}
+					></cosmoz-omnitable-dropdown-input>
 				`,
-			})}
+				() =>
+					renderDropdown({
+						title: this.title,
+						tooltip: this._tooltip,
+						filterText: this._filterText,
+						horizontalAlign: 'right',
+						externalValues: this.externalValues,
+						onOpenedChanged,
+						content: html`
+							<h3>${this.title}</h3>
+							<cosmoz-input
+								class=${this._fromClasses}
+								type="number"
+								label=${t('From')}
+								.value=${this._filterInput?.min}
+								@value-changed=${(event) => {
+									this.set('_filterInput.min', event.detail.value);
+								}}
+								@blur=${(event) => this._onBlur(event)}
+								@keydown=${(event) => this._onKeyDown(event)}
+								min=${this._toInputString(this._limit.fromMin)}
+								max=${this._toInputString(this._limit.fromMax)}
+							></cosmoz-input>
+							<cosmoz-input
+								class=${this._toClasses}
+								type="number"
+								label=${t('To')}
+								.value=${this._filterInput?.max}
+								@value-changed=${(event) => {
+									this.set('_filterInput.max', event.detail.value);
+								}}
+								@blur=${(event) => this._onBlur(event)}
+								@keydown=${(event) => this._onKeyDown(event)}
+								min=${this._toInputString(this._limit.toMin)}
+								max=${this._toInputString(this._limit.toMax)}
+							></cosmoz-input>
+						`,
+					}),
+			)}
 		`;
 	}
 

--- a/src/lib/cosmoz-omnitable-number-range-input.js
+++ b/src/lib/cosmoz-omnitable-number-range-input.js
@@ -59,14 +59,6 @@ class NumberRangeInput extends rangeInputMixin(
 			</style>
 
 			${when(
-				!this.disabled,
-				() =>
-					html`<cosmoz-clear-button
-						@click=${() => this.resetFilter()}
-						?visible=${this.hasFilter()}
-					></cosmoz-clear-button>`,
-			)}
-			${when(
 				this.disabled,
 				() => html`
 					<cosmoz-omnitable-dropdown-input
@@ -75,8 +67,12 @@ class NumberRangeInput extends rangeInputMixin(
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
 				`,
-				() =>
-					renderDropdown({
+				() => html`
+					<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>
+					${renderDropdown({
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
@@ -112,7 +108,8 @@ class NumberRangeInput extends rangeInputMixin(
 								max=${this._toInputString(this._limit.toMax)}
 							></cosmoz-input>
 						`,
-					}),
+					})}
+				`,
 			)}
 		`;
 	}

--- a/src/lib/cosmoz-omnitable-range-input-mixin.js
+++ b/src/lib/cosmoz-omnitable-range-input-mixin.js
@@ -1,7 +1,7 @@
-import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
-import { timeOut } from '@polymer/polymer/lib/utils/async.js';
-import { enqueueDebouncer } from '@polymer/polymer/lib/utils/flush.js';
 import { invoke } from '@neovici/cosmoz-utils/function';
+import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
+import { enqueueDebouncer } from '@polymer/polymer/lib/utils/flush.js';
 
 const getCloseableParent = (el) => {
 	if (!el) return null;
@@ -25,6 +25,7 @@ export const rangeInputMixin = (base) =>
 	class extends base {
 		static get properties() {
 			return {
+				disabled: { type: Boolean, value: false },
 				filter: { type: Object, notify: true },
 
 				values: {

--- a/src/lib/cosmoz-omnitable-time-range-input.js
+++ b/src/lib/cosmoz-omnitable-time-range-input.js
@@ -1,10 +1,10 @@
-import { t } from 'i18next';
-import { PolymerElement } from '@polymer/polymer';
-import { html } from 'lit-html';
 import '@neovici/cosmoz-input';
+import { PolymerElement } from '@polymer/polymer';
+import { t } from 'i18next';
+import { html } from 'lit-html';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
-import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
 class TimeRangeInput extends dateInputMixin(
 	polymerHauntedRender(PolymerElement),
@@ -24,6 +24,7 @@ class TimeRangeInput extends dateInputMixin(
 				title: this.title,
 				tooltip: this._tooltip,
 				filterText: this._filterText,
+				disabled: this.disabled,
 				externalValues: this.externalValues,
 				onOpenedChanged,
 				content: html`

--- a/src/lib/cosmoz-omnitable-time-range-input.js
+++ b/src/lib/cosmoz-omnitable-time-range-input.js
@@ -2,6 +2,7 @@ import '@neovici/cosmoz-input';
 import { PolymerElement } from '@polymer/polymer';
 import { t } from 'i18next';
 import { html } from 'lit-html';
+import { when } from 'lit-html/directives/when.js';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
@@ -15,11 +16,14 @@ class TimeRangeInput extends dateInputMixin(
 		};
 
 		return html`
-			<cosmoz-clear-button
-				@click=${() => this.resetFilter()}
-				?visible=${this.hasFilter()}
-			></cosmoz-clear-button>
-
+			${when(
+				!this.disabled,
+				() =>
+					html`<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>`,
+			)}
 			${renderDropdown({
 				title: this.title,
 				tooltip: this._tooltip,

--- a/src/lib/cosmoz-omnitable-time-range-input.js
+++ b/src/lib/cosmoz-omnitable-time-range-input.js
@@ -18,14 +18,6 @@ class TimeRangeInput extends dateInputMixin(
 
 		return html`
 			${when(
-				!this.disabled,
-				() =>
-					html`<cosmoz-clear-button
-						@click=${() => this.resetFilter()}
-						?visible=${this.hasFilter()}
-					></cosmoz-clear-button>`,
-			)}
-			${when(
 				this.disabled,
 				() => html`
 					<cosmoz-omnitable-dropdown-input
@@ -34,8 +26,12 @@ class TimeRangeInput extends dateInputMixin(
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
 				`,
-				() =>
-					renderDropdown({
+				() => html`
+					<cosmoz-clear-button
+						@click=${() => this.resetFilter()}
+						?visible=${this.hasFilter()}
+					></cosmoz-clear-button>
+					${renderDropdown({
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
@@ -60,7 +56,8 @@ class TimeRangeInput extends dateInputMixin(
 									this.set('_filterInput.max', event.detail.value)}
 							></cosmoz-input>
 						`,
-					}),
+					})}
+				`,
 			)}
 		`;
 	}

--- a/src/lib/cosmoz-omnitable-time-range-input.js
+++ b/src/lib/cosmoz-omnitable-time-range-input.js
@@ -5,6 +5,7 @@ import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 import { dateInputMixin } from './cosmoz-omnitable-date-input-mixin';
 import { renderDropdown } from './cosmoz-omnitable-dropdown';
+import './cosmoz-omnitable-dropdown-input';
 import { polymerHauntedRender } from './polymer-haunted-render-mixin';
 
 class TimeRangeInput extends dateInputMixin(
@@ -24,33 +25,43 @@ class TimeRangeInput extends dateInputMixin(
 						?visible=${this.hasFilter()}
 					></cosmoz-clear-button>`,
 			)}
-			${renderDropdown({
-				title: this.title,
-				tooltip: this._tooltip,
-				filterText: this._filterText,
-				disabled: this.disabled,
-				externalValues: this.externalValues,
-				onOpenedChanged,
-				content: html`
-					<h3 style="margin: 0;">${this.title}</h3>
-					<cosmoz-input
-						type="time"
-						label=${t('From time')}
-						step=${this.filterStep}
-						.value=${this._filterInput.min}
-						@value-changed=${(event) =>
-							this.set('_filterInput.min', event.detail.value)}
-					></cosmoz-input>
-					<cosmoz-input
-						type="time"
-						label=${t('Until time')}
-						step=${this.filterStep}
-						.value=${this._filterInput.max}
-						@value-changed=${(event) =>
-							this.set('_filterInput.max', event.detail.value)}
-					></cosmoz-input>
+			${when(
+				this.disabled,
+				() => html`
+					<cosmoz-omnitable-dropdown-input
+						disabled
+						.label=${this.title}
+						.value=${this._filterText ?? ''}
+					></cosmoz-omnitable-dropdown-input>
 				`,
-			})}
+				() =>
+					renderDropdown({
+						title: this.title,
+						tooltip: this._tooltip,
+						filterText: this._filterText,
+						externalValues: this.externalValues,
+						onOpenedChanged,
+						content: html`
+							<h3 style="margin: 0;">${this.title}</h3>
+							<cosmoz-input
+								type="time"
+								label=${t('From time')}
+								step=${this.filterStep}
+								.value=${this._filterInput.min}
+								@value-changed=${(event) =>
+									this.set('_filterInput.min', event.detail.value)}
+							></cosmoz-input>
+							<cosmoz-input
+								type="time"
+								label=${t('Until time')}
+								step=${this.filterStep}
+								.value=${this._filterInput.max}
+								@value-changed=${(event) =>
+									this.set('_filterInput.max', event.detail.value)}
+							></cosmoz-input>
+						`,
+					}),
+			)}
 		`;
 	}
 

--- a/src/lib/settings/use-settings.js
+++ b/src/lib/settings/use-settings.js
@@ -1,8 +1,8 @@
-import { useMemo, useState, useRef, useCallback } from '@pionjs/pion';
+import { useCallback, useMemo, useRef, useState } from '@pionjs/pion';
 
-import useSavedSettings from './use-saved-settings';
-import normalize, { sgProps } from './normalize';
 import { useDOMColumns } from '../use-dom-columns';
+import normalize, { sgProps } from './normalize';
+import useSavedSettings from './use-saved-settings';
 
 export default ({ settingsId, host }) => {
 	const initial = useMemo(
@@ -21,8 +21,8 @@ export default ({ settingsId, host }) => {
 			setSettings,
 			onReset,
 		),
-		{ enabledColumns } = host,
-		columns = useDOMColumns(host, { enabledColumns }),
+		{ enabledColumns, disabledFiltering } = host,
+		columns = useDOMColumns(host, { enabledColumns, disabledFiltering }),
 		normalizedSettings = useMemo(
 			() =>
 				normalize({

--- a/src/lib/use-dom-columns.js
+++ b/src/lib/use-dom-columns.js
@@ -34,7 +34,7 @@ const verifyColumnSetup = (columns) => {
 	return ok;
 };
 
-const normalizeColumn = (column) => {
+const normalizeColumn = (column, disabledFiltering) => {
 	const valuePath = column.valuePath ?? column.name;
 
 	return {
@@ -45,6 +45,7 @@ const normalizeColumn = (column) => {
 		groupOn: column.groupOn ?? valuePath,
 		sortOn: column.sortOn ?? valuePath,
 		noSort: column.noSort,
+		disabledFiltering: disabledFiltering || column.disabledFiltering,
 
 		minWidth: column.minWidth,
 		width: column.width,
@@ -127,15 +128,15 @@ const collectDomColumns = (assignedElements) => {
 	return domColumns;
 };
 
-const normalizeColumns = (domColumns, enabledColumns) => {
+const normalizeColumns = (domColumns, enabledColumns, disabledFiltering) => {
 	const columns = Array.isArray(enabledColumns)
 		? domColumns.filter((column) => enabledColumns.includes(column.name))
 		: domColumns.filter((column) => !column.disabled);
 
-	return columns.map(normalizeColumn);
+	return columns.map((col) => normalizeColumn(col, disabledFiltering));
 };
 
-export const useDOMColumns = (host, { enabledColumns }) => {
+export const useDOMColumns = (host, { enabledColumns, disabledFiltering }) => {
 	const [columns, setColumns] = useState([]);
 
 	useLayoutEffect(() => {
@@ -159,7 +160,13 @@ export const useDOMColumns = (host, { enabledColumns }) => {
 				previous = current;
 			}
 
-			setColumns(normalizeColumns(collectDomColumns(current), enabledColumns));
+			setColumns(
+				normalizeColumns(
+					collectDomColumns(current),
+					enabledColumns,
+					disabledFiltering,
+				),
+			);
 		};
 
 		const scheduleUpdate = (ev) => {
@@ -179,7 +186,7 @@ export const useDOMColumns = (host, { enabledColumns }) => {
 			host.removeEventListener('cosmoz-column-prop-changed', scheduleUpdate);
 			cancelAnimationFrame(sched);
 		};
-	}, [enabledColumns]);
+	}, [enabledColumns, disabledFiltering]);
 
 	return columns;
 };

--- a/stories/cosmoz-omnitable-full-demo.stories.ts
+++ b/stories/cosmoz-omnitable-full-demo.stories.ts
@@ -21,7 +21,6 @@ const meta: Meta = {
 		hashParam: '',
 		settingsId: '',
 		selectedItems: [],
-		disabled: false,
 		disabledFiltering: false,
 	},
 	argTypes: {
@@ -73,13 +72,6 @@ const meta: Meta = {
 		settingsId: {
 			control: 'text',
 			description: 'ID for storing table settings',
-		},
-		disabled: {
-			control: 'boolean',
-			description: 'Hide one column',
-			table: {
-				defaultValue: { summary: 'false' },
-			},
 		},
 		disabledFiltering: {
 			control: 'boolean',

--- a/stories/cosmoz-omnitable-full-demo.stories.ts
+++ b/stories/cosmoz-omnitable-full-demo.stories.ts
@@ -22,6 +22,7 @@ const meta: Meta = {
 		settingsId: '',
 		selectedItems: [],
 		disabled: false,
+		disabledFiltering: false,
 	},
 	argTypes: {
 		loading: {
@@ -80,6 +81,13 @@ const meta: Meta = {
 				defaultValue: { summary: 'false' },
 			},
 		},
+		disabledFiltering: {
+			control: 'boolean',
+			description: 'Disable filter inputs in all column headers',
+			table: {
+				defaultValue: { summary: 'false' },
+			},
+		},
 	},
 	render: (args) => {
 		return html`
@@ -100,6 +108,7 @@ const meta: Meta = {
 				.descending=${args.descending}
 				.group-on-descending=${args.groupOnDescending}
 				settings-id=${args.settingsId}
+				?disabled-filtering=${args.disabledFiltering}
 			>
 				<cosmoz-omnitable-column
 					priority="-1"

--- a/stories/cosmoz-omnitable.stories.js
+++ b/stories/cosmoz-omnitable.stories.js
@@ -48,6 +48,7 @@ const Template = (args) => {
 				?no-local=${args.noLocal}
 				?no-local-sort=${args.noLocalSort}
 				?no-local-filter=${args.noLocalFilter}
+				?disabled-filtering=${args.disabledFiltering}
 				?loading=${args.loading}
 				mini-breakpoint=${args.miniBreakpoint || '768px'}
 			>
@@ -125,4 +126,9 @@ Loading.args = {
 export const HideSelectAll = Template.bind({});
 HideSelectAll.args = {
 	hideSelectAll: true,
+};
+
+export const DisabledFiltering = Template.bind({});
+DisabledFiltering.args = {
+	disabledFiltering: true,
 };

--- a/test/disabled-filtering.test.js
+++ b/test/disabled-filtering.test.js
@@ -1,0 +1,208 @@
+import { assert, html, nextFrame } from '@open-wc/testing';
+
+import {
+	ignoreResizeObserverLoopErrors,
+	setupOmnitableFixture,
+} from './helpers/utils';
+
+import '../src/cosmoz-omnitable-column-number.js';
+import '../src/cosmoz-omnitable-column.js';
+import '../src/cosmoz-omnitable.js';
+
+const data = [
+	{ id: 1, name: 'Alice', age: 30 },
+	{ id: 2, name: 'Bob', age: 25 },
+	{ id: 3, name: 'Charlie', age: 35 },
+];
+
+suite('disabled-filtering (per-column)', () => {
+	let omnitable;
+
+	ignoreResizeObserverLoopErrors(setup, teardown);
+
+	setup(async () => {
+		omnitable = await setupOmnitableFixture(
+			html`
+				<cosmoz-omnitable
+					hash-param="test-df"
+					style="height:300px"
+					.resizeSpeedFactor=${1}
+					selection-enabled
+				>
+					<cosmoz-omnitable-column
+						title="ID"
+						name="id"
+						value-path="id"
+						disabled-filtering
+					>
+					</cosmoz-omnitable-column>
+					<cosmoz-omnitable-column title="Name" name="name" value-path="name">
+					</cosmoz-omnitable-column>
+					<cosmoz-omnitable-column-number
+						title="Age"
+						name="age"
+						value-path="age"
+						disabled-filtering
+					>
+					</cosmoz-omnitable-column-number>
+				</cosmoz-omnitable>
+			`,
+			data,
+		);
+		await nextFrame();
+	});
+
+	teardown(() => {
+		location.hash = '#!/';
+	});
+
+	test('sets disabledFiltering property on column', () => {
+		const idColumn = omnitable.columns.find((col) => col.name === 'id');
+		assert.isTrue(idColumn.disabledFiltering);
+	});
+
+	test('does not set disabledFiltering on column without attribute', () => {
+		const nameColumn = omnitable.columns.find((col) => col.name === 'name');
+		assert.isFalse(nameColumn.disabledFiltering);
+	});
+
+	test('text column header input is disabled', () => {
+		const idHeaderCell = omnitable.shadowRoot.querySelector(
+			'.header-cell[name="id"]',
+		);
+		const input = idHeaderCell.querySelector('cosmoz-input');
+		assert.isNotNull(input, 'Input should exist');
+		assert.isTrue(input.hasAttribute('disabled'), 'Input should be disabled');
+	});
+
+	test('text column without disabled-filtering has enabled input', () => {
+		const nameHeaderCell = omnitable.shadowRoot.querySelector(
+			'.header-cell[name="name"]',
+		);
+		const input = nameHeaderCell.querySelector('cosmoz-input');
+		assert.isNotNull(input, 'Input should exist');
+		assert.isFalse(
+			input.hasAttribute('disabled'),
+			'Input should not be disabled',
+		);
+	});
+
+	test('number column range input is disabled', () => {
+		const ageHeaderCell = omnitable.shadowRoot.querySelector(
+			'.header-cell[name="age"]',
+		);
+		const rangeInput = ageHeaderCell.querySelector(
+			'cosmoz-omnitable-number-range-input',
+		);
+		assert.isNotNull(rangeInput, 'Range input should exist');
+		assert.isTrue(
+			rangeInput.hasAttribute('disabled'),
+			'Range input should be disabled',
+		);
+	});
+
+	test('sort buttons still render on disabled-filtering columns', () => {
+		const idHeaderCell = omnitable.shadowRoot.querySelector(
+			'.header-cell[name="id"]',
+		);
+		const sortButton = idHeaderCell.querySelector('button.sg');
+		assert.isNotNull(
+			sortButton,
+			'Sort button should still exist for disabled-filtering column',
+		);
+	});
+});
+
+suite('disabled-filtering (table-level)', () => {
+	let omnitable;
+
+	ignoreResizeObserverLoopErrors(setup, teardown);
+
+	setup(async () => {
+		omnitable = await setupOmnitableFixture(
+			html`
+				<cosmoz-omnitable
+					hash-param="test-df2"
+					style="height:300px"
+					.resizeSpeedFactor=${1}
+					selection-enabled
+					disabled-filtering
+				>
+					<cosmoz-omnitable-column title="ID" name="id" value-path="id">
+					</cosmoz-omnitable-column>
+					<cosmoz-omnitable-column title="Name" name="name" value-path="name">
+					</cosmoz-omnitable-column>
+					<cosmoz-omnitable-column-number
+						title="Age"
+						name="age"
+						value-path="age"
+					>
+					</cosmoz-omnitable-column-number>
+				</cosmoz-omnitable>
+			`,
+			data,
+		);
+		await nextFrame();
+	});
+
+	teardown(() => {
+		location.hash = '#!/';
+	});
+
+	test('all columns have disabledFiltering set to true', () => {
+		omnitable.columns.forEach((col) => {
+			assert.isTrue(
+				col.disabledFiltering,
+				`Column "${col.name}" should have disabledFiltering=true`,
+			);
+		});
+	});
+
+	test('all text column inputs are disabled', () => {
+		const idInput = omnitable.shadowRoot
+			.querySelector('.header-cell[name="id"]')
+			?.querySelector('cosmoz-input');
+		const nameInput = omnitable.shadowRoot
+			.querySelector('.header-cell[name="name"]')
+			?.querySelector('cosmoz-input');
+
+		assert.isTrue(
+			idInput?.hasAttribute('disabled'),
+			'ID input should be disabled',
+		);
+		assert.isTrue(
+			nameInput?.hasAttribute('disabled'),
+			'Name input should be disabled',
+		);
+	});
+
+	test('number column range input is disabled', () => {
+		const rangeInput = omnitable.shadowRoot
+			.querySelector('.header-cell[name="age"]')
+			?.querySelector('cosmoz-omnitable-number-range-input');
+		assert.isTrue(
+			rangeInput?.hasAttribute('disabled'),
+			'Age range input should be disabled',
+		);
+	});
+
+	test('table-level overrides per-column (columns without attribute are still disabled)', () => {
+		// None of the columns have disabled-filtering attribute, but the table does
+		const nameColumn = omnitable.columns.find((col) => col.name === 'name');
+		assert.isTrue(
+			nameColumn.disabledFiltering,
+			'Column without per-column disabled-filtering should still be disabled due to table-level attribute',
+		);
+	});
+
+	test('sort buttons still render', () => {
+		const idHeaderCell = omnitable.shadowRoot.querySelector(
+			'.header-cell[name="id"]',
+		);
+		const sortButton = idHeaderCell.querySelector('button.sg');
+		assert.isNotNull(
+			sortButton,
+			'Sort button should still exist when filtering is disabled',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Adds `disabled-filtering` attribute to disable filter inputs in column headers while preserving sort functionality.

- **Per-column**: `<cosmoz-omnitable-column disabled-filtering>`
- **Table-level**: `<cosmoz-omnitable disabled-filtering>` (applies to all columns)

When disabled:
- Filter inputs render as disabled (solid underline, full opacity, no interaction)
- Clear buttons are hidden
- Sort buttons remain functional
- Existing filter state is preserved

## Implementation

- Range inputs (number, date, datetime, time, amount): render static `<cosmoz-omnitable-dropdown-input disabled>`
- Autocomplete columns: pass `?disabled` to `cosmoz-autocomplete-ui` which handles it natively
- Text/boolean columns: render `<cosmoz-input disabled>`

## Tests

11 test cases in `test/disabled-filtering.test.js` covering per-column, table-level, and inheritance scenarios.

Closes FE-69