### PR TITLE
feat: add smooth transitions and fix mini mode spacing

### DIFF
--- a/src/cosmoz-omnitable-styles.js
+++ b/src/cosmoz-omnitable-styles.js
@@ -15,7 +15,7 @@ export const checkbox = css`
 		user-select: none;
 		cursor: pointer;
 		display: inline-block;
-		box-shadow: var(--cz-shadow-xs-skeumorphic);
+		box-shadow: inset 0 0 0 2px var(--cz-color-border-primary);
 		-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 		transition: background-color 140ms;
 		margin: 1px calc(var(--cz-spacing) * 3);
@@ -24,7 +24,7 @@ export const checkbox = css`
 
 	.checkbox:checked {
 		background: rgb(
-			from var(--cz-color-bg-brand-solid) r g b / calc(alpha * 0.55)
+			from var(--cz-color-bg-brand-solid) r g b / calc(alpha * 0.85)
 		);
 		box-shadow: none;
 	}
@@ -57,7 +57,7 @@ export const checkbox = css`
 	}
 
 	.checkbox:checked:hover {
-		box-shadow: 0 0 2px 6px #2021240f;
+		box-shadow: 0 0 2px 4px var(--cz-color-bg-quaternary);
 	}
 
 	.checkbox:indeterminate::before {
@@ -67,10 +67,7 @@ export const checkbox = css`
 		height: 2px;
 		left: 4px;
 		top: 8px;
-		background-color: var(
-			--cosmoz-omnitable-checkbox-checked-color,
-			var(--primary-color)
-		);
+		background-color: var(--cz-color-text-brand);
 	}
 `;
 
@@ -287,6 +284,18 @@ export default css`
 		padding: 5px 4%;
 		border-bottom: 1px var(--cz-color-border-secondary) solid;
 		background-color: var(--cz-color-bg-disabled);
