### PR TITLE
fix: stop spurious filters-changed events on every render

### DIFF
--- a/src/lib/use-public-interface.js
+++ b/src/lib/use-public-interface.js
@@ -90,12 +90,6 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 		return () => host.removeEventListener('legacy-filter-changed', handler);
 	}, []);
 
-	setVisibleData(visibleData);
-	setSortedFiltered(api.sortedFilteredGroupedItems);
-	setSortOn(api.sortOn);
-	setDescending(api.descending);
-	setIsMini(api.isMini);
-
 	const filterValues = useMemo(
 		() =>
 			Object.fromEntries(
@@ -106,7 +100,17 @@ export const usePublicInterface = ({ host, visibleData, filters, ...api }) => {
 		[filters],
 	);
 
-	setFilters(filterValues);
+	useEffect(() => setSortOn(api.sortOn), [api.sortOn]);
+	useEffect(() => setDescending(api.descending), [api.descending]);
+	useEffect(() => setIsMini(api.isMini), [api.isMini]);
+
+	useEffect(() => setVisibleData(visibleData), [visibleData]);
+	useEffect(
+		() => setSortedFiltered(api.sortedFilteredGroupedItems),
+		[api.sortedFilteredGroupedItems],
+	);
+
+	useEffect(() => setFilters(filterValues), Object.values(filterValues));
 
 	return { selectedItems, setSelectedItems };
 };


### PR DESCRIPTION
## Problem

Focusing a header cell in an omnitable backed by `cosmoz-queue` (e.g. sales/purchase invoice lists) triggers a loading spinner and a full data refetch. The same happens for any state change that touches the `filters` object (`headerFocused`, `query`, `inputValue`).

## Root cause

PR #996 replaced `useNotifyProperty` with `useProperty` for all informational props in \`src/lib/use-public-interface.js\`. Two issues compound:

1. `useProperty.updater` (\`@pionjs/pion/lib/use-property.js\`) dispatches the \`-changed\` event **before** the \`Object.is\` guard, so calling the setters directly in render body fires \`filters-changed\` / \`visible-data-changed\` etc. synchronously on **every render**, even when the value hasn't changed.

2. \`headerFocused\`, \`query\`, and \`inputValue\` are stored in the same \`filters\` state object as real filter values (\`src/lib/use-processed-items.js\`). Focusing a header cell creates a new \`filters\` ref via \`setFilterState\`, which propagates:
   - \`useHashState\` → writes to URL hash
   - \`use-public-interface.js\` → \`filterValues\` memo recomputes (strips \`headerFocused\`) → \`setFilters(filterValues)\` → dispatches \`filters-changed\`
   - \`cosmoz-queue\`'s \`render-list-core.js\` catches \`filters-changed\` → updates queue filters → \`use-list-core.js\` recomputes params → \`use-more.js\` resets page to 0 and refetches

## Fix

In \`src/lib/use-public-interface.js\`, wrap the informational \`useProperty\` setter calls in \`useEffect\` with value-appropriate deps so \`-changed\` events only fire when values actually change:

- **Primitives** — value itself is the dep (\`sortOn\`, \`descending\`, \`isMini\`)
- **Objects/arrays** — value-based deps (\`visibleData\`, \`sortedFilteredGroupedItems\`)
- **filters** — \`Object.values(filterValues)\` as deps, reproducing the deep-compare semantics of the old \`useNotifyProperty\`

This keeps the \`useProperty\` pattern (consistent with #996's direction) without reintroducing \`useNotifyProperty\`. Equivalent to what #1028 does with \`useNotifyProperty\`.

## Verification

- [x] \`npm test\` — 304 passed, 0 failed (coverage 87.71%)
- [x] \`npx eslint src/lib/use-public-interface.js\` — no new errors
- [ ] Manual: focus a header cell in a \`cosmoz-queue\`-backed omnitable (sales/purchase invoices) — should **not** trigger a loading spinner / data refetch
- [ ] Manual: actually changing a filter value — should still trigger a refetch

## Long-term follow-up (separate PR)

Separate UI state (\`headerFocused\`, \`query\`, \`inputValue\`) from filter state in \`use-processed-items.js\`. These should live in a separate state map (e.g. \`headerState\`) keyed by column name and be passed separately to \`renderHeader\`, since they:

- Pollute the URL hash via \`useHashState\` (even though \`write\` strips them, \`navigate()\` is still called)
- Cause unnecessary re-renders through the \`filterValues\` memo
- Trigger cascading memo/dependency invalidations