### PR TITLE
fix: handle primitive value-path values gracefully in listColumnMixin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@neovici/cosmoz-input": "^5.0.0",
         "@neovici/cosmoz-router": "^11.0.0",
         "@neovici/cosmoz-spinner": "^1.0.1",
-        "@neovici/cosmoz-utils": "^6.20.2",
+        "@neovici/cosmoz-utils": "^6.21.0",
         "@neovici/nullxlsx": "^3.0.0",
         "@pionjs/pion": "^2.16.0",
         "@polymer/polymer": "^3.3.0",
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/@neovici/cosmoz-utils": {
-      "version": "6.20.2",
-      "resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-6.20.2.tgz",
-      "integrity": "sha512-kcZT10Ds24voKsKjdUKDLelqZl8q98rzAXLDIodVW0NICixREQuGcPaBroz/aG/BAQAVlNWjcz5XTEmwet+2DQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@neovici/cosmoz-utils/-/cosmoz-utils-6.21.0.tgz",
+      "integrity": "sha512-r2pjx/GkCv0iQm0zVdKM7e3ayccenSna1/8Byi2oNaGMW6IO5VQOnfh9AIafhRPB2I8Y2W3N6Za6XrZi+bPCpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@pionjs/pion": "^2.7.1"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@neovici/cosmoz-input": "^5.0.0",
     "@neovici/cosmoz-router": "^11.0.0",
     "@neovici/cosmoz-spinner": "^1.0.1",
-    "@neovici/cosmoz-utils": "^6.20.2",
+    "@neovici/cosmoz-utils": "^6.21.0",
     "@neovici/nullxlsx": "^3.0.0",
     "@pionjs/pion": "^2.16.0",
     "@polymer/polymer": "^3.3.0",

--- a/src/cosmoz-omnitable-column-autocomplete.js
+++ b/src/cosmoz-omnitable-column-autocomplete.js
@@ -22,7 +22,13 @@ export const getComparableValue = (
 	{ valuePath, textProperty, valueProperty },
 	item,
 ) => {
-	const property = textProperty ? strProp(textProperty) : prop(valueProperty),
+	const rawProperty = textProperty
+			? strProp(textProperty)
+			: prop(valueProperty),
+		property = (v) =>
+			(textProperty || valueProperty) && typeof v === 'object' && v !== null
+				? rawProperty(v)
+				: v,
 		values = array(valuePath && get(item, valuePath)).map(property);
 	return values.length > 1 ? values.filter(Boolean).join(',') : values[0];
 };

--- a/src/cosmoz-omnitable-column-autocomplete.js
+++ b/src/cosmoz-omnitable-column-autocomplete.js
@@ -22,13 +22,7 @@ export const getComparableValue = (
 	{ valuePath, textProperty, valueProperty },
 	item,
 ) => {
-	const rawProperty = textProperty
-			? strProp(textProperty)
-			: prop(valueProperty),
-		property = (v) =>
-			(textProperty || valueProperty) && typeof v === 'object' && v !== null
-				? rawProperty(v)
-				: v,
+	const property = textProperty ? strProp(textProperty) : prop(valueProperty),
 		values = array(valuePath && get(item, valuePath)).map(property);
 	return values.length > 1 ? values.filter(Boolean).join(',') : values[0];
 };

--- a/src/cosmoz-omnitable-column-list-mixin.js
+++ b/src/cosmoz-omnitable-column-list-mixin.js
@@ -66,7 +66,11 @@ const unique = (values, valueProperty) => {
 		return [];
 	},
 	getTexts = (item, valuePath, textProperty) =>
