### PR TITLE
feat: migrate useNotifyProperty to useProperty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@neovici/cosmoz-spinner": "^1.0.1",
         "@neovici/cosmoz-utils": "^6.20.2",
         "@neovici/nullxlsx": "^3.0.0",
-        "@pionjs/pion": "^2.0.0",
+        "@pionjs/pion": "^2.6.0",
         "@polymer/polymer": "^3.3.0",
         "file-saver-es": "^2.0.0",
         "i18next": ">=23.0.0 <27.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@neovici/cosmoz-spinner": "^1.0.1",
         "@neovici/cosmoz-utils": "^6.20.2",
         "@neovici/nullxlsx": "^3.0.0",
-        "@pionjs/pion": "^2.6.0",
+        "@pionjs/pion": "^2.16.0",
         "@polymer/polymer": "^3.3.0",
         "file-saver-es": "^2.0.0",
         "i18next": ">=23.0.0 <27.0.0",
@@ -2465,9 +2465,9 @@
       ]
     },
     "node_modules/@pionjs/pion": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@pionjs/pion/-/pion-2.13.0.tgz",
-      "integrity": "sha512-C9RK2ix/gsNpmDo+JAkg2GR/mca9nISJlulDEDHGTwqLU6qVSsL6z7O9FVwYT0/gIUhP5+eNLjSEnEQbNDHkYA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@pionjs/pion/-/pion-2.16.0.tgz",
+      "integrity": "sha512-AxWeiooL2s4gSuxCckmOVcQMx4dLYmX5YN8utW7YVbyDx8RH/SZUqJfueoAYHEnTBJoxL7+ujKQqvhfKEOTK0Q==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "lit-html": "^2.0.0 || ^3.0.0"

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@neovici/cosmoz-spinner": "^1.0.1",
     "@neovici/cosmoz-utils": "^6.20.2",
     "@neovici/nullxlsx": "^3.0.0",
-    "@pionjs/pion": "^2.6.0",
+    "@pionjs/pion": "^2.16.0",
     "@polymer/polymer": "^3.3.0",
     "file-saver-es": "^2.0.0",
     "i18next": ">=23.0.0 <27.0.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@neovici/cosmoz-spinner": "^1.0.1",
     "@neovici/cosmoz-utils": "^6.20.2",
     "@neovici/nullxlsx": "^3.0.0",
-    "@pionjs/pion": "^2.0.0",
+    "@pionjs/pion": "^2.6.0",
     "@polymer/polymer": "^3.3.0",
     "file-saver-es": "^2.0.0",
     "i18next": ">=23.0.0 <27.0.0",

--- a/src/cosmoz-omnitable.js
+++ b/src/cosmoz-omnitable.js
@@ -7,7 +7,6 @@ import './cosmoz-omnitable-header-row';
 import './cosmoz-omnitable-item-expand';
 import './cosmoz-omnitable-item-row';
 
-import { notifyProperty } from '@neovici/cosmoz-utils/hooks/use-notify-property';
 import { component } from '@pionjs/pion';
 import { html as polymerHtml } from '@polymer/polymer/lib/utils/html-tag';
 import { html } from 'lit-html';
