### PR TITLE
fix: ignore codecov uploader artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ tsconfig.tsbuildinfo
 .direnv
 .envrc
 
+# Codecov uploader artifacts
+codecov
+codecov.SHA256SUM
+codecov.SHA256SUM.sig
+
 # Playwright MCP logs
 .playwright-mcp/
 .npmrc


### PR DESCRIPTION
Fixes FE-864

The foundry reusable workflow downloads the codecov uploader binary and signature files into the repo root. These untracked artifacts were being committed by the changeset release bot.

This adds the codecov artifacts to .gitignore:
- codecov (binary)
- codecov.SHA256SUM
- codecov.SHA256SUM.sig