-		array(valuePath && get(item, valuePath)).map(prop(textProperty)),
+		array(valuePath && get(item, valuePath)).map((v) =>
+			textProperty && typeof v === 'object' && v !== null
+				? get(v, textProperty)
+				: v,
+		),
 	getString = ({ valuePath, textProperty }, item) => {
 		return getTexts(item, valuePath, textProperty)
 			.filter((i) => i != null)
@@ -77,12 +81,15 @@ const unique = (values, valueProperty) => {
 		({ valueProperty, valuePath, emptyValue, emptyProperty }, filters) =>
 		(item) => {
 			const val = prop(valueProperty),
-				values = array(get(item, valuePath));
+				values = array(get(item, valuePath)),
+				cellVal = valueProperty
+					? (v) => (typeof v === 'object' && v !== null ? val(v) : v)
+					: val;
 			return filters.some(
 				(filter) =>
 					(values.length === 0 &&
 						prop(emptyProperty || valueProperty)(filter) === emptyValue) ||
-					values.some((value) => val(value) === val(filter)),
+					values.some((value) => cellVal(value) === val(filter)),
 			);
 		},
 	onChange = (setState) => (value) =>
@@ -147,7 +154,11 @@ const unique = (values, valueProperty) => {
 					return value;
 				}
 				const subValues = array(value).reduce((acc, subItem) => {
-					acc.push(get(subItem, valueProperty));
+					acc.push(
+						valueProperty && typeof subItem === 'object' && subItem !== null
+							? get(subItem, valueProperty)
+							: subItem,
+					);
 					return acc;
 				}, []);
 				return subValues.sort().join(' ');

--- a/src/cosmoz-omnitable-column-list-mixin.js
+++ b/src/cosmoz-omnitable-column-list-mixin.js
@@ -66,11 +66,7 @@ const unique = (values, valueProperty) => {
 		return [];
 	},
 	getTexts = (item, valuePath, textProperty) =>
-		array(valuePath && get(item, valuePath)).map((v) =>
-			textProperty && typeof v === 'object' && v !== null
-				? get(v, textProperty)
-				: v,
-		),
+		array(valuePath && get(item, valuePath)).map(prop(textProperty)),
 	getString = ({ valuePath, textProperty }, item) => {
 		return getTexts(item, valuePath, textProperty)
 			.filter((i) => i != null)
@@ -81,15 +77,12 @@ const unique = (values, valueProperty) => {
 		({ valueProperty, valuePath, emptyValue, emptyProperty }, filters) =>
 		(item) => {
 			const val = prop(valueProperty),
-				values = array(get(item, valuePath)),
-				cellVal = valueProperty
-					? (v) => (typeof v === 'object' && v !== null ? val(v) : v)
-					: val;
+				values = array(get(item, valuePath));
 			return filters.some(
 				(filter) =>
 					(values.length === 0 &&
 						prop(emptyProperty || valueProperty)(filter) === emptyValue) ||
-					values.some((value) => cellVal(value) === val(filter)),
+					values.some((value) => val(value) === val(filter)),
 			);
 		},
 	onChange = (setState) => (value) =>
@@ -153,15 +146,7 @@ const unique = (values, valueProperty) => {
 				if (valueProperty == null) {
 					return value;
 				}
-				const subValues = array(value).reduce((acc, subItem) => {
-					acc.push(
-						valueProperty && typeof subItem === 'object' && subItem !== null
-							? get(subItem, valueProperty)
-							: subItem,
-					);
-					return acc;
-				}, []);
-				return subValues.sort().join(' ');
+				return array(value).map(prop(valueProperty)).sort().join(' ');
 			}
 
 			getFilterFn(column, filters) {

--- a/test/autocomplete.test.js
+++ b/test/autocomplete.test.js
@@ -475,40 +475,6 @@ suite('pure functions', () => {
 });
 
 suite('primitive value-path with text/value properties', () => {
-	test('getString returns primitive string when textProperty is set', () => {
-		assert.equal(
-			getString(
-				{ valuePath: 'priority', textProperty: 'key' },
-				{ priority: 'Normal' },
-			),
-			'Normal',
-		);
-	});
-
-	test('getString returns primitive number when textProperty is set', () => {
-		assert.equal(
-			getString({ valuePath: 'amount', textProperty: 'key' }, { amount: 42 }),
-			'42',
-		);
-	});
-
-	test('toXlsxValue returns primitive string when textProperty is set', () => {
-		assert.equal(
-			toXlsxValue(
-				{ valuePath: 'priority', textProperty: 'key' },
-				{ priority: 'Normal' },
-			),
-			'Normal',
-		);
-	});
-
-	test('toXlsxValue returns primitive number when textProperty is set', () => {
-		assert.equal(
-			toXlsxValue({ valuePath: 'amount', textProperty: 'key' }, { amount: 42 }),
-			'42',
-		);
-	});
-
 	test('getComparableValue returns primitive string when valueProperty is set', () => {
 		assert.equal(
 			getComparableValue(
@@ -539,7 +505,7 @@ suite('primitive value-path with text/value properties', () => {
 		);
 	});
 
-	test('getString still works with object values when textProperty is set', () => {
+	test('getString reads textProperty from object values', () => {
 		assert.equal(
 			getString(
 				{ valuePath: 'group', textProperty: 'name' },
@@ -549,7 +515,7 @@ suite('primitive value-path with text/value properties', () => {
 		);
 	});
 
-	test('getComparableValue still works with object values when valueProperty is set', () => {
+	test('getComparableValue reads valueProperty from object values', () => {
 		assert.equal(
 			getComparableValue(
 				{ valuePath: 'group', valueProperty: 'value' },
@@ -559,7 +525,7 @@ suite('primitive value-path with text/value properties', () => {
 		);
 	});
 
-	test('applyMultiFilter matches primitive values when valueProperty is set', () => {
+	test('applyMultiFilter matches primitive value when valueProperty is set', () => {
 		const column = { valuePath: 'priority', valueProperty: 'value' };
 		assert.isTrue(
 			applyMultiFilter(column, [{ key: 'Normal', value: 'Normal' }])({
@@ -568,7 +534,7 @@ suite('primitive value-path with text/value properties', () => {
 		);
 	});
 
-	test('applyMultiFilter does not mis-match primitive values when valueProperty is set', () => {
+	test('applyMultiFilter does not match different primitive value when valueProperty is set', () => {
 		const column = { valuePath: 'priority', valueProperty: 'value' };
 		assert.isFalse(
 			applyMultiFilter(column, [{ key: 'High', value: 'High' }])({

--- a/test/autocomplete.test.js
+++ b/test/autocomplete.test.js
@@ -474,6 +474,110 @@ suite('pure functions', () => {
 	});
 });
 
+suite('primitive value-path with text/value properties', () => {
+	test('getString returns primitive string when textProperty is set', () => {
+		assert.equal(
+			getString(
+				{ valuePath: 'priority', textProperty: 'key' },
+				{ priority: 'Normal' },
+			),
+			'Normal',
+		);
+	});
+
+	test('getString returns primitive number when textProperty is set', () => {
+		assert.equal(
+			getString({ valuePath: 'amount', textProperty: 'key' }, { amount: 42 }),
+			'42',
+		);
+	});
+
+	test('toXlsxValue returns primitive string when textProperty is set', () => {
+		assert.equal(
+			toXlsxValue(
+				{ valuePath: 'priority', textProperty: 'key' },
+				{ priority: 'Normal' },
+			),
+			'Normal',
+		);
+	});
+
+	test('toXlsxValue returns primitive number when textProperty is set', () => {
+		assert.equal(
+			toXlsxValue({ valuePath: 'amount', textProperty: 'key' }, { amount: 42 }),
+			'42',
+		);
+	});
+
+	test('getComparableValue returns primitive string when valueProperty is set', () => {
+		assert.equal(
+			getComparableValue(
+				{ valuePath: 'priority', valueProperty: 'value' },
+				{ priority: 'Normal' },
+			),
+			'Normal',
+		);
+	});
+
+	test('getComparableValue returns primitive number when valueProperty is set', () => {
+		assert.equal(
+			getComparableValue(
+				{ valuePath: 'amount', valueProperty: 'value' },
+				{ amount: 42 },
+			),
+			42,
+		);
+	});
+
+	test('getComparableValue returns primitive string when textProperty is set', () => {
+		assert.equal(
+			getComparableValue(
+				{ valuePath: 'priority', textProperty: 'key' },
+				{ priority: 'Normal' },
+			),
+			'Normal',
+		);
+	});
+
+	test('getString still works with object values when textProperty is set', () => {
+		assert.equal(
+			getString(
+				{ valuePath: 'group', textProperty: 'name' },
+				{ group: { name: 'Grupp 0', value: 'group0' } },
+			),
+			'Grupp 0',
+		);
+	});
+
+	test('getComparableValue still works with object values when valueProperty is set', () => {
+		assert.equal(
+			getComparableValue(
+				{ valuePath: 'group', valueProperty: 'value' },
+				{ group: { name: 'Grupp 0', value: 'group0' } },
+			),
+			'group0',
+		);
+	});
+
+	test('applyMultiFilter matches primitive values when valueProperty is set', () => {
+		const column = { valuePath: 'priority', valueProperty: 'value' };
+		assert.isTrue(
+			applyMultiFilter(column, [{ key: 'Normal', value: 'Normal' }])({
+				priority: 'Normal',
+			}),
+		);
+	});
+
+	test('applyMultiFilter does not mis-match primitive values when valueProperty is set', () => {
+		const column = { valuePath: 'priority', valueProperty: 'value' };
+		assert.isFalse(
+			applyMultiFilter(column, [{ key: 'High', value: 'High' }])({
+				priority: 'Normal',
+			}),
+		);
+	});
+});
+
 const basicFixture = html`
 	<cosmoz-omnitable style="height:300px" .resizeSpeedFactor=${1}>
 		<cosmoz-omnitable-column-autocomplete

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -9,6 +9,7 @@ import {
 import {
 	applyMultiFilter,
 	getString,
+	listColumnMixin,
 } from '../src/cosmoz-omnitable-column-list-mixin';
 import { applySingleFilter } from '../src/cosmoz-omnitable-column-mixin';
 import '../src/cosmoz-omnitable-columns.ts';
@@ -234,6 +235,76 @@ suite('primitive value-path with text/value properties', () => {
 			applyMultiFilter(column, [{ key: 'High', value: 'High' }])({
 				priority: 'Normal',
 			}),
+		);
+	});
+});
+
+suite('mixin class getComparableValue', () => {
+	const ListColumnClass = listColumnMixin(class {});
+	const instance = new ListColumnClass();
+
+	test('returns primitive value when valueProperty is set and value-path is primitive string', () => {
+		assert.equal(
+			instance.getComparableValue(
+				{ valuePath: 'priority', valueProperty: 'value' },
+				{ priority: 'Normal' },
+			),
+			'Normal',
+		);
+	});
+
+	test('returns primitive value when valueProperty is set and value-path is primitive number', () => {
+		assert.equal(
+			instance.getComparableValue(
+				{ valuePath: 'amount', valueProperty: 'value' },
+				{ amount: 42 },
+			),
+			'42',
+		);
+	});
+
+	test('returns value directly when valueProperty is null', () => {
+		assert.equal(
+			instance.getComparableValue(
+				{ valuePath: 'priority', valueProperty: null },
+				{ priority: 'Normal' },
+			),
+			'Normal',
+		);
+	});
+
+	test('reads valueProperty from object values', () => {
+		assert.equal(
+			instance.getComparableValue(
+				{ valuePath: 'group', valueProperty: 'value' },
+				{ group: { name: 'Grupp 0', value: 'group0' } },
+			),
+			'group0',
+		);
+	});
+
+	test('joins array of primitive values when valueProperty is set', () => {
+		assert.equal(
+			instance.getComparableValue(
+				{ valuePath: 'tags', valueProperty: 'value' },
+				{ tags: ['a', 'b'] },
+			),
+			'a b',
+		);
+	});
+
+	test('reads valueProperty from each object in array', () => {
+		assert.equal(
+			instance.getComparableValue(
+				{ valuePath: 'groups', valueProperty: 'id' },
+				{
+					groups: [
+						{ id: 'g2', name: 'B' },
+						{ id: 'g1', name: 'A' },
+					],
+				},
+			),
+			'g1 g2',
 		);
 	});
 });

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -202,3 +202,38 @@ suite('pure functions', () => {
 		);
 	});
 });
+
+suite('primitive value-path with text/value properties', () => {
+	test('getString returns primitive string when textProperty is set', () => {
+		const column = { valuePath: 'priority', textProperty: 'key' };
+		assert.equal(getString(column, { priority: 'Normal' }), 'Normal');
+	});
+
+	test('getString returns primitive number when textProperty is set', () => {
+		const column = { valuePath: 'amount', textProperty: 'key' };
+		assert.equal(getString(column, { amount: 42 }), '42');
+	});
+
+	test('getString returns primitive values from array when textProperty is set', () => {
+		const column = { valuePath: 'tags', textProperty: 'key' };
+		assert.equal(getString(column, { tags: ['a', 'b', 'c'] }), 'a, b, c');
+	});
+
+	test('applyMultiFilter matches primitive value when valueProperty is set', () => {
+		const column = { valuePath: 'priority', valueProperty: 'value' };
+		assert.isTrue(
+			applyMultiFilter(column, [{ key: 'Normal', value: 'Normal' }])({
+				priority: 'Normal',
+			}),
+		);
+	});
+
+	test('applyMultiFilter does not match different primitive value when valueProperty is set', () => {
+		const column = { valuePath: 'priority', valueProperty: 'value' };
+		assert.isFalse(
+			applyMultiFilter(column, [{ key: 'High', value: 'High' }])({
+				priority: 'Normal',
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes FE-725

When `text-property`/`value-property` are set but `value-path` points to a primitive (string, number), `getString`, `toXlsxValue`, `getComparableValue`, and `applyMultiFilter` would try to read a sub-property off the primitive via `prop()`, returning `undefined`. This caused empty cell rendering, empty XLSX exports, broken tooltips, grouping, and filtering.

### Changes

- **`@neovici/cosmoz-utils` bumped to `^6.21.0`** — `prop()` now returns primitives as-is instead of `undefined` (FE-726)

### Backwards compatibility

When `value-path` points to an object (e.g. `status: { name, description }`), behavior is unchanged.