@@ -47,7 +46,7 @@ const Omnitable = (host) => {
 
 customElements.define(
 	'cosmoz-omnitable',
-	class extends component(Omnitable, {
+	component(Omnitable, {
 		observedAttributes: [
 			'hash-param',
 			'sort-on',
@@ -63,14 +62,7 @@ customElements.define(
 			'loading',
 			'mini-breakpoint',
 		],
-	}) {
-		connectedCallback() {
-			super.connectedCallback();
-			notifyProperty(this, 'selectedItems', []);
-			notifyProperty(this, 'visibleData', []);
-			notifyProperty(this, 'sortedFilteredGroupedItems', []);
-		}
-	},
+	}),
 );
 
 const tmplt = `

--- a/src/grouped-list/use-cosmoz-grouped-list.ts
+++ b/src/grouped-list/use-cosmoz-grouped-list.ts
@@ -1,20 +1,19 @@
+import { virtualize } from '@lit-labs/virtualizer/virtualize.js';
 import { useImperativeApi } from '@neovici/cosmoz-utils/hooks/use-imperative-api';
-import { useNotifyProperty } from '@neovici/cosmoz-utils/hooks/use-notify-property';
 import { useCallback, useLayoutEffect, useMemo } from '@pionjs/pion';
 import { html } from 'lit-html';
+import type { DirectiveResult } from 'lit/directive.js';
+import type { Item } from '../lib/types';
 import './cosmoz-grouped-list-row';
 import { useCollapsibleItems } from './use-collapsible-items';
 import { useSelectedItems } from './use-selected-items';
 import {
 	byReference,
+	GroupItem,
 	isExpanded,
 	isFolded,
 	prepareData,
-	GroupItem,
 } from './utils';
-import { virtualize } from '@lit-labs/virtualizer/virtualize.js';
-import type { DirectiveResult } from 'lit/directive.js';
-import type { Item } from '../lib/types';
 
 export interface RenderItemParams {
 	selected: boolean;
@@ -105,8 +104,6 @@ const useCosmozGroupedList = (host: UseCosmozGroupedListHost) => {
 	useLayoutEffect(() => {
 		Object.assign(host.style, styles.host);
 	}, []);
-
-	useNotifyProperty('selectedItems', selectedItems);
 
 	const api = {
 		toggleFold,

--- a/src/grouped-list/use-cosmoz-grouped-list.ts
+++ b/src/grouped-list/use-cosmoz-grouped-list.ts
@@ -74,7 +74,7 @@ const useCosmozGroupedList = (host: UseCosmozGroupedListHost) => {
 			deselectAll,
 			toggleSelect,
 			toggleSelectTo,
-		} = useSelectedItems({ initial: [], compareItemsFn, data, flatData });
+		} = useSelectedItems({ compareItemsFn, data, flatData });
 	const renderRow = useCallback(
 		(item: Item | GroupItem<Item>, index: number) =>
 			Array.isArray((item as GroupItem<Item>).items)

--- a/src/grouped-list/use-selected-items.ts
+++ b/src/grouped-list/use-selected-items.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from '@pionjs/pion';
-import { isGroup, GroupItem } from './utils';
+import { useCallback, useEffect, useProperty, useState } from '@pionjs/pion';
 import type { Item } from '../lib/types';
+import { GroupItem, isGroup } from './utils';
 
 export interface UseSelectedItemsParams {
 	initial: Item[];
@@ -29,7 +29,16 @@ export const useSelectedItems = ({
 	data,
 	flatData,
 }: UseSelectedItemsParams): UseSelectedItemsResult => {
-	const [selectedItems, setSelectedItems] = useState<Item[]>(initial);
+	const [selectedItemsRaw, setSelectedItemsRaw] = useProperty<Item[]>(
+			'selectedItems',
+			initial,
+		),
+		selectedItems = selectedItemsRaw ?? initial,
+		setSelectedItems = (update: Item[] | ((prev: Item[]) => Item[])) =>
+			setSelectedItemsRaw((prev: Item[] | undefined) => {
+				const selection = prev ?? initial;
+				return typeof update === 'function' ? update(selection) : update;
+			});
 	const [lastSelection, setLastSelection] = useState<Item | GroupItem<Item>>();
 	/**
 	 * Check if item is selected.

--- a/src/grouped-list/use-selected-items.ts
+++ b/src/grouped-list/use-selected-items.ts
@@ -3,7 +3,6 @@ import type { Item } from '../lib/types';
 import { GroupItem, isGroup } from './utils';
 
 export interface UseSelectedItemsParams {
-	initial: Item[];
 	compareItemsFn: <T>(a: T, b: T) => boolean;
 	data: (Item | GroupItem<Item>)[];
 	flatData: (Item | GroupItem<Item>)[] | undefined;
@@ -24,21 +23,14 @@ export interface UseSelectedItemsResult {
 }
 
 export const useSelectedItems = ({
-	initial,
 	compareItemsFn,
 	data,
 	flatData,
 }: UseSelectedItemsParams): UseSelectedItemsResult => {
-	const [selectedItemsRaw, setSelectedItemsRaw] = useProperty<Item[]>(
-			'selectedItems',
-			initial,
-		),
-		selectedItems = selectedItemsRaw ?? initial,
-		setSelectedItems = (update: Item[] | ((prev: Item[]) => Item[])) =>
-			setSelectedItemsRaw((prev: Item[] | undefined) => {
-				const selection = prev ?? initial;
-				return typeof update === 'function' ? update(selection) : update;
-			});
+	const [selectedItems, setSelectedItems] = useProperty<Item[]>(
+		'selectedItems',
+		() => [],
+	);
 	const [lastSelection, setLastSelection] = useState<Item | GroupItem<Item>>();
 	/**
 	 * Check if item is selected.

--- a/src/lib/render-list.js
+++ b/src/lib/render-list.js
@@ -1,6 +1,7 @@
 import '../cosmoz-omnitable-skeleton.js';
 
 import { announcementIcon, errorIcon } from '@neovici/cosmoz-icons';
+import { lift } from '@pionjs/pion';
 import { t } from 'i18next';
 import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
@@ -89,8 +90,7 @@ export const renderList = (header, list) => {
 				id="groupedList"
 				.data=${processedItems}
 				.selectedItems=${selectedItems}
-				@selected-items-changed=${(event) =>
-					setSelectedItems(event.detail.value)}
+				@selected-items-changed=${lift(setSelectedItems)}
 				.displayEmptyGroups=${
 					displayEmptyGroups /* TODO: check if still works */
 				}

--- a/src/lib/render-list.js
+++ b/src/lib/render-list.js
@@ -1,3 +1,4 @@
+import { lift } from '@pionjs/pion';
 import '../cosmoz-omnitable-skeleton.js';
 
 import { announcementIcon, errorIcon } from '@neovici/cosmoz-icons';
@@ -89,8 +90,7 @@ export const renderList = (header, list) => {
 				id="groupedList"
 				.data=${processedItems}
 				.selectedItems=${selectedItems}
-				@selected-items-changed=${(event) =>
-					setSelectedItems(event.detail.value)}
+				@selected-items-changed=${lift(setSelectedItems)}
 				.displayEmptyGroups=${
 					displayEmptyGroups /* TODO: check if still works */
 				}

--- a/src/lib/render-list.js
+++ b/src/lib/render-list.js
@@ -1,7 +1,6 @@
 import '../cosmoz-omnitable-skeleton.js';
 
 import { announcementIcon, errorIcon } from '@neovici/cosmoz-icons';
-import { lift } from '@pionjs/pion';
 import { t } from 'i18next';
 import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
@@ -90,7 +89,8 @@ export const renderList = (header, list) => {
 				id="groupedList"
 				.data=${processedItems}
 				.selectedItems=${selectedItems}
-				@selected-items-changed=${lift(setSelectedItems)}
+				@selected-items-changed=${(event) =>
+					setSelectedItems(event.detail.value)}
 				.displayEmptyGroups=${
 					displayEmptyGroups /* TODO: check if still works */
 				}

--- a/src/lib/render-list.js
+++ b/src/lib/render-list.js
@@ -1,9 +1,9 @@
 import '../cosmoz-omnitable-skeleton.js';
 
+import { announcementIcon, errorIcon } from '@neovici/cosmoz-icons';
 import { t } from 'i18next';
 import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
-import { announcementIcon, errorIcon } from '@neovici/cosmoz-icons';
 
 export const renderList = (header, list) => {
 	const { settingsConfig } = header,
@@ -14,6 +14,7 @@ export const renderList = (header, list) => {
 			loading,
 			displayEmptyGroups,
 			compareItemsFn,
+			selectedItems,
 			setSelectedItems,
 			renderItem,
 			renderGroup,
@@ -87,6 +88,7 @@ export const renderList = (header, list) => {
 			<cosmoz-grouped-list
 				id="groupedList"
 				.data=${processedItems}
+				.selectedItems=${selectedItems}
 				@selected-items-changed=${(event) =>
 					setSelectedItems(event.detail.value)}
 				.displayEmptyGroups=${

--- a/src/lib/use-omnitable.js
+++ b/src/lib/use-omnitable.js
@@ -79,6 +79,7 @@ export const useOmnitable = (host) => {
 			error,
 			dataIsValid,
 			processedItems,
+			selectedItems,
 			setSelectedItems,
 			columns,
 			collapsedColumns,

--- a/src/lib/use-omnitable.js
+++ b/src/lib/use-omnitable.js
@@ -1,4 +1,3 @@
-import { useState } from '@pionjs/pion';
 import { useSettings } from './settings';
 import { useFastLayout } from './use-fast-layout';
 import { useFooter } from './use-footer';
@@ -48,19 +47,16 @@ export const useOmnitable = (host) => {
 			sortAndGroupOptions,
 		}),
 		dataIsValid = data && Array.isArray(data) && data.length > 0,
-		[selectedItems, setSelectedItems] = useState([]);
-
-	usePublicInterface({
-		host,
-		visibleData,
-		sortedFilteredGroupedItems: processedItems,
-		columns,
-		filters,
-		setFilterState,
-		selectedItems,
-		isMini,
-		...sortAndGroupOptions,
-	});
+		{ selectedItems, setSelectedItems } = usePublicInterface({
+			host,
+			visibleData,
+			sortedFilteredGroupedItems: processedItems,
+			columns,
+			filters,
+			setFilterState,
+			isMini,
+			...sortAndGroupOptions,
+		});
 
 	return {
 		header: useHeader({

--- a/src/lib/use-public-interface.js
+++ b/src/lib/use-public-interface.js
@@ -1,6 +1,5 @@
 import { useImperativeApi } from '@neovici/cosmoz-utils/hooks/use-imperative-api';
-import { useEffect, useMemo } from '@pionjs/pion';
-import { useNotifyProperty } from '@neovici/cosmoz-utils/hooks/use-notify-property';
+import { useEffect, useMemo, useProperty } from '@pionjs/pion';
 
 const mkNapi = (host) => {
 	const /**
@@ -70,6 +69,14 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 	const { setFilterState } = api,
 		napi = useMemo(() => mkNapi(host), []);
 
+	const [selectedItems, setSelectedItems] = useProperty('selectedItems', []);
+	const [, setVisibleData] = useProperty('visibleData', []);
+	const [, setSortedFiltered] = useProperty('sortedFilteredGroupedItems', []);
+	const [, setSortOn] = useProperty('sortOn');
+	const [, setDescending] = useProperty('descending');
+	const [, setIsMini] = useProperty('isMini');
+	const [, setFilters] = useProperty('filters');
+
 	useImperativeApi(api, Object.values(api));
 	useImperativeApi(napi, Object.values(napi));
 
@@ -83,15 +90,11 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 		return () => host.removeEventListener('legacy-filter-changed', handler);
 	}, []);
 
-	useNotifyProperty('visibleData', visibleData);
-	useNotifyProperty(
-		'sortedFilteredGroupedItems',
-		api.sortedFilteredGroupedItems,
-	);
-	useNotifyProperty('selectedItems', api.selectedItems);
-	useNotifyProperty('sortOn', api.sortOn);
-	useNotifyProperty('descending', api.descending);
-	useNotifyProperty('isMini', api.isMini);
+	setVisibleData(visibleData);
+	setSortedFiltered(api.sortedFilteredGroupedItems);
+	setSortOn(api.sortOn);
+	setDescending(api.descending);
+	setIsMini(api.isMini);
 
 	const filterValues = useMemo(
 		() =>
@@ -103,5 +106,7 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 		[filters],
 	);
 
-	useNotifyProperty('filters', filterValues, Object.values(filterValues));
+	setFilters(filterValues);
+
+	return { selectedItems, setSelectedItems };
 };

--- a/test/grouped-list.test.js
+++ b/test/grouped-list.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
-import { spy as sinonSpy } from 'sinon';
-import { assert, html, fixture, nextFrame } from '@open-wc/testing';
 import { setupIgnoreWindowResizeObserverLoopErrors } from '@lit-labs/virtualizer/support/resize-observer-errors.js';
+import { assert, fixture, html, nextFrame } from '@open-wc/testing';
+import { spy as sinonSpy } from 'sinon';
 
 import '../src/grouped-list/index';
 
@@ -49,7 +49,8 @@ suite('empty', () => {
 
 		await nextFrame();
 
-		assert.isTrue(spy.calledOnce);
+		assert.isTrue(spy.called);
+		assert.strictEqual(spy.firstCall.args[0].detail.value.length, 0);
 	});
 
 	test('it maintains selection accross data updates', async () => {


### PR DESCRIPTION
## Summary

Migrates all `useNotifyProperty` (from `@neovici/cosmoz-utils`) usages to `useProperty` (from `@pionjs/pion`), and uses `lift` for two-way binding of `selectedItems` between omnitable and grouped-list.

This eliminates forced re-renders caused by `useEffect`-based property updates — `useProperty` sets properties synchronously during render with an `Object.is` guard that skips redundant writes.

### Changes

- **`package.json`** — Bump `@pionjs/pion` from `^2.0.0` to `^2.16.0`
- **`src/grouped-list/use-selected-items.ts`** — Replace `useState` with `useProperty('selectedItems', () => [])` as host property source of truth; remove `initial` param
- **`src/grouped-list/use-cosmoz-grouped-list.ts`** — Remove `useNotifyProperty` call and `initial` param from `useSelectedItems`
- **`src/lib/use-public-interface.js`** — Replace all 7 `useNotifyProperty` calls with `useProperty` + setter calls; returns `{ selectedItems, setSelectedItems }`
- **`src/lib/use-omnitable.js`** — Remove `useState` for `selectedItems`; destructures it from `usePublicInterface`; pass `selectedItems` to `useList`
- **`src/lib/render-list.js`** — Add `.selectedItems` prop binding and `@selected-items-changed=${lift(setSelectedItems)}` for two-way binding
- **`src/cosmoz-omnitable.js`** — Remove `connectedCallback` override and `notifyProperty` import (initial values now handled by `useProperty`)
- **`test/grouped-list.test.js`** — Adjust assertion: `useProperty` now always dispatches events, check firstCall value instead of calledOnce

### Why `lift` works now

The parent (omnitable) owns `selectedItems` state via `useProperty`. The child (grouped-list) also uses `useProperty('selectedItems')`. When the child calls `setSelectedItems((sel) => [...sel, item])`, `useProperty` resolves the updater locally and dispatches an event with both the resolved `value` and the original `updater` function. `lift` catches the event and passes `updater` to the parent's setter, which resolves against the parent's authoritative `host.selectedItems`. This fixes the rapid-fire functional updater bug where each call would read stale state.

This requires `@pionjs/pion` ^2.16.0 which includes the `resolve`/`notify`/`updater` pattern and `ev.detail.updater` bubbling (pionjs/pion#150).

### Behavioral changes

| Aspect | Before | After |
|---|---|---|
| Property update timing | `useEffect` (async, post-render) | Synchronous during render |
| Redundant updates | Always dispatches event | `Object.is` guard skips host write if unchanged |
| Event cancelable | `false` | `true` |
| Event detail | `{ value }` | `{ value, updater, path }` (backward compatible) |
| `connectedCallback` | Sets `[]` synchronously before hooks | `useProperty` sets `[]` during first render |
| `filters` change detection | Custom deps `Object.values(filterValues)` | `Object.is` reference comparison |
| `selectedItems` binding | Direct event handler | `lift` for two-way parent-owned state |
| Event dispatch on same value | Skipped | Always dispatched (pion ^2.16.0) |