### PR TITLE
fix: noLocal disables local range limiting (#FE-863)

### DIFF
--- a/src/lib/settings/use-settings.js
+++ b/src/lib/settings/use-settings.js
@@ -21,8 +21,12 @@ export default ({ settingsId, host }) => {
 			setSettings,
 			onReset,
 		),
-		{ enabledColumns, disabledFiltering } = host,
-		columns = useDOMColumns(host, { enabledColumns, disabledFiltering }),
+		{ enabledColumns, disabledFiltering, noLocal } = host,
+		columns = useDOMColumns(host, {
+			enabledColumns,
+			disabledFiltering,
+			noLocal,
+		}),
 		normalizedSettings = useMemo(
 			() =>
 				normalize({

--- a/src/lib/use-dom-columns.js
+++ b/src/lib/use-dom-columns.js
@@ -34,7 +34,7 @@ const verifyColumnSetup = (columns) => {
 	return ok;
 };
 
-const normalizeColumn = (column, disabledFiltering) => {
+const normalizeColumn = (column, disabledFiltering, noLocal) => {
 	const valuePath = column.valuePath ?? column.name;
 
 	return {
@@ -75,6 +75,7 @@ const normalizeColumn = (column, disabledFiltering) => {
 		source: memooize(column.computeSource),
 
 		noLocalFilter: column.noLocalFilter,
+		noLocal,
 
 		mini: column.mini,
 		renderMini: column.renderMini,
@@ -128,15 +129,23 @@ const collectDomColumns = (assignedElements) => {
 	return domColumns;
 };
 
-const normalizeColumns = (domColumns, enabledColumns, disabledFiltering) => {
+const normalizeColumns = (
+	domColumns,
+	enabledColumns,
+	disabledFiltering,
+	noLocal,
+) => {
 	const columns = Array.isArray(enabledColumns)
 		? domColumns.filter((column) => enabledColumns.includes(column.name))
 		: domColumns.filter((column) => !column.disabled);
 
-	return columns.map((col) => normalizeColumn(col, disabledFiltering));
+	return columns.map((col) => normalizeColumn(col, disabledFiltering, noLocal));
 };
 
-export const useDOMColumns = (host, { enabledColumns, disabledFiltering }) => {
+export const useDOMColumns = (
+	host,
+	{ enabledColumns, disabledFiltering, noLocal },
+) => {
 	const [columns, setColumns] = useState([]);
 
 	useLayoutEffect(() => {
@@ -165,6 +174,7 @@ export const useDOMColumns = (host, { enabledColumns, disabledFiltering }) => {
 					collectDomColumns(current),
 					enabledColumns,
 					disabledFiltering,
+					noLocal,
 				),
 			);
 		};
@@ -186,7 +196,7 @@ export const useDOMColumns = (host, { enabledColumns, disabledFiltering }) => {
 			host.removeEventListener('cosmoz-column-prop-changed', scheduleUpdate);
 			cancelAnimationFrame(sched);
 		};
-	}, [enabledColumns, disabledFiltering]);
+	}, [enabledColumns, disabledFiltering, noLocal]);
 
 	return columns;
 };

--- a/src/lib/utils-data.ts
+++ b/src/lib/utils-data.ts
@@ -1,11 +1,12 @@
 import { get, set } from '@polymer/polymer/lib/utils/path';
+import { Column, GetPath, Item, Items } from './types';
 import { columnSymbol } from './use-dom-columns';
-import { GetPath, Items, Item, Column } from './types';
 
 interface DefaultComputeSource {
 	externalValues?: unknown[];
 	values?: unknown[];
 	valuePath?: GetPath;
+	noLocal?: boolean;
 }
 
 export const valuesFrom = (data: Items, valuePath: GetPath) => {
@@ -20,7 +21,7 @@ export const valuesFrom = (data: Items, valuePath: GetPath) => {
 };
 
 export const defaultComputeSource = (
-	{ externalValues, values, valuePath }: DefaultComputeSource,
+	{ externalValues, values, valuePath, noLocal }: DefaultComputeSource,
 	data: Items,
 ) => {
 	if (externalValues) {
@@ -29,6 +30,10 @@ export const defaultComputeSource = (
 
 	if (typeof values === 'function') {
 		return values;
+	}
+
+	if (noLocal) {
+		return undefined;
 	}
 
 	if (valuePath !== undefined) {

--- a/test/range.test.js
+++ b/test/range.test.js
@@ -297,3 +297,91 @@ suite('external values', () => {
 		assert.equal(omnitable.filters.age.min, -1);
 	});
 });
+
+suite('noLocal', () => {
+	ignoreResizeObserverLoopErrors(setup, teardown);
+
+	test('noLocal omits local-data-derived range bounds', async () => {
+		const omnitable = await setupOmnitableFixture(
+				html`
+					<cosmoz-omnitable no-local>
+						<cosmoz-omnitable-column-number
+							title="Age"
+							name="age"
+							value-path="age"
+							maximum-fraction-digits="2"
+						>
+						</cosmoz-omnitable-column-number>
+					</cosmoz-omnitable>
+				`,
+				[{ age: 1 }, { age: 0 }, { age: 20 }],
+			),
+			columnHeaderInput = omnitable.shadowRoot.querySelector(
+				'cosmoz-omnitable-number-range-input',
+			);
+
+		await nextFrame();
+
+		assert.deepEqual(columnHeaderInput._range, { min: null, max: null });
+	});
+
+	test('noLocal does not clamp _filterInput to local data bounds', async () => {
+		const omnitable = await setupOmnitableFixture(
+				html`
+					<cosmoz-omnitable no-local>
+						<cosmoz-omnitable-column-number
+							title="Age"
+							name="age"
+							value-path="age"
+							maximum-fraction-digits="2"
+						>
+						</cosmoz-omnitable-column-number>
+					</cosmoz-omnitable>
+				`,
+				[{ age: 1 }, { age: 0 }, { age: 20 }],
+			),
+			column = omnitable.columns[0][columnSymbol],
+			columnHeaderInput = omnitable.shadowRoot.querySelector(
+				'cosmoz-omnitable-number-range-input',
+			);
+
+		column.autoupdate = true;
+		await nextFrame();
+
+		columnHeaderInput.set('_filterInput.min', -1);
+		flush();
+		await nextFrame();
+
+		assert.equal(omnitable.filters.age.min, -1);
+	});
+
+	test('without noLocal, _filterInput below local min is clamped', async () => {
+		const omnitable = await setupOmnitableFixture(
+				html`
+					<cosmoz-omnitable>
+						<cosmoz-omnitable-column-number
+							title="Age"
+							name="age"
+							value-path="age"
+							maximum-fraction-digits="2"
+						>
+						</cosmoz-omnitable-column-number>
+					</cosmoz-omnitable>
+				`,
+				[{ age: 1 }, { age: 0 }, { age: 20 }],
+			),
+			column = omnitable.columns[0][columnSymbol],
+			columnHeaderInput = omnitable.shadowRoot.querySelector(
+				'cosmoz-omnitable-number-range-input',
+			);
+
+		column.autoupdate = true;
+		await nextFrame();
+
+		columnHeaderInput.set('_filterInput.min', -1);
+		flush();
+		await nextFrame();
+
+		assert.equal(omnitable.filters.age.min, 0);
+	});
+});


### PR DESCRIPTION
## Fixes FE-863

When `no-local` is set on `cosmoz-omnitable`, range columns (number/amount/date/datetime/time) no longer derive their min/max bounds from the local `data` slice. This was causing the range picker to clamp to the currently-loaded page in server-filtered, paginated lists — requiring every such list to manually add `external-values` to each range column.

## Root cause

`noLocal` only set `noLocalFilter`/`noLocalSort` on the omnitable (`use-processed-items.js`), skipping `data.filter()`/`data.sort()`. Range bounds were computed independently: `headerRow` → `column.source(column, data)` → `defaultComputeSource(column, data)` (`utils-data.ts`) → `valuesFrom(data, valuePath)` for range columns. The `noLocal` flag never reached the columns, so bounds always came from local `data`.

## Fix (Option 1 from the issue)

Thread the omnitable's `noLocal` flag through to columns, then have `defaultComputeSource` skip local-data derivation when `noLocal` is true and no explicit `externalValues`/`values` function is provided. Range columns' `.values` becomes `undefined` → `_computeRange` returns `{min:null, max:null}` → `_computeLimit` falls back to the column's explicit `min`/`max` props (or none) → no local-data clamping.

## Scope

- **Range columns** (number, amount, date, datetime, time) — fixed. These are the sole callers of `defaultComputeSource`.
- **Autocomplete / list / list-horizontal / autocomplete-excluding / boolean / base text columns** — **unaffected**. Their `computeSource` does not call `defaultComputeSource`; they derive dropdown *options* (not range bounds) from local data and keep their own `external-values` + `values` escape hatch. Emptying their dropdowns on `noLocal` would be wrong.
- Explicit `external-values` or a `values` function on a range column still takes precedence over the `noLocal` short-circuit, preserving the existing override path.

## Changes

- `src/lib/settings/use-settings.js` — destructure `noLocal` from `host`, pass to `useDOMColumns`.
- `src/lib/use-dom-columns.js` — thread `noLocal` through `useDOMColumns` → `normalizeColumns` → `normalizeColumn`; add `noLocal` to the normalized column object (host-level only, no per-column attribute).
- `src/lib/utils-data.ts` — add `noLocal?: boolean` to `DefaultComputeSource`; in `defaultComputeSource`, return `undefined` when `noLocal` is true and no `externalValues`/`values` function is set.
- `test/range.test.js` — new `suite('noLocal')`: verifies `_range` is `{min:null, max:null}`, that `_filterInput.min` below the local min is not clamped, and a regression test that without `no-local` the same input is clamped to the local min.

## Verification

- `npm run lint` — 0 errors (3 pre-existing warnings, unchanged).
- `npm run build` (`tsc`) — passes.
- `npm test` — 311 passed, 0 failed (incl. 3 new tests).