### PR TITLE
fix: correct typo minimumFractionDigsits -> minimumFractionDigits

### DIFF
--- a/src/cosmoz-omnitable-column-number.js
+++ b/src/cosmoz-omnitable-column-number.js
@@ -138,7 +138,7 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 			.limits=${limits}
 			.locale=${locale}
 			.maximumFractionDigits=${maximumFractionDigits}
-			.minimumFractionDigsits=${minimumFractionDigits}
+			.minimumFractionDigits=${minimumFractionDigits}
 			.autoupdate=${autoupdate}
 			@filter-changed=${({ detail: { value } }) =>
 				setState((state) => ({ ...state, filter: value }))}


### PR DESCRIPTION
The `minimumFractionDigits` property is correctly defined in the static properties (line 39) but was misspelled as `minimumFractionDigsits` in `renderHeader` (line 141). This meant the value was never passed to the `cosmoz-omnitable-number-range-input` component.