### PR TITLE
fix: visible items changed fires constantly for no reason

### DIFF
--- a/src/lib/use-public-interface.js
+++ b/src/lib/use-public-interface.js
@@ -1,4 +1,5 @@
 import { useImperativeApi } from '@neovici/cosmoz-utils/hooks/use-imperative-api';
+import { useNotifyProperty } from '@neovici/cosmoz-utils/hooks/use-notify-property';
 import { useEffect, useMemo, useProperty } from '@pionjs/pion';
 
 const mkNapi = (host) => {
@@ -70,12 +71,6 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 		napi = useMemo(() => mkNapi(host), []);
 
 	const [selectedItems, setSelectedItems] = useProperty('selectedItems', []);
-	const [, setVisibleData] = useProperty('visibleData', []);
-	const [, setSortedFiltered] = useProperty('sortedFilteredGroupedItems', []);
-	const [, setSortOn] = useProperty('sortOn');
-	const [, setDescending] = useProperty('descending');
-	const [, setIsMini] = useProperty('isMini');
-	const [, setFilters] = useProperty('filters');
 
 	useImperativeApi(api, Object.values(api));
 	useImperativeApi(napi, Object.values(napi));
@@ -90,11 +85,14 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 		return () => host.removeEventListener('legacy-filter-changed', handler);
 	}, []);
 
-	setVisibleData(visibleData);
-	setSortedFiltered(api.sortedFilteredGroupedItems);
-	setSortOn(api.sortOn);
-	setDescending(api.descending);
-	setIsMini(api.isMini);
+	useNotifyProperty('visibleData', visibleData);
+	useNotifyProperty(
+		'sortedFilteredGroupedItems',
+		api.sortedFilteredGroupedItems,
+	);
+	useNotifyProperty('sortOn', api.sortOn);
+	useNotifyProperty('descending', api.descending);
+	useNotifyProperty('isMini', api.isMini);
 
 	const filterValues = useMemo(
 		() =>
@@ -106,7 +104,7 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 		[filters],
 	);
 
-	setFilters(filterValues);
+	useNotifyProperty('filters', filterValues, Object.values(filterValues));
 
 	return { selectedItems, setSelectedItems };
 };


### PR DESCRIPTION
Follow-up to #996.

## Context

PR #996 converted all `useNotifyProperty` uses to `useProperty`. But `useProperty` is for **true State** — props that are owned locally, two-way bindable, and accept parent overrides. Most of the converted props are not that; they're **informational/derived outputs** that only need to fire a `-changed` event so external/Polymer observers can react.

## What changed

In `src/lib/use-public-interface.js`, reverted these props from `useProperty` back to `useNotifyProperty`:

| Prop | Reason |
|------|--------|
| `visibleData` | Derived from `data` + filters + sort; read-only externally, never written from outside |
| `sortedFilteredGroupedItems` | Derived output; tests read `omnitable.sortedFilteredGroupedItems` but no parent writes it |
| `sortOn` | Source of truth lives in `useSortAndGroupOptions`/`useHashState`; this is just a mirror for external observers (also an observed attribute) |
| `descending` | Same as `sortOn` |
| `isMini` | Derived from `useFastLayout` (breakpoint/settings); pure output |
| `filters` | Derived from `useProcessedItems`; read-only externally. Restored the original value-based deps (`Object.values(filterValues)`) so `filters-changed` only fires when filter values actually change, not on object-identity changes |

### Kept as `useProperty` (true State)
- `selectedItems` in `use-public-interface.js` — owned by omnitable, two-way bound with `groupedList` via `@selected-items-changed=${lift(setSelectedItems)}` and `.selectedItems=${...}`
- `selectedItems` in `use-selected-items.ts` — owned by `groupedList`, two-way bound with the parent omnitable

### Kept from #996 (not reverted)
- Removal of the duplicate `useNotifyProperty('selectedItems', ...)` in `use-cosmoz-grouped-list.ts` (it was redundant with the one in `use-selected-items.ts`)
- Removal of the `connectedCallback` initial `notifyProperty` calls in `cosmoz-omnitable.js` (the hooks now handle initialization)
- The `lift(setSelectedItems)` two-way binding in `render-list.ts`
- `usePublicInterface` returning `{ selectedItems, setSelectedItems }` so `useOmnitable` no longer keeps a parallel `useState`

## Side benefit
Resolves the `max-statements` eslint warning (`Arrow function has too many statements (19)`) that #996 introduced on `usePublicInterface` — statement count drops from 19 back to ~13.

## Verification
- `npm run lint` — no new warnings (the two remaining are pre-existing in unrelated files)
- `npx web-test-runner` — all 304 tests pass