### PR TITLE
fix(use-track-size): drop requestAnimationFrame from ResizeObserver callback

### DIFF
--- a/src/lib/use-track-size.ts
+++ b/src/lib/use-track-size.ts
@@ -12,15 +12,13 @@ export const useTrackSize = (
 ) =>
 	useEffect(() => {
 		const onResize = ([entry]: ResizeObserverEntry[]) => {
-				if (entry.contentRect?.width === 0) {
-					return;
-				}
+			if (entry.contentRect?.width === 0) {
+				return;
+			}
 
-				requestAnimationFrame(() =>
-					setCanvasWidth(entry.contentRect?.width - LAYOUT_OFFSET),
-				);
-			},
-			observer = new ResizeObserver(onResize);
+			setCanvasWidth(entry.contentRect.width - LAYOUT_OFFSET);
+		};
+		observer = new ResizeObserver(onResize);
 
 		observer.observe(host);
 		return () => observer.unobserve(host);


### PR DESCRIPTION
Drops `requestAnimationFrame` from the ResizeObserver callback in `useTrackSize`.

**Problem:** The rAF callback schedules `setCanvasWidth` just before repaint. When the resulting render changes element dimensions, it triggers a synchronous reflow which fires ResizeObserver again — creating a tight reflow loop during resize.

**Fix:** Call `setCanvasWidth` directly. The state update is deferred out of the ResizeObserver callback chain, breaking the loop. PionJS's own `Object.is` equality check on the width value naturally terminates the update cycle once the width stabilizes.