### PR TITLE
fix: support lazy-open in autocomplete column

### DIFF
--- a/src/cosmoz-omnitable-column-autocomplete.js
+++ b/src/cosmoz-omnitable-column-autocomplete.js
@@ -41,6 +41,7 @@ class OmnitableColumnAutocomplete extends listColumnMixin(
 			minWidth: { type: String, value: '55px' },
 			editMinWidth: { type: String, value: '55px' },
 			keepOpened: { type: Boolean, value: true },
+			lazyOpen: { type: Boolean },
 			keepQuery: { type: Boolean },
 			showSingle: { type: Boolean },
 			preserveOrder: { type: Boolean },
@@ -53,6 +54,7 @@ class OmnitableColumnAutocomplete extends listColumnMixin(
 		return {
 			...super.getConfig?.(column),
 			keepOpened: column.keepOpened,
+			lazyOpen: column.lazyOpen,
 			keepQuery: column.keepQuery,
 			showSingle: column.showSingle,
 			preserveOrder: column.preserveOrder,
@@ -82,6 +84,7 @@ class OmnitableColumnAutocomplete extends listColumnMixin(
 			class="external-values-${column.externalValues}"
 			?disabled=${column.disabledFiltering}
 			?keep-opened=${column.keepOpened}
+			?lazy-open=${column.lazyOpen}
 			?keep-query=${column.keepQuery}
 			?show-single=${column.showSingle}
 			?preserve-order=${column.preserveOrder}


### PR DESCRIPTION
## Summary
- add `lazyOpen` support to `cosmoz-omnitable-column-autocomplete`
- forward the `lazy-open` attribute to the underlying `cosmoz-autocomplete-ui`

## Validation
- verified the edited source file has no diagnostics
- `npm run build` is currently blocked by pre-existing TypeScript errors in `src/lib/use-hash-state.ts`, unrelated to this change