+		animation: expand-in 0.25s ease;
+	}
+
+	@keyframes expand-in {
+		from {
+			opacity: 0;
+			transform: translateY(-4px);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0);
+		}
 	}
 
 	cosmoz-omnitable-item-expand:not([expanded]) {
@@ -418,6 +427,10 @@ export default css`
 		outline: none;
 		color: var(--cz-color-text-primary);
 		background: transparent;
+
+		&[hidden] {
+			display: none;
+		}
 	}
 
 	.groupRow .expand {
@@ -447,6 +460,7 @@ export default css`
 		outline: none;
 		color: inherit;
 		padding: 0;
+		transition: transform 0.3s ease;
 	}
 	.sg span {
 		display: none;
@@ -470,35 +484,42 @@ export default css`
 		flex: auto;
 	}
 
+	.itemRow-minis {
+		display: flex;
+		justify-content: space-between;
+		margin: 14px 12px 12px 12px;
+		color: var(--cz-color-text-primary);
+	}
+
+	:host([mini]) {
+		--checkbox-offset: calc(var(--cz-spacing) * 2);
+	}
+
 	:host([mini]) .itemRow .expand,
 	:host([mini]) cosmoz-omnitable-item-expand {
 		display: none;
 	}
 
-	.itemRow-minis {
-		display: flex;
+	:host([mini]) .header > cosmoz-omnitable-header-row {
+		flex: 0;
+	}
+
+	:host([mini]) .groupRow {
+		padding-left: var(--checkbox-offset);
+	}
+
+	:host([mini]) .header {
+		padding-left: var(--checkbox-offset);
 		justify-content: space-between;
-		margin: 14px 12px 12px 12px;
-		color: var(--cosmoz-omnitable-mini-color, #000);
 	}
 
 	:host([mini]) .itemRow {
 		border-radius: 12px;
-		border: 1px solid var(--cosmoz-omnitable-border-color, #e1e2e5);
-		margin: 4px 8px;
-		padding-top: 2px;
-	}
-
-	:host([mini]) .itemRow:not([selected]) {
-		background: var(--cosmoz-omnitable-mini-item-background, #fdfdfd);
-	}
-
-	:host([mini]) .itemRow:hover {
-		box-shadow: none;
-	}
-
-	:host([mini]) .header {
-		margin: 0 8px;
+		box-shadow: inset 0 0 0 2px var(--cz-color-border-tertiary);
+		margin-block: var(--checkbox-offset);
+		margin-inline: var(--checkbox-offset);
+		padding-block: 4px;
+		border: none;
 	}
 
 	:host([mini]) .tableContent {
@@ -518,7 +539,7 @@ export default css`
 	}
 
 	:host([mini]) .tableContent-scroller:hover::-webkit-scrollbar-thumb {
-		background: var(--cosmoz-omnitable-mini-scrollbar-thumb-bg, #aaa);
+		background: var(--cz-color-bg-tertiary);
 	}
 
 	:host([mini]) .tableContent-scroller::-webkit-scrollbar-button:decrement,

--- a/src/lib/settings/style.css.js
+++ b/src/lib/settings/style.css.js
@@ -35,14 +35,13 @@ export default css`
 		scrollbar-width: 2px;
 		scrollbar-gutter: stable;
 		text-transform: uppercase;
-		font-size: 12px;
 		color: var(--cz-color-text-primary);
 	}
 	.contents::-webkit-scrollbar {
-		width: 2px;
+		width: 3px;
 	}
 	.contents::-webkit-scrollbar-thumb {
-		background: rgba(0, 0, 0, 0.5);
+		background: var(--cz-color-bg-brand-solid);
 	}
 	.contents::-webkit-scrollbar-track-piece:start,
 	.contents::-webkit-scrollbar-track-piece:end {
@@ -50,7 +49,7 @@ export default css`
 	}
 
 	.heading {
-		box-shadow: inset 0px -1px 0px rgba(0, 0, 0, 0.15);
+		box-shadow: inset 0px -1px 0px var(--cz-color-border-primary);
 		font-weight: var(--cz-font-weight-medium);
 		font-size: var(--cz-text-xs);
 		line-height: var(--cz-text-xs-line-height);
@@ -69,8 +68,8 @@ export default css`
 	}
 	cosmoz-collapse[opened] + .heading {
 		box-shadow:
-			inset 0px -1px 0px rgba(0, 0, 0, 0.15),
-			inset 0px 1px 0px rgba(0, 0, 0, 0.15);
+			inset 0px -1px 0px var(--cz-color-border-primary),
+			inset 0px 1px 0px var(--cz-color-border-primary);
 	}
 
 	.list {
@@ -98,10 +97,7 @@ export default css`
 		background: transparent;
 		cursor: move;
 		margin-right: 12px;
-		color: var(
-			--cosmoz-omnitable-settings-pull-color,
-			var(--cz-color-muted, #c4c4c4)
-		);
+		color: var(--cz-color-bg-brand-solid);
 	}
 	.title {
 		flex: auto;
@@ -124,7 +120,7 @@ export default css`
 		display: flex;
 		gap: 8px;
 		padding: 12px 14px;
-		box-shadow: inset 0px 1px 0px rgba(0, 0, 0, 0.15);
+		box-shadow: inset 0px 1px 0px var(--cz-color-border-primary);
 
 		& cosmoz-button {
 			flex: 1;
@@ -142,8 +138,9 @@ export default css`
 	}
 	.sg {
 		color: inherit;
-		border: 1px solid rgba(0, 0, 0, 0.2);
-		border-radius: 6px;
+		box-shadow: inset 0 0 0 2px var(--cz-color-border-primary);
+		border: none;
+		border-radius: var(--cz-radius-sm);
 		font-size: var(--cz-text-xs);
 		line-height: var(--cz-text-xs-line-height);
 		text-transform: uppercase;
@@ -154,21 +151,23 @@ export default css`
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		transition:
+			background 0.3s ease,
+			box-shadow 0.3s ease;
 	}
 	.sg span {
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 	.sg[data-on] {
-		background: var(
-			--cosmoz-omnitable-checkbox-checked-color,
-			var(--primary-color)
-		);
+		background: var(--cz-color-bg-brand-secondary);
+		box-shadow: none;
 	}
 	.sg svg {
 		margin-left: 4px;
 		flex: none;
 		vertical-align: middle;
+		transition: transform 0.3s ease;
 	}
 
 	.sg:not([data-on='desc']) svg {
@@ -199,6 +198,10 @@ export const dropdown = css`
 		color: inherit;
 		width: 40px;
 		height: 40px;
+		transition: color 0.3s ease;
+	}
+	cosmoz-dropdown::part(button):hover {
+		color: var(--cz-color-text-primary);
 	}
 	cosmoz-dropdown::part(anchor) {
 		display: inline-block;
@@ -206,22 +209,17 @@ export const dropdown = css`
 	.badge {
 		position: absolute;
 		top: 1px;
-		right: -4px;
-		background-color: var(
-			--cosmoz-omnitable-checkbox-checked-color,
-			var(--primary-color)
-		);
+		right: 1px;
+		background-color: var(--cz-color-bg-brand-solid);
 		width: 8px;
 		height: 8px;
 		border-radius: 100%;
 	}
 	.headerDots {
 		align-items: center;
-		color: var(--cosmoz-input-color);
+		color: var(--cz-color-text-primary);
 		display: flex;
 		font-size: 20px;
-		height: 42px;
-		justify-content: center;
 		margin-left: 12px;
 		min-width: 30px;
 		transform: rotate(90deg);

--- a/stories/cosmoz-omnitable-item-row-minimode.stories.js
+++ b/stories/cosmoz-omnitable-item-row-minimode.stories.js
@@ -1,0 +1,61 @@
+import { html } from 'lit-html';
+import { generateTableDemoData } from '../demo/table-demo-helper.js';
+import '../src/cosmoz-omnitable.js';
+
+const data = generateTableDemoData(10, 10, 10);
+
+export default {
+	title: 'Components/CosmozOmnitableItemRowMiniMode',
+	component: 'cosmoz-omnitable-item-row',
+};
+
+const Template = (args) => html`
+	<style>
+		.container {
+			width: ${args.width || '400px'};
+			height: 400px;
+			display: flex;
+			flex-direction: column;
+		}
+		cosmoz-omnitable {
+			flex: 1;
+			min-height: 0;
+		}
+	</style>
+	<div class="container">
+		<cosmoz-omnitable .data=${data} mini-breakpoint="9999">
+			<cosmoz-omnitable-column
+				name="name"
+				title="Name"
+				value-path="name"
+				mini="0"
+			></cosmoz-omnitable-column>
+			<cosmoz-omnitable-column
+				name="group"
+				title="Group"
+				value-path="group"
+				mini="1"
+			></cosmoz-omnitable-column>
+			<cosmoz-omnitable-column
+				name="value"
+				title="Value"
+				value-path="value"
+				mini="2"
+			></cosmoz-omnitable-column>
+			<cosmoz-omnitable-column
+				name="randomString"
+				title="Random String"
+				value-path="randomString"
+				mini="3"
+			></cosmoz-omnitable-column>
+			<cosmoz-omnitable-column
+				name="bool"
+				title="Bool"
+				value-path="bool"
+			></cosmoz-omnitable-column>
+		</cosmoz-omnitable>
+	</div>
+`;
+
+export const MiniMode = Template.bind({});
+MiniMode.args = { width: '400px' };


### PR DESCRIPTION
- Fix checkbox border with box-shadow [FE-762](https://linear.app/neovici/issue/FE-762/dark-mode-checkboxes-are-not-visible)
- Add transition on .sg arrow flip (sort/group indicators) in header
- Add transition on .sg buttons in settings (background, box-shadow, svg)
- Add dropdown-in animation for settings panel appearance
- Add expand-in animation for item expand section
- Add mini mode story with generateTableDemoData