### PR TITLE
fix: use-hash-state bugs

### DIFF
--- a/src/lib/settings/drivers/local.ts
+++ b/src/lib/settings/drivers/local.ts
@@ -1,20 +1,21 @@
 export default ({ prefix = 'omnitable-' } = {}) => {
 	const read = async (settingsId: string) => {
 		if (!settingsId) {
-			return;
+			return null;
 		}
 
 		try {
 			const item = localStorage.getItem(prefix + settingsId);
 
 			if (item == null) {
-				return;
+				return null;
 			}
 
 			return JSON.parse(item);
 		} catch (e) {
 			// eslint-disable-next-line no-console
 			console.error(e);
+			return null;
 		}
 	};
 

--- a/src/lib/settings/drivers/remote.ts
+++ b/src/lib/settings/drivers/remote.ts
@@ -9,10 +9,11 @@ export default (params: RemoteParams) => {
 	const read = async (settingsId: string) => {
 		const key = prefix + settingsId;
 		try {
-			return await get$(key);
+			return (await get$(key)) ?? null;
 		} catch (e) {
 			// eslint-disable-next-line no-console
 			console.error(e);
+			return null;
 		}
 	};
 	const write = async (settingsId: string, settings = {}) => {

--- a/src/lib/settings/use-saved-settings.js
+++ b/src/lib/settings/use-saved-settings.js
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from '@pionjs/pion';
-import { normalizeStore } from './normalize';
 import { useDriver } from './drivers';
+import { normalizeStore } from './normalize';
 
 export default (settingsId, settings, setSettings, onReset) => {
-	const [savedSettings, setSavedSettings] = useState(),
+	const [savedSettings, setSavedSettings] = useState(
+			settingsId ? undefined : null,
+		),
 		{ read, write } = useDriver();
 
 	useEffect(async () => {
@@ -32,7 +34,7 @@ export default (settingsId, settings, setSettings, onReset) => {
 				setSettings();
 				if (e.shiftKey) {
 					await write(settingsId);
-					setSavedSettings();
+					setSavedSettings(null);
 				}
 				onReset?.();
 			},

--- a/src/lib/settings/use-settings.js
+++ b/src/lib/settings/use-settings.js
@@ -43,6 +43,7 @@ export default ({ settingsId, host }) => {
 
 	return {
 		...rest,
+		savedSettings,
 		opened,
 		setOpened,
 		settings: normalizedSettings,

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -1,5 +1,6 @@
 import { navigate } from '@neovici/cosmoz-router';
 import { identity, invoke } from '@neovici/cosmoz-utils/function';
+import { useMeta } from '@neovici/cosmoz-utils/hooks/use-meta';
 import {
 	hashUrl,
 	multiParse,
@@ -104,6 +105,12 @@ export function useHashState<T>(
 	}: SingleHashStateOpts<T> | MultiHashStateOpts<Record<string, unknown>> = {},
 ): [T, (value: T | ((prev: T) => T)) => void] {
 	const link = multi ? multiLink : singleLink,
+		meta = useMeta({
+			param,
+			suffix,
+			link,
+			write: (write ?? identity) as (v: unknown) => string,
+		}),
 		hashWasExplicit = useMemo(() => {
 			if (param == null) return false;
 			if (multi) {
@@ -132,13 +139,9 @@ export function useHashState<T>(
 				_setState((oldState) => {
 					const newState = invoke(state, oldState);
 
-					if (param != null) {
+					if (meta.param != null) {
 						navigate(
-							link(
-								param + suffix,
-								newState,
-								(write ?? identity) as (v: unknown) => string,
-							),
+							meta.link(meta.param + meta.suffix, newState, meta.write),
 							null,
 							{
 								notify: false,
@@ -148,7 +151,7 @@ export function useHashState<T>(
 
 					return newState;
 				}),
-			[param, suffix, link, write],
+			[],
 		);
 
 	// Sync state with initial when:
@@ -156,8 +159,7 @@ export function useHashState<T>(
 	// - AND hash was NOT explicitly provided in URL on mount
 	// - AND initial has meaningful content (not empty object)
 	useEffect(() => {
-		if (param == null) return;
-		if (hashWasExplicit) return;
+		if (meta.param == null || hashWasExplicit) return;
 
 		const isEmptyObj =
 			initial != null &&
@@ -168,7 +170,7 @@ export function useHashState<T>(
 		if (initial != null) {
 			setState(initial);
 		}
-	}, [...Object.values(initial ?? {}), param, hashWasExplicit, setState]);
+	}, [...Object.values(initial ?? {}), hashWasExplicit]);
 
 	return [state, setState];
 }

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -57,15 +57,20 @@ const makeLinker =
 			? searchParams.set(hashParam, codec(value))
 			: searchParams.delete(hashParam),
 	),
-	multiLink = makeLinker((hashParam, value, codec, searchParams) =>
+	multiLink = makeLinker((hashParam, value, codec, searchParams) => {
+		const prefix = hashParam;
+		Array.from(searchParams.keys())
+			.filter((key) => key.startsWith(prefix))
+			.forEach((key) => searchParams.delete(key));
+
 		Object.entries(value as Record<string, unknown>)
 			.map(codec)
 			.forEach(([key, val]) =>
 				!isEmpty(val)
 					? searchParams.set(hashParam + key, val as string)
 					: searchParams.delete(hashParam + key),
-			),
-	);
+			);
+	});
 
 export function useHashState<T>(
 	initial: T,
@@ -93,14 +98,10 @@ export function useHashState<T>(
 		hashWasExplicit = useMemo(() => {
 			if (param == null) return false;
 			if (multi) {
-				return (
-					multiParse(param + suffix, read as MultiCodec<unknown> | undefined) !=
-					null
-				);
+				const result = multiParse(param + suffix);
+				return Object.keys(result).length > 0;
 			}
-			return (
-				singleParse(param + suffix, read as SingleCodec<T> | undefined) != null
-			);
+			return singleParse(param + suffix) !== undefined;
 		}, []),
 		[state, _setState] = useState(() => {
 			if (param == null) return initial;
@@ -109,7 +110,7 @@ export function useHashState<T>(
 					param + suffix,
 					read as MultiCodec<unknown> | undefined,
 				);
-				return (result ?? initial) as T;
+				return Object.keys(result).length > 0 ? (result as T) : initial;
 			}
 			const result = singleParse(
 				param + suffix,

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -82,6 +82,16 @@ const makeLinker =
 		);
 	});
 
+/**
+ * Synchronizes a state value with a URL hash parameter.
+ *
+ * @param initial - The initial state value. **Must be a stable reference** when
+ *   it is an object or array (e.g. a module-level constant, `useMemo`, or
+ *   `useState` value). Passing an inline literal (e.g. `{}`) will cause the
+ *   initial-sync effect to re-fire on every render.
+ * @param param - The URL hash parameter name, or `null`/`undefined` to disable.
+ * @param opts - Optional codec and mode options.
+ */
 export function useHashState<T>(
 	initial: T,
 	param: string | null | undefined,
@@ -157,18 +167,16 @@ export function useHashState<T>(
 	// Sync state with initial when:
 	// - initial changes (e.g., savedSettings loaded async)
 	// - AND hash was NOT explicitly provided in URL on mount
+	// NOTE: `initial` must be a stable reference when it is an object.
+	// Pass a module-level constant, useMemo, or useState value — never an inline literal.
+	// An unstable reference will cause this effect to re-fire on every render.
 	useEffect(() => {
 		if (meta.param == null || hashWasExplicit) return;
 
 		if (initial != null) {
 			setState(initial);
 		}
-	}, [
-		hashWasExplicit,
-		...(typeof initial === 'object' && initial != null
-			? Object.values(initial)
-			: [initial]),
-	]);
+	}, [initial]);
 
 	return [state, setState];
 }

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -170,7 +170,12 @@ export function useHashState<T>(
 		if (initial != null) {
 			setState(initial);
 		}
-	}, [...Object.values(initial ?? {}), hashWasExplicit]);
+	}, [
+		hashWasExplicit,
+		...(typeof initial === 'object' && initial != null
+			? Object.values(initial)
+			: [initial]),
+	]);
 
 	return [state, setState];
 }

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -157,15 +157,8 @@ export function useHashState<T>(
 	// Sync state with initial when:
 	// - initial changes (e.g., savedSettings loaded async)
 	// - AND hash was NOT explicitly provided in URL on mount
-	// - AND initial has meaningful content (not empty object)
 	useEffect(() => {
 		if (meta.param == null || hashWasExplicit) return;
-
-		const isEmptyObj =
-			initial != null &&
-			typeof initial === 'object' &&
-			Object.keys(initial).length === 0;
-		if (isEmptyObj) return;
 
 		if (initial != null) {
 			setState(initial);

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -58,18 +58,27 @@ const makeLinker =
 			: searchParams.delete(hashParam),
 	),
 	multiLink = makeLinker((hashParam, value, codec, searchParams) => {
+		const originalEntries = Object.entries(value as Record<string, unknown>);
+		const entries = originalEntries
+			.map(codec)
+			.filter(([, val]) => val !== undefined);
+
+		// If write returns undefined for ALL entries, do nothing (e.g., columns not ready)
+		// If value was empty object {}, entries will be empty but we should still delete
+		if (entries.length === 0 && originalEntries.length > 0) {
+			return;
+		}
+
 		const prefix = hashParam;
 		Array.from(searchParams.keys())
 			.filter((key) => key.startsWith(prefix))
 			.forEach((key) => searchParams.delete(key));
 
-		Object.entries(value as Record<string, unknown>)
-			.map(codec)
-			.forEach(([key, val]) =>
-				!isEmpty(val)
-					? searchParams.set(hashParam + key, val as string)
-					: searchParams.delete(hashParam + key),
-			);
+		entries.forEach(([key, val]) =>
+			!isEmpty(val)
+				? searchParams.set(hashParam + key, val as string)
+				: searchParams.delete(hashParam + key),
+		);
 	});
 
 export function useHashState<T>(
@@ -145,14 +154,21 @@ export function useHashState<T>(
 	// Sync state with initial when:
 	// - initial changes (e.g., savedSettings loaded async)
 	// - AND hash was NOT explicitly provided in URL on mount
+	// - AND initial has meaningful content (not empty object)
 	useEffect(() => {
 		if (param == null) return;
 		if (hashWasExplicit) return;
 
+		const isEmptyObj =
+			initial != null &&
+			typeof initial === 'object' &&
+			Object.keys(initial).length === 0;
+		if (isEmptyObj) return;
+
 		if (initial != null) {
 			setState(initial);
 		}
-	}, [initial, param, hashWasExplicit, setState]);
+	}, [...Object.values(initial ?? {}), param, hashWasExplicit, setState]);
 
 	return [state, setState];
 }

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -16,6 +16,7 @@ type SingleHashStateOpts<T> = {
 	read?: SingleCodec<T>;
 	write?: (value: T) => string;
 	multi?: false;
+	ready?: boolean;
 };
 
 type MultiHashStateOpts<T extends Record<string, unknown>> = {
@@ -23,6 +24,7 @@ type MultiHashStateOpts<T extends Record<string, unknown>> = {
 	read?: MultiCodec<T[keyof T]>;
 	write?: (entry: [string, T[keyof T]]) => [string, string | undefined];
 	multi: true;
+	ready?: boolean;
 };
 
 const makeLinker =
@@ -85,12 +87,17 @@ const makeLinker =
 /**
  * Synchronizes a state value with a URL hash parameter.
  *
- * @param initial - The initial state value. **Must be a stable reference** when
- *   it is an object or array (e.g. a module-level constant, `useMemo`, or
- *   `useState` value). Passing an inline literal (e.g. `{}`) will cause the
- *   initial-sync effect to re-fire on every render.
+ * On mount, if the hash contains an explicit value for the parameter, that
+ * value is used. Otherwise, `initial` is used.
+ *
+ * When `ready` is `false`, the hook skips syncing `initial` into state.
+ * When `ready` transitions to `true`, the hook syncs `initial` into state
+ * (unless the hash was explicitly set on mount). This is useful for deferring
+ * the initial sync until async data (e.g. saved settings) has loaded.
+ *
+ * @param initial - The initial state value used when the hash is not set.
  * @param param - The URL hash parameter name, or `null`/`undefined` to disable.
- * @param opts - Optional codec and mode options.
+ * @param opts - Optional codec, mode, and readiness options.
  */
 export function useHashState<T>(
 	initial: T,
@@ -111,6 +118,7 @@ export function useHashState<T>(
 		suffix = '',
 		read,
 		write,
+		ready = true,
 		multi,
 	}: SingleHashStateOpts<T> | MultiHashStateOpts<Record<string, unknown>> = {},
 ): [T, (value: T | ((prev: T) => T)) => void] {
@@ -165,18 +173,15 @@ export function useHashState<T>(
 		);
 
 	// Sync state with initial when:
-	// - initial changes (e.g., savedSettings loaded async)
+	// - ready transitions to true (e.g., saved settings loaded async)
 	// - AND hash was NOT explicitly provided in URL on mount
-	// NOTE: `initial` must be a stable reference when it is an object.
-	// Pass a module-level constant, useMemo, or useState value — never an inline literal.
-	// An unstable reference will cause this effect to re-fire on every render.
 	useEffect(() => {
-		if (meta.param == null || hashWasExplicit) return;
+		if (meta.param == null || !ready || hashWasExplicit) return;
 
 		if (initial != null) {
 			setState(initial);
 		}
-	}, [initial]);
+	}, [ready]);
 
 	return [state, setState];
 }

--- a/src/lib/use-hash-state.ts
+++ b/src/lib/use-hash-state.ts
@@ -64,8 +64,8 @@ const makeLinker =
 			.map(codec)
 			.filter(([, val]) => val !== undefined);
 
-		// If write returns undefined for ALL entries, do nothing (e.g., columns not ready)
-		// If value was empty object {}, entries will be empty but we should still delete
+		// Preserve hash when values are not encodable (all are undefined)
+		// Update hash when intent is to clear (empty object)
 		if (entries.length === 0 && originalEntries.length > 0) {
 			return;
 		}

--- a/src/lib/use-omnitable.js
+++ b/src/lib/use-omnitable.js
@@ -21,14 +21,14 @@ export const useOmnitable = (host) => {
 			rowPartFn,
 		} = host,
 		settingS = useSettings({ settingsId, host }),
-		{ settings, setSettings, columns, resetRef } = settingS,
-		sortAndGroupOptions = useSortAndGroupOptions(
-			columns,
-			hashParam,
+		{ settings, setSettings, columns, resetRef, savedSettings } = settingS,
+		ready = savedSettings !== undefined,
+		sortAndGroupOptions = useSortAndGroupOptions(columns, hashParam, {
 			settings,
 			setSettings,
 			resetRef,
-		),
+			ready,
+		}),
 		// TODO: drop filterFunctions
 		{ processedItems, visibleData, filters, setFilterState, filterFunctions } =
 			useProcessedItems({

--- a/src/lib/use-processed-items.js
+++ b/src/lib/use-processed-items.js
@@ -1,11 +1,12 @@
-import { useCallback, useEffect, useMemo } from '@pionjs/pion';
 import { invoke } from '@neovici/cosmoz-utils/function';
+import { useCallback, useEffect, useMemo } from '@pionjs/pion';
 import { genericSorter } from './generic-sorter';
 import { columnSymbol } from './use-dom-columns';
 import { useHashState } from './use-hash-state';
 import { indexSymbol } from './utils';
 
-const sortBy = (valueFn, descending) => (a, b) =>
+const EMPTY_FILTERS = {},
+	sortBy = (valueFn, descending) => (a, b) =>
 		genericSorter(valueFn(a), valueFn(b)) * (descending ? -1 : 1),
 	kebab = (input) =>
 		input.replace(/([a-z0-9])([A-Z])/gu, '$1-$2').toLowerCase(),
@@ -65,7 +66,7 @@ export const useProcessedItems = ({
 			},
 			[columns],
 		),
-		[filters, setFilters] = useHashState({}, hashParam, {
+		[filters, setFilters] = useHashState(EMPTY_FILTERS, hashParam, {
 			multi: true,
 			suffix: '-filter--',
 			write,

--- a/src/lib/use-processed-items.js
+++ b/src/lib/use-processed-items.js
@@ -5,8 +5,7 @@ import { columnSymbol } from './use-dom-columns';
 import { useHashState } from './use-hash-state';
 import { indexSymbol } from './utils';
 
-const EMPTY_FILTERS = {},
-	sortBy = (valueFn, descending) => (a, b) =>
+const sortBy = (valueFn, descending) => (a, b) =>
 		genericSorter(valueFn(a), valueFn(b)) * (descending ? -1 : 1),
 	kebab = (input) =>
 		input.replace(/([a-z0-9])([A-Z])/gu, '$1-$2').toLowerCase(),
@@ -66,7 +65,7 @@ export const useProcessedItems = ({
 			},
 			[columns],
 		),
-		[filters, setFilters] = useHashState(EMPTY_FILTERS, hashParam, {
+		[filters, setFilters] = useHashState({}, hashParam, {
 			multi: true,
 			suffix: '-filter--',
 			write,

--- a/src/lib/use-sort-and-group-options.js
+++ b/src/lib/use-sort-and-group-options.js
@@ -1,10 +1,10 @@
 import {
-	useMemo,
-	createContext,
 	component,
-	useContext,
+	createContext,
 	useCallback,
+	useContext,
 	useEffect,
+	useMemo,
 } from '@pionjs/pion';
 import { useHashState } from './use-hash-state';
 
@@ -22,25 +22,25 @@ const parseBool = (bool) => [true, 'true', 1, 'yes', 'on'].includes(bool),
 export const useSortAndGroupOptions = (
 		columns,
 		hashParam,
-		settings,
-		setSettings,
-		resetRef,
+		{ settings, setSettings, resetRef, ready = true },
 	) => {
 		const [sortOn, setSortOn] = useHashState(settings.sortOn, hashParam, {
 				suffix: '-sortOn',
+				ready,
 			}),
 			[descending, setDescending] = useHashState(
 				boolParam(settings.descending),
 				hashParam,
-				{ suffix: '-descending', read: boolParam },
+				{ suffix: '-descending', read: boolParam, ready },
 			),
 			[groupOn, setGroupOn] = useHashState(settings.groupOn, hashParam, {
 				suffix: '-groupOn',
+				ready,
 			}),
 			[groupOnDescending, setGroupOnDescending] = useHashState(
 				boolParam(settings.groupOnDescending),
 				hashParam,
-				{ suffix: '-groupOnDescending', read: boolParam },
+				{ suffix: '-groupOnDescending', read: boolParam, ready },
 			),
 			sortOnColumn = useMemo(
 				() => columns.find((column) => column.name === sortOn),

--- a/test/hash-param-write.test.js
+++ b/test/hash-param-write.test.js
@@ -1,4 +1,4 @@
-import { assert, html, nextFrame } from '@open-wc/testing';
+import { assert, aTimeout, html, nextFrame } from '@open-wc/testing';
 
 import {
 	ignoreResizeObserverLoopErrors,
@@ -207,7 +207,7 @@ suite('hash params vs saved settings', () => {
 		await instantiateWithSettings();
 
 		// Wait for async settings load
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await aTimeout(50);
 		await nextFrame();
 
 		assert.equal(omnitable.sortOn, 'name');
@@ -273,7 +273,7 @@ suite('hash params vs saved settings', () => {
 		await instantiateWithSettings();
 
 		// Wait for async settings load
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await aTimeout(50);
 
 		assert.equal(omnitable.sortOn, 'id');
 		assert.equal(omnitable.descending, false);
@@ -289,7 +289,7 @@ suite('hash params vs saved settings', () => {
 		await instantiateWithSettings();
 
 		// Wait for async settings load
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		await aTimeout(50);
 
 		assert.equal(omnitable.sortOn, 'id');
 		assert.equal(omnitable.groupOn, 'group');

--- a/test/hash-param-write.test.js
+++ b/test/hash-param-write.test.js
@@ -5,9 +5,9 @@ import {
 	setupOmnitableFixture,
 } from './helpers/utils';
 
-import '../src/cosmoz-omnitable.js';
 import '../src/cosmoz-omnitable-column-autocomplete.js';
 import '../src/cosmoz-omnitable-column.js';
+import '../src/cosmoz-omnitable.js';
 
 let omnitable;
 const data = [
@@ -33,50 +33,89 @@ const data = [
 		},
 	],
 	location = window.location,
+	basicFixture = html`
+		<cosmoz-omnitable
+			hash-param="test"
+			style="height:300px"
+			.resizeSpeedFactor=${1}
+		>
+			<cosmoz-omnitable-column-autocomplete
+				width="40px"
+				title="Id"
+				name="id"
+				value-path="id"
+				sort-on="id"
+				group-on="id"
+			>
+			</cosmoz-omnitable-column-autocomplete>
+			<cosmoz-omnitable-column-autocomplete
+				title="Group"
+				name="group"
+				value-path="group"
+				flex="0"
+				width="125px"
+			>
+			</cosmoz-omnitable-column-autocomplete>
+			<cosmoz-omnitable-column
+				title="Name"
+				name="name"
+				value-path="name"
+				sort-on="name"
+				group-on="name"
+				flex="2"
+			>
+			</cosmoz-omnitable-column>
+		</cosmoz-omnitable>
+	`,
+	savedSettingsFixture = html`
+		<cosmoz-omnitable
+			hash-param="test"
+			settings-id="test-settings"
+			style="height:300px"
+			.resizeSpeedFactor=${1}
+		>
+			<cosmoz-omnitable-column-autocomplete
+				width="40px"
+				title="Id"
+				name="id"
+				value-path="id"
+				sort-on="id"
+				group-on="id"
+			>
+			</cosmoz-omnitable-column-autocomplete>
+			<cosmoz-omnitable-column-autocomplete
+				title="Group"
+				name="group"
+				value-path="group"
+				flex="0"
+				width="125px"
+			>
+			</cosmoz-omnitable-column-autocomplete>
+			<cosmoz-omnitable-column
+				title="Name"
+				name="name"
+				value-path="name"
+				sort-on="name"
+				group-on="name"
+				flex="2"
+			>
+			</cosmoz-omnitable-column>
+		</cosmoz-omnitable>
+	`,
 	instantiate = async () => {
 		await nextFrame();
-		omnitable = await setupOmnitableFixture(
-			html`
-				<cosmoz-omnitable
-					hash-param="test"
-					style="height:300px"
-					.resizeSpeedFactor=${1}
-				>
-					<cosmoz-omnitable-column-autocomplete
-						width="40px"
-						title="Id"
-						name="id"
-						value-path="id"
-						sort-on="id"
-						group-on="id"
-					>
-					</cosmoz-omnitable-column-autocomplete>
-					<cosmoz-omnitable-column-autocomplete
-						title="Group"
-						name="group"
-						value-path="group"
-						flex="0"
-						width="125px"
-					>
-					</cosmoz-omnitable-column-autocomplete>
-					<cosmoz-omnitable-column
-						title="Name"
-						name="name"
-						value-path="name"
-						sort-on="name"
-						group-on="name"
-						flex="2"
-					>
-					</cosmoz-omnitable-column>
-				</cosmoz-omnitable>
-			`,
-			data,
-		);
+		omnitable = await setupOmnitableFixture(basicFixture, data);
+		await nextFrame();
+	},
+	instantiateWithSettings = async () => {
+		await nextFrame();
+		omnitable = await setupOmnitableFixture(savedSettingsFixture, data);
 		await nextFrame();
 	};
 
 suite('basic-write', () => {
 	ignoreResizeObserverLoopErrors(setup, teardown);
+
 	setup(async () => {
 		location.hash = '#!/';
 		await instantiate();
@@ -130,5 +169,131 @@ suite('basic-write', () => {
 		omnitable.setFilterState('id', { filter: null });
 		await nextFrame();
 		assert.equal(location.hash, '#!/');
+	});
+});
+
+suite('hash params vs saved settings', () => {
+	const SETTINGS_KEY = 'omnitable-test-settings';
+
+	ignoreResizeObserverLoopErrors(setup, teardown);
+
+	setup(() => {
+		localStorage.removeItem(SETTINGS_KEY);
+	});
+
+	teardown(() => {
+		localStorage.removeItem(SETTINGS_KEY);
+	});
+
+	test('hash params override saved settings', async () => {
+		localStorage.setItem(
+			SETTINGS_KEY,
+			JSON.stringify({ sortOn: 'name', descending: false }),
+		);
+		location.hash = '#!/#test-sortOn=id&test-descending=true';
+		await instantiateWithSettings();
+
+		assert.equal(omnitable.sortOn, 'id');
+		assert.equal(omnitable.descending, true);
+		assert.equal(location.hash, '#!/#test-sortOn=id&test-descending=true');
+	});
+
+	test('saved settings sync to hash when no hash params', async () => {
+		localStorage.setItem(
+			SETTINGS_KEY,
+			JSON.stringify({ sortOn: 'name', descending: true }),
+		);
+		location.hash = '#!/';
+		await instantiateWithSettings();
+
+		// Wait for async settings load
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		await nextFrame();
+
+		assert.equal(omnitable.sortOn, 'name');
+		assert.equal(omnitable.descending, true);
+		assert.equal(location.hash, '#!/#test-sortOn=name&test-descending=true');
+	});
+
+	test('host attribute syncs to hash when no hash params and no saved', async () => {
+		location.hash = '#!/';
+		await nextFrame();
+
+		// Set host attribute before columns ready
+		omnitable = await setupOmnitableFixture(
+			html`
+				<cosmoz-omnitable
+					hash-param="test"
+					sort-on="group"
+					style="height:300px"
+					.resizeSpeedFactor=${1}
+				>
+					<cosmoz-omnitable-column-autocomplete
+						width="40px"
+						title="Id"
+						name="id"
+						value-path="id"
+						sort-on="id"
+						group-on="id"
+					>
+					</cosmoz-omnitable-column-autocomplete>
+					<cosmoz-omnitable-column-autocomplete
+						title="Group"
+						name="group"
+						value-path="group"
+						flex="0"
+						width="125px"
+					>
+					</cosmoz-omnitable-column-autocomplete>
+					<cosmoz-omnitable-column
+						title="Name"
+						name="name"
+						value-path="name"
+						sort-on="name"
+						group-on="name"
+						flex="2"
+					>
+					</cosmoz-omnitable-column>
+				</cosmoz-omnitable>
+			`,
+			data,
+		);
+		await nextFrame();
+
+		assert.equal(omnitable.sortOn, 'group');
+		assert.equal(location.hash, '#!/#test-sortOn=group');
+	});
+
+	test('saved settings load async does not overwrite explicit hash', async () => {
+		localStorage.setItem(
+			SETTINGS_KEY,
+			JSON.stringify({ sortOn: 'name', descending: true }),
+		);
+		location.hash = '#!/#test-sortOn=id&test-descending=false';
+		await instantiateWithSettings();
+
+		// Wait for async settings load
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		assert.equal(omnitable.sortOn, 'id');
+		assert.equal(omnitable.descending, false);
+		assert.equal(location.hash, '#!/#test-sortOn=id&test-descending=false');
+	});
+
+	test('multiple params: hash params take precedence individually', async () => {
+		localStorage.setItem(
+			SETTINGS_KEY,
+			JSON.stringify({ sortOn: 'name', groupOn: 'group' }),
+		);
+		location.hash = '#!/#test-sortOn=id';
+		await instantiateWithSettings();
+
+		// Wait for async settings load
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		assert.equal(omnitable.sortOn, 'id');
+		assert.equal(omnitable.groupOn, 'group');
+		assert.include(location.hash, 'test-sortOn=id');
+		assert.include(location.hash, 'test-groupOn=group');
 	});
 });

--- a/test/hash-param-write.test.js
+++ b/test/hash-param-write.test.js
@@ -1,4 +1,4 @@
-import { assert, aTimeout, html, nextFrame } from '@open-wc/testing';
+import { assert, html, nextFrame } from '@open-wc/testing';
 
 import {
 	ignoreResizeObserverLoopErrors,
@@ -207,7 +207,7 @@ suite('hash params vs saved settings', () => {
 		await instantiateWithSettings();
 
 		// Wait for async settings load
-		await aTimeout(50);
+		await nextFrame();
 		await nextFrame();
 
 		assert.equal(omnitable.sortOn, 'name');
@@ -273,7 +273,8 @@ suite('hash params vs saved settings', () => {
 		await instantiateWithSettings();
 
 		// Wait for async settings load
-		await aTimeout(50);
+		await nextFrame();
+		await nextFrame();
 
 		assert.equal(omnitable.sortOn, 'id');
 		assert.equal(omnitable.descending, false);
@@ -289,7 +290,8 @@ suite('hash params vs saved settings', () => {
 		await instantiateWithSettings();
 
 		// Wait for async settings load
-		await aTimeout(50);
+		await nextFrame();
+		await nextFrame();
 
 		assert.equal(omnitable.sortOn, 'id');
 		assert.equal(omnitable.groupOn, 'group');

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -17,7 +17,7 @@ suite('useHashState', () => {
 			const { result } = await renderHook(() =>
 				useHashState('name', 'test', { suffix: '-sortOn' }),
 			);
-			const [value, setValue]: [
+			const [value]: [
 				string,
 				(v: string | ((p: string) => string)) => void,
 			] = result.current;
@@ -165,7 +165,7 @@ suite('useHashState', () => {
 				useHashState<string[]>([], 'test', { suffix: '-suffix' }),
 			);
 			expect(result.current[0]).to.deep.equal(['a', 'b']);
-			expect(Array.isArray(result.current[0])).to.be.true;
+			expect(Array.isArray(result.current[0])).to.equal(true);
 		});
 
 		test('empty string value', async () => {

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -282,19 +282,7 @@ suite('useHashState', () => {
 			await rerender({ foo: 'synced' });
 			await nextFrame();
 			expect(result.current[0]).to.deep.equal({ foo: 'synced' });
-		});
-
-		test('syncs with initial changes when empty hash in multi mode', async () => {
-			location.hash = '#!/';
-			const { result, rerender } = await renderHook(
-				(initial: Record<string, string>) =>
-					useHashState(initial, 'test', { suffix: '-', multi: true }),
-				{ initialProps: {} },
-			);
-			expect(result.current[0]).to.deep.equal({});
-			await rerender({ bar: 'newValue' });
-			await nextFrame();
-			expect(location.hash).to.include('test-bar=newValue');
+			expect(location.hash).to.include('test-foo=synced');
 		});
 
 		test('with read codec - parses values', async () => {

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -2,6 +2,8 @@ import { renderHook } from '@neovici/testing';
 import { expect, nextFrame } from '@open-wc/testing';
 import { useHashState } from '../src/lib/use-hash-state.js';
 
+const EMPTY_RECORD: Record<string, string> = {};
+
 suite('useHashState', () => {
 	setup(() => {
 		location.hash = '#!/';
@@ -207,7 +209,7 @@ suite('useHashState', () => {
 		test('uses initial value when no hash params exist', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -218,7 +220,7 @@ suite('useHashState', () => {
 		test('uses hash params when they exist', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -229,7 +231,7 @@ suite('useHashState', () => {
 		test('setState updates multiple hash params', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -242,7 +244,7 @@ suite('useHashState', () => {
 		test('setState with function receives previous state', async () => {
 			location.hash = '#!/#test-foo=a';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -290,7 +292,7 @@ suite('useHashState', () => {
 				parseInt(value, 10),
 			];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, number>>({}, 'test', {
+				useHashState<Record<string, number>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 					read,
@@ -306,7 +308,7 @@ suite('useHashState', () => {
 				value.toUpperCase(),
 			];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 					write,
@@ -319,7 +321,7 @@ suite('useHashState', () => {
 		test('delete param via empty string value', async () => {
 			location.hash = '#!/#test-foo=a';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -332,7 +334,7 @@ suite('useHashState', () => {
 		test('delete param via setState removing key', async () => {
 			location.hash = '#!/#test-foo=a';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -345,7 +347,7 @@ suite('useHashState', () => {
 		test('setState replaces all params for prefix', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b&other=x';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -365,7 +367,7 @@ suite('useHashState', () => {
 				string | undefined,
 			] => [key, value === 'delete-me' ? '' : value];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 					write,
@@ -382,7 +384,7 @@ suite('useHashState', () => {
 				string | undefined,
 			] => [key, value === 'delete-me' ? null! : value];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 					write,
@@ -395,7 +397,7 @@ suite('useHashState', () => {
 		test('special characters are URL decoded', async () => {
 			location.hash = '#!/#test-foo=hello%20world';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -406,7 +408,7 @@ suite('useHashState', () => {
 		test('empty object initial', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -417,7 +419,7 @@ suite('useHashState', () => {
 		test('param: null - does not interact with hash', async () => {
 			location.hash = '#!/existing=hash';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, null, {
+				useHashState<Record<string, string>>(EMPTY_RECORD, null, {
 					suffix: '-',
 					multi: true,
 				}),
@@ -452,7 +454,7 @@ suite('useHashState', () => {
 		test('concurrent setState calls - last write wins', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -467,7 +469,7 @@ suite('useHashState', () => {
 		test('mixing add and delete in single setState', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>({}, 'test', {
+				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
 					suffix: '-',
 					multi: true,
 				}),

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -145,7 +145,7 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.equal('initial');
 		});
 
-		test('regression: param exists but codec returns null - hashWasExplicit is true', async () => {
+		test('codec returning null does not trigger initial sync', async () => {
 			location.hash = '#!/#test-suffix=value';
 			const read = (): null => null;
 			const { result, rerender } = await renderHook(
@@ -284,7 +284,7 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.deep.equal({ foo: 'synced' });
 		});
 
-		test('regression: empty multiParse result treated as non-explicit', async () => {
+		test('syncs with initial changes when empty hash in multi mode', async () => {
 			location.hash = '#!/';
 			const { result, rerender } = await renderHook(
 				(initial: Record<string, string>) =>
@@ -356,7 +356,7 @@ suite('useHashState', () => {
 			expect(location.hash).to.equal('#!/');
 		});
 
-		test('regression: multiLink deletes all params with prefix', async () => {
+		test('setState replaces all params for prefix in multi mode', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b&other=x';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string>>({}, 'test', {
@@ -449,7 +449,7 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.equal(null);
 		});
 
-		test('regression: undefined initial value preserved when no hash params', async () => {
+		test('undefined initial value preserved in multi mode', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string> | undefined>(undefined, 'test', {

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -2,8 +2,6 @@ import { renderHook } from '@neovici/testing';
 import { expect, nextFrame } from '@open-wc/testing';
 import { useHashState } from '../src/lib/use-hash-state.js';
 
-const EMPTY_RECORD: Record<string, string> = {};
-
 suite('useHashState', () => {
 	setup(() => {
 		location.hash = '#!/';
@@ -32,17 +30,17 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.equal('id');
 		});
 
-		test('updates state when initial changes and hash was not explicit', async () => {
+		test('updates state when ready transitions and hash was not explicit', async () => {
 			location.hash = '#!/';
 			const { result, rerender } = await renderHook(
-				(initial: string) =>
-					useHashState(initial, 'test', { suffix: '-sortOn' }),
-				{ initialProps: 'name' },
+				({ initial, ready }: { initial: string; ready: boolean }) =>
+					useHashState(initial, 'test', { suffix: '-sortOn', ready }),
+				{ initialProps: { initial: 'name', ready: false } },
 			);
 
 			expect(result.current[0]).to.equal('name');
 
-			await rerender('id');
+			await rerender({ initial: 'id', ready: true });
 			await nextFrame();
 
 			expect(result.current[0]).to.equal('id');
@@ -52,18 +50,35 @@ suite('useHashState', () => {
 		test('does not override state when hash was explicit', async () => {
 			location.hash = '#!/#test-sortOn=date';
 			const { result, rerender } = await renderHook(
-				(initial: string) =>
-					useHashState(initial, 'test', { suffix: '-sortOn' }),
-				{ initialProps: 'name' },
+				({ initial, ready }: { initial: string; ready: boolean }) =>
+					useHashState(initial, 'test', { suffix: '-sortOn', ready }),
+				{ initialProps: { initial: 'name', ready: false } },
 			);
 
 			expect(result.current[0]).to.equal('date');
 
-			await rerender('id');
+			await rerender({ initial: 'id', ready: true });
 			await nextFrame();
 
 			expect(result.current[0]).to.equal('date');
 			expect(location.hash).to.include('test-sortOn=date');
+		});
+
+		test('syncs on mount when ready is true (default)', async () => {
+			location.hash = '#!/';
+			const { result } = await renderHook(() =>
+				useHashState('initial', 'test', { suffix: '-suffix' }),
+			);
+			expect(result.current[0]).to.equal('initial');
+			expect(location.hash).to.include('test-suffix=initial');
+		});
+
+		test('does not sync when ready is false', async () => {
+			location.hash = '#!/';
+			const { result } = await renderHook(() =>
+				useHashState('initial', 'test', { suffix: '-suffix', ready: false }),
+			);
+			expect(result.current[0]).to.equal('initial');
 		});
 
 		test('setState updates hash', async () => {
@@ -145,20 +160,6 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.equal('initial');
 		});
 
-		test('codec returning null does not trigger initial sync', async () => {
-			location.hash = '#!/#test-suffix=value';
-			const read = (): null => null;
-			const { result, rerender } = await renderHook(
-				(initial: string) =>
-					useHashState(initial, 'test', { suffix: '-suffix', read }),
-				{ initialProps: 'initial' },
-			);
-			expect(result.current[0]).to.equal('initial');
-			await rerender('newInitial');
-			await nextFrame();
-			expect(result.current[0]).to.equal('initial');
-		});
-
 		test('multiple values for same param returns array', async () => {
 			location.hash = '#!/#test-suffix=a&test-suffix=b';
 			const { result } = await renderHook(() =>
@@ -209,7 +210,7 @@ suite('useHashState', () => {
 		test('uses initial value when no hash params exist', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -220,7 +221,7 @@ suite('useHashState', () => {
 		test('uses hash params when they exist', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -231,7 +232,7 @@ suite('useHashState', () => {
 		test('setState updates multiple hash params', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -244,7 +245,7 @@ suite('useHashState', () => {
 		test('setState with function receives previous state', async () => {
 			location.hash = '#!/#test-foo=a';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -258,31 +259,74 @@ suite('useHashState', () => {
 			expect(location.hash).to.include('test-bar=b');
 		});
 
-		test('does not override when hash was explicit', async () => {
+		test('syncs initial when ready transitions', async () => {
+			location.hash = '#!/';
+			const { result, rerender } = await renderHook(
+				({
+					initial,
+					ready,
+				}: {
+					initial: Record<string, string>;
+					ready: boolean;
+				}) =>
+					useHashState(initial, 'test', { suffix: '-', multi: true, ready }),
+				{ initialProps: { initial: {}, ready: false } },
+			);
+			expect(result.current[0]).to.deep.equal({});
+			await rerender({ initial: { foo: 'synced' }, ready: true });
+			await nextFrame();
+			expect(result.current[0]).to.deep.equal({ foo: 'synced' });
+			expect(location.hash).to.include('test-foo=synced');
+		});
+
+		test('does not sync when ready transitions but hash was explicit', async () => {
 			location.hash = '#!/#test-foo=explicit';
 			const { result, rerender } = await renderHook(
-				(initial: Record<string, string>) =>
-					useHashState(initial, 'test', { suffix: '-', multi: true }),
-				{ initialProps: {} },
+				({
+					initial,
+					ready,
+				}: {
+					initial: Record<string, string>;
+					ready: boolean;
+				}) =>
+					useHashState(initial, 'test', { suffix: '-', multi: true, ready }),
+				{ initialProps: { initial: {}, ready: false } },
 			);
 			expect(result.current[0]).to.deep.equal({ foo: 'explicit' });
-			await rerender({ new: 'ignored' });
+			await rerender({ initial: { new: 'ignored' }, ready: true });
 			await nextFrame();
 			expect(result.current[0]).to.deep.equal({ foo: 'explicit' });
 		});
 
-		test('syncs with initial when hash was not explicit', async () => {
+		test('does not sync when ready stays false', async () => {
 			location.hash = '#!/';
 			const { result, rerender } = await renderHook(
-				(initial: Record<string, string>) =>
-					useHashState(initial, 'test', { suffix: '-', multi: true }),
-				{ initialProps: {} },
+				({
+					initial,
+					ready,
+				}: {
+					initial: Record<string, string>;
+					ready: boolean;
+				}) =>
+					useHashState(initial, 'test', { suffix: '-', multi: true, ready }),
+				{ initialProps: { initial: {}, ready: false } },
 			);
 			expect(result.current[0]).to.deep.equal({});
-			await rerender({ foo: 'synced' });
+			await rerender({ initial: { foo: 'bar' }, ready: false });
 			await nextFrame();
-			expect(result.current[0]).to.deep.equal({ foo: 'synced' });
-			expect(location.hash).to.include('test-foo=synced');
+			expect(result.current[0]).to.deep.equal({});
+		});
+
+		test('syncs on mount when ready is true (default)', async () => {
+			location.hash = '#!/';
+			const { result } = await renderHook(() =>
+				useHashState<Record<string, string>>({ foo: 'bar' }, 'test', {
+					suffix: '-',
+					multi: true,
+				}),
+			);
+			expect(result.current[0]).to.deep.equal({ foo: 'bar' });
+			expect(location.hash).to.include('test-foo=bar');
 		});
 
 		test('with read codec - parses values', async () => {
@@ -292,7 +336,7 @@ suite('useHashState', () => {
 				parseInt(value, 10),
 			];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, number>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, number>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 					read,
@@ -308,7 +352,7 @@ suite('useHashState', () => {
 				value.toUpperCase(),
 			];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 					write,
@@ -321,7 +365,7 @@ suite('useHashState', () => {
 		test('delete param via empty string value', async () => {
 			location.hash = '#!/#test-foo=a';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -334,7 +378,7 @@ suite('useHashState', () => {
 		test('delete param via setState removing key', async () => {
 			location.hash = '#!/#test-foo=a';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -347,7 +391,7 @@ suite('useHashState', () => {
 		test('setState replaces all params for prefix', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b&other=x';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -367,7 +411,7 @@ suite('useHashState', () => {
 				string | undefined,
 			] => [key, value === 'delete-me' ? '' : value];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 					write,
@@ -384,7 +428,7 @@ suite('useHashState', () => {
 				string | undefined,
 			] => [key, value === 'delete-me' ? null! : value];
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 					write,
@@ -397,7 +441,7 @@ suite('useHashState', () => {
 		test('special characters are URL decoded', async () => {
 			location.hash = '#!/#test-foo=hello%20world';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -408,7 +452,7 @@ suite('useHashState', () => {
 		test('empty object initial', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -419,7 +463,7 @@ suite('useHashState', () => {
 		test('param: null - does not interact with hash', async () => {
 			location.hash = '#!/existing=hash';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, null, {
+				useHashState<Record<string, string>>({}, null, {
 					suffix: '-',
 					multi: true,
 				}),
@@ -454,7 +498,7 @@ suite('useHashState', () => {
 		test('concurrent setState calls - last write wins', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),
@@ -469,7 +513,7 @@ suite('useHashState', () => {
 		test('mixing add and delete in single setState', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b';
 			const { result } = await renderHook(() =>
-				useHashState<Record<string, string>>(EMPTY_RECORD, 'test', {
+				useHashState<Record<string, string>>({}, 'test', {
 					suffix: '-',
 					multi: true,
 				}),

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -17,10 +17,8 @@ suite('useHashState', () => {
 			const { result } = await renderHook(() =>
 				useHashState('name', 'test', { suffix: '-sortOn' }),
 			);
-			const [value]: [
-				string,
-				(v: string | ((p: string) => string)) => void,
-			] = result.current;
+			const [value]: [string, (v: string | ((p: string) => string)) => void] =
+				result.current;
 			expect(value).to.equal('name');
 		});
 
@@ -354,7 +352,10 @@ suite('useHashState', () => {
 			);
 			expect(result.current[0]).to.deep.equal({ foo: 'a', bar: 'b' });
 			await result.current[1]({ baz: 'c' });
-			expect(location.hash).to.equal('#!/#test-baz=c&other=x');
+			expect(location.hash).to.include('test-baz=c');
+			expect(location.hash).to.include('other=x');
+			expect(location.hash).to.not.include('test-foo');
+			expect(location.hash).to.not.include('test-bar');
 		});
 
 		test('delete param via write returning empty string', async () => {

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -145,6 +145,20 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.equal('initial');
 		});
 
+		test('regression: param exists but codec returns null - hashWasExplicit is true', async () => {
+			location.hash = '#!/#test-suffix=value';
+			const read = (): null => null;
+			const { result, rerender } = await renderHook(
+				(initial: string) =>
+					useHashState(initial, 'test', { suffix: '-suffix', read }),
+				{ initialProps: 'initial' },
+			);
+			expect(result.current[0]).to.equal('initial');
+			await rerender('newInitial');
+			await nextFrame();
+			expect(result.current[0]).to.equal('initial');
+		});
+
 		test('multiple values for same param returns array', async () => {
 			location.hash = '#!/#test-suffix=a&test-suffix=b';
 			const { result } = await renderHook(() =>
@@ -257,7 +271,7 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.deep.equal({ foo: 'explicit' });
 		});
 
-		test('BUG: syncs with initial when hash was not explicit', async () => {
+		test('syncs with initial when hash was not explicit', async () => {
 			location.hash = '#!/';
 			const { result, rerender } = await renderHook(
 				(initial: Record<string, string>) =>
@@ -267,7 +281,20 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.deep.equal({});
 			await rerender({ foo: 'synced' });
 			await nextFrame();
+			expect(result.current[0]).to.deep.equal({ foo: 'synced' });
+		});
+
+		test('regression: empty multiParse result treated as non-explicit', async () => {
+			location.hash = '#!/';
+			const { result, rerender } = await renderHook(
+				(initial: Record<string, string>) =>
+					useHashState(initial, 'test', { suffix: '-', multi: true }),
+				{ initialProps: {} },
+			);
 			expect(result.current[0]).to.deep.equal({});
+			await rerender({ bar: 'newValue' });
+			await nextFrame();
+			expect(location.hash).to.include('test-bar=newValue');
 		});
 
 		test('with read codec - parses values', async () => {
@@ -316,7 +343,7 @@ suite('useHashState', () => {
 			expect(location.hash).to.equal('#!/');
 		});
 
-		test('delete param via setState removing key - BUG: does not delete', async () => {
+		test('delete param via setState removing key', async () => {
 			location.hash = '#!/#test-foo=a';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string>>({}, 'test', {
@@ -326,7 +353,20 @@ suite('useHashState', () => {
 			);
 			expect(result.current[0]).to.deep.equal({ foo: 'a' });
 			await result.current[1]({});
-			expect(location.hash).to.equal('#!/#test-foo=a');
+			expect(location.hash).to.equal('#!/');
+		});
+
+		test('regression: multiLink deletes all params with prefix', async () => {
+			location.hash = '#!/#test-foo=a&test-bar=b&other=x';
+			const { result } = await renderHook(() =>
+				useHashState<Record<string, string>>({}, 'test', {
+					suffix: '-',
+					multi: true,
+				}),
+			);
+			expect(result.current[0]).to.deep.equal({ foo: 'a', bar: 'b' });
+			await result.current[1]({ baz: 'c' });
+			expect(location.hash).to.equal('#!/#test-baz=c&other=x');
 		});
 
 		test('delete param via write returning empty string', async () => {
@@ -398,7 +438,7 @@ suite('useHashState', () => {
 			expect(location.hash).to.equal('#!/existing=hash');
 		});
 
-		test('null initial value - gets empty object from multiParse', async () => {
+		test('null initial value - preserved when no hash params', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string> | null>(null, 'test', {
@@ -406,10 +446,21 @@ suite('useHashState', () => {
 					multi: true,
 				}),
 			);
-			expect(result.current[0]).to.deep.equal({});
+			expect(result.current[0]).to.equal(null);
 		});
 
-		test('concurrent setState calls - BUG: accumulates hash params', async () => {
+		test('regression: undefined initial value preserved when no hash params', async () => {
+			location.hash = '#!/';
+			const { result } = await renderHook(() =>
+				useHashState<Record<string, string> | undefined>(undefined, 'test', {
+					suffix: '-',
+					multi: true,
+				}),
+			);
+			expect(result.current[0]).to.equal(undefined);
+		});
+
+		test('concurrent setState calls - last write wins', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string>>({}, 'test', {
@@ -421,12 +472,10 @@ suite('useHashState', () => {
 			result.current[1]({ bar: 'second' });
 			result.current[1]({ baz: 'third' });
 			await nextFrame();
-			expect(location.hash).to.include('test-foo=first');
-			expect(location.hash).to.include('test-bar=second');
-			expect(location.hash).to.include('test-baz=third');
+			expect(location.hash).to.equal('#!/#test-baz=third');
 		});
 
-		test('mixing add and delete in single setState - BUG: old params stay', async () => {
+		test('mixing add and delete in single setState', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string>>({}, 'test', {
@@ -438,7 +487,7 @@ suite('useHashState', () => {
 			await result.current[1]({ foo: '', baz: 'c' });
 			expect(location.hash).to.include('test-baz=c');
 			expect(location.hash).to.not.include('test-foo');
-			expect(location.hash).to.include('test-bar=b');
+			expect(location.hash).to.not.include('test-bar');
 		});
 	});
 });

--- a/test/use-hash-state.test.ts
+++ b/test/use-hash-state.test.ts
@@ -344,7 +344,7 @@ suite('useHashState', () => {
 			expect(location.hash).to.equal('#!/');
 		});
 
-		test('setState replaces all params for prefix in multi mode', async () => {
+		test('setState replaces all params for prefix', async () => {
 			location.hash = '#!/#test-foo=a&test-bar=b&other=x';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string>>({}, 'test', {
@@ -437,7 +437,7 @@ suite('useHashState', () => {
 			expect(result.current[0]).to.equal(null);
 		});
 
-		test('undefined initial value preserved in multi mode', async () => {
+		test('undefined initial value preserved', async () => {
 			location.hash = '#!/';
 			const { result } = await renderHook(() =>
 				useHashState<Record<string, string> | undefined>(undefined, 'test', {


### PR DESCRIPTION
## Summary

Implementation correctness fixes for `useHashState`:

- `hashWasExplicit` checks param existence directly (was using codec result)
- Empty `multiParse` result `{}` treated as non-explicit
- `multiLink` deletes all prefix params before setting new state
- `multiLink` preserves hash when `write` can't encode values
- Empty parse result returns `initial` instead of empty object
- `setState` stable via `useMeta` with empty dependency array

### `ready` gate — replacing the initial-sync effect

The original `useEffect([initial])` that synced `initial` into state was a footgun: passing an unstable object reference (e.g. inline `{}`) caused an infinite re-render loop.

Replaced with a `ready` boolean option on `useHashState` (defaults to `true`):
- When `ready` is `false`, the hook skips syncing `initial` into state
- When `ready` transitions `false → true`, the hook syncs `initial` once (unless hash was explicit on mount)
- No dep array on `initial` — infinite loops are impossible regardless of reference stability

**Data flow:** `useSavedSettings` starts with `savedSettings = undefined` (not loaded) or `null` (no settingsId, immediately ready). `useOmnitable` derives `ready = savedSettings !== undefined` and passes it through `useSortAndGroupOptions` to each `useHashState` call.

**Driver changes:** Both `local.ts` and `remote.ts` now return `null` instead of `undefined` for "no data" cases, making the contract consistent: `undefined` = not yet loaded, `null` = loaded but empty.

**Refactors:**
- `useSortAndGroupOptions` now accepts an options object `{ settings, setSettings, resetRef, ready }` instead of 6 positional params
- Reverted `EMPTY_FILTERS` workaround in `use-processed-items` — inline `{}` is safe again

Fixes FE-585