### PR TITLE
feat: add select all items feature

### DIFF
--- a/demo/helpers/i18n.js
+++ b/demo/helpers/i18n.js
@@ -36,6 +36,9 @@ export const resources = {
 			'Filter too strict': 'För strikt filter',
 			'No matches for selection': 'Inga träffar för urvalet',
 			'Error loading data': 'Fel vid laddning av data',
+			'All {count} items selected': 'Alla {count} objekt valda',
+			'All items selected': 'Alla objekt valda',
+			'Select all items': 'Välj alla objekt',
 			'Save selected items as CSV': 'Spara valda objekt som CSV',
 			'Save selected items as XLSX': 'Spara valda objekt som XLSX',
 			'{count} selected item': '{count} valt objekt',
@@ -84,8 +87,14 @@ export const resources = {
 			'Filter too strict': 'Filtre trop strict',
 			'No matches for selection': 'Aucun résultat pour la sélection',
 			'Error loading data': 'Erreur lors du chargement des données',
-			'Save selected items as CSV': 'Enregistrer les éléments sélectionnés en CSV',
-			'Save selected items as XLSX': 'Enregistrer les éléments sélectionnés en XLSX',
+			'All {count} items selected':
+				'Tous les {count} éléments sont sélectionnés',
+			'All items selected': 'Tous les éléments sont sélectionnés',
+			'Select all items': 'Sélectionner tous les éléments',
+			'Save selected items as CSV':
+				'Enregistrer les éléments sélectionnés en CSV',
+			'Save selected items as XLSX':
+				'Enregistrer les éléments sélectionnés en XLSX',
 			'{count} selected item': '{count} élément sélectionné',
 			'{count} selected item_one': '{count} élément sélectionné',
 			'{count} selected item_other': '{count} éléments sélectionnés',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2648,17 +2648,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@oxc-project/types": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
-      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
       "version": "11.19.1",
       "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
@@ -3386,361 +3375,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
-      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
-      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
-      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
-      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
-      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
-      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
-      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
-      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
-      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
-      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
-      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
-      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
-      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.1",
-        "@emnapi/runtime": "1.11.1",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
-      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
-      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.3.1",
@@ -7809,17 +7443,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/devtools-protocol": {
       "version": "0.0.1551306",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
@@ -10767,279 +10390,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13025,41 +12375,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rolldown": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
-      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@oxc-project/types": "=0.137.0",
-        "@rolldown/pluginutils": "^1.0.0"
-      },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.1.3",
-        "@rolldown/binding-darwin-arm64": "1.1.3",
-        "@rolldown/binding-darwin-x64": "1.1.3",
-        "@rolldown/binding-freebsd-x64": "1.1.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
-        "@rolldown/binding-linux-arm64-musl": "1.1.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-gnu": "1.1.3",
-        "@rolldown/binding-linux-x64-musl": "1.1.3",
-        "@rolldown/binding-openharmony-arm64": "1.1.3",
-        "@rolldown/binding-wasm32-wasi": "1.1.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
-        "@rolldown/binding-win32-x64-msvc": "1.1.3"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -14480,18 +13795,19 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
-        "tinyglobby": "^0.2.17"
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -14507,10 +13823,9 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.3.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -14523,16 +13838,13 @@
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
         "jiti": {
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -14554,6 +13866,25 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "overrides": {
+    "vite": "7.3.6",
+    "comment": "latest vite misidentifies @polymer/polymer's static import and throw SyntaxError: Unexpected token '('"
+  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"

--- a/src/cosmoz-omnitable.js
+++ b/src/cosmoz-omnitable.js
@@ -62,6 +62,7 @@ customElements.define(
 			'loading',
 			'mini-breakpoint',
 			'inline',
+			'enable-select-all',
 		],
 	}),
 );

--- a/src/grouped-list/use-cosmoz-grouped-list.ts
+++ b/src/grouped-list/use-cosmoz-grouped-list.ts
@@ -89,7 +89,7 @@ const useCosmozGroupedList = (host: UseCosmozGroupedListHost) => {
 						toggleFold: () => toggleFold(item as Item),
 					})
 				: renderItem(item as Item, index, {
-						selected: selectedItems.includes(item as Item),
+						selected: isItemSelected(item as Item),
 						expanded: isExpanded(item as Item, state),
 						toggleSelect: (selected?: boolean) =>
 							toggleSelect(

--- a/src/grouped-list/use-selected-items.ts
+++ b/src/grouped-list/use-selected-items.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useProperty, useState } from '@pionjs/pion';
 import type { Item } from '../lib/types';
+import { All, type TAll } from '../lib/utils';
 import { GroupItem, isGroup } from './utils';
 
 export interface UseSelectedItemsParams {
@@ -9,7 +10,7 @@ export interface UseSelectedItemsParams {
 }
 
 export interface UseSelectedItemsResult {
-	selectedItems: Item[];
+	selectedItems: Item[] | TAll;
 	isItemSelected: (item: Item) => boolean;
 	isGroupSelected: (group: GroupItem<Item>) => boolean;
 	isSelected: (item: Item | GroupItem<Item>) => boolean;
@@ -27,7 +28,7 @@ export const useSelectedItems = ({
 	data,
 	flatData,
 }: UseSelectedItemsParams): UseSelectedItemsResult => {
-	const [selectedItems, setSelectedItems] = useProperty<Item[]>(
+	const [selectedItems, setSelectedItems] = useProperty<Item[] | TAll>(
 		'selectedItems',
 		() => [],
 	);
@@ -36,15 +37,16 @@ export const useSelectedItems = ({
 	 * Check if item is selected.
 	 */
 	const isItemSelected = useCallback(
-		(item: Item) => selectedItems.includes(item),
+		(item: Item) => selectedItems === All || selectedItems.includes(item),
 		[selectedItems],
 	);
 	/**
 	 * Check if group is selected.
 	 */
 	const isGroupSelected = useCallback(
-		(group: GroupItem<Item>) => group?.items?.every(isItemSelected) ?? false,
-		[isItemSelected],
+		(group: GroupItem<Item>) =>
+			selectedItems === All || (group?.items?.every(isItemSelected) ?? false),
+		[selectedItems, isItemSelected],
 	);
 	/**
 	 * Check if item.group is selected.
@@ -60,23 +62,36 @@ export const useSelectedItems = ({
 	const select = useCallback((item: Item | GroupItem<Item>) => {
 		const groupItem = item as GroupItem<Item>;
 		const items = groupItem.items ?? [item as Item];
-		setSelectedItems((selection) => [
-			...selection,
-			...items.filter((i: Item) => !selection.includes(i)),
-		]);
+		setSelectedItems((selection) => {
+			if (selection === All) {
+				return selection;
+			}
+			return [
+				...selection,
+				...items.filter((i: Item) => !selection.includes(i)),
+			];
+		});
 		setLastSelection(item);
 	}, []);
 	/**
 	 * Removes an item/group from the list of selected items.
 	 */
-	const deselect = useCallback((item: Item | GroupItem<Item>) => {
-		const groupItem = item as GroupItem<Item>;
-		const items = groupItem.items ?? [item as Item];
-		setSelectedItems((selection) =>
-			selection.filter((i) => !items.includes(i)),
-		);
-		setLastSelection(item);
-	}, []);
+	const deselect = useCallback(
+		(item: Item | GroupItem<Item>) => {
+			const groupItem = item as GroupItem<Item>;
+			const items = groupItem.items ?? [item as Item];
+			setSelectedItems((selection) => {
+				if (selection === All) {
+					return (flatData ?? []).filter(
+						(selectedItem) => !items.includes(selectedItem as Item),
+					) as Item[];
+				}
+				return selection.filter((i) => !items.includes(i));
+			});
+			setLastSelection(item);
+		},
+		[flatData],
+	);
 
 	const selectOnly = useCallback((item: Item | GroupItem<Item>) => {
 		const groupItem = item as GroupItem<Item>;
@@ -136,7 +151,7 @@ export const useSelectedItems = ({
 	useEffect(
 		() =>
 			setSelectedItems((selectedItems) =>
-				selectedItems.length > 0 && flatData
+				selectedItems !== All && selectedItems.length > 0 && flatData
 					? (flatData.filter((i) =>
 							selectedItems.find((item) => compareItemsFn(i, item)),
 						) as Item[])

--- a/src/grouped-list/use-selected-items.ts
+++ b/src/grouped-list/use-selected-items.ts
@@ -82,9 +82,12 @@ export const useSelectedItems = ({
 			const items = groupItem.items ?? [item as Item];
 			setSelectedItems((selection) => {
 				if (selection === All) {
-					return (flatData ?? []).filter(
-						(selectedItem) => !items.includes(selectedItem as Item),
-					) as Item[];
+					return (flatData ?? [])
+						.filter((selectedItem) => !isGroup(selectedItem))
+						.filter(
+							(selectedItem) =>
+								!items.some((item) => compareItemsFn(selectedItem, item)),
+						) as Item[];
 				}
 				return selection.filter((i) => !items.includes(i));
 			});

--- a/src/grouped-list/use-selected-items.ts
+++ b/src/grouped-list/use-selected-items.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useProperty, useState } from '@pionjs/pion';
 import type { Item } from '../lib/types';
-import { All, type TAll } from '../lib/utils';
+import { All, type TSelection } from '../lib/utils';
 import { GroupItem, isGroup } from './utils';
 
 export interface UseSelectedItemsParams {
@@ -10,7 +10,7 @@ export interface UseSelectedItemsParams {
 }
 
 export interface UseSelectedItemsResult {
-	selectedItems: Item[] | TAll;
+	selectedItems: TSelection<Item>;
 	isItemSelected: (item: Item) => boolean;
 	isGroupSelected: (group: GroupItem<Item>) => boolean;
 	isSelected: (item: Item | GroupItem<Item>) => boolean;
@@ -28,7 +28,7 @@ export const useSelectedItems = ({
 	data,
 	flatData,
 }: UseSelectedItemsParams): UseSelectedItemsResult => {
-	const [selectedItems, setSelectedItems] = useProperty<Item[] | TAll>(
+	const [selectedItems, setSelectedItems] = useProperty<TSelection<Item>>(
 		'selectedItems',
 		() => [],
 	);
@@ -85,8 +85,7 @@ export const useSelectedItems = ({
 					return (flatData ?? [])
 						.filter((selectedItem) => !isGroup(selectedItem))
 						.filter(
-							(selectedItem) =>
-								!items.some((item) => compareItemsFn(selectedItem, item)),
+							(selectedItem) => !items.includes(selectedItem as Item),
 						) as Item[];
 				}
 				return selection.filter((i) => !items.includes(i));

--- a/src/lib/render-footer.ts
+++ b/src/lib/render-footer.ts
@@ -17,7 +17,7 @@ interface RenderFooterParams {
 	xlsxSheetname?: string;
 	topPlacement?: string;
 	enableSelectAll?: boolean;
-	allSelected?: boolean;
+	allSelected: boolean;
 	allItemsCount?: number;
 }
 
@@ -30,18 +30,14 @@ export const renderFooter = ({
 	xlsxSheetname,
 	topPlacement,
 	enableSelectAll,
-	allSelected = false,
+	allSelected,
 	allItemsCount,
 }: RenderFooterParams) => {
 	const isAllSelected = selectedItems === All;
 	const hasSelection = isAllSelected || selectedItems.length > 0;
 	const showSelectAllItems =
 		selectedItems !== All && enableSelectAll && allSelected;
-	const renderExportMenu = () => {
-		if (selectedItems === All) {
-			return;
-		}
-
+	const renderExportMenu = (items: Item[]) => {
 		return html`<cosmoz-dropdown-menu
 			part="extra"
 			slot="extra"
@@ -67,7 +63,7 @@ export const renderFooter = ({
 			</svg>
 			<button
 				@click=${() =>
-					saveAsCsvAction(columns as CsvColumn[], selectedItems, csvFilename!)}
+					saveAsCsvAction(columns as CsvColumn[], items, csvFilename!)}
 			>
 				${t('Save selected items as CSV')}
 			</button>
@@ -75,7 +71,7 @@ export const renderFooter = ({
 				@click=${() =>
 					saveAsXlsxAction(
 						columns as XlsxColumn[],
-						selectedItems,
+						items,
 						xlsxFilename!,
 						xlsxSheetname!,
 					)}
@@ -103,17 +99,28 @@ export const renderFooter = ({
 		part="bottomBar"
 		exportparts="bar: bottomBar-bar, info: bottomBar-info, buttons: bottomBar-buttons"
 	>
-		<span slot="info"> ${allLabel} </span>
-		${when(
-			showSelectAllItems,
-			() =>
-				html`<button @click=${() => setSelectedItems(All)}>
-					${t('Select all items')}
-				</button>`,
-		)}
+		<span slot="info">
+			${allLabel}
+			${when(
+				showSelectAllItems,
+				() =>
+					html`&nbsp;<span
+							part="select-all-items"
+							class="selectAllItems"
+							role="button"
+							tabindex="0"
+							style="cursor: pointer; color: white;"
+							@click=${() => setSelectedItems(All)}
+						>
+							${t('Select all items')}
+						</span>`,
+			)}
+		</span>
 		<slot name="actions" id="actions"></slot>
 		<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
 		<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>
-		${when(selectedItems !== All, renderExportMenu)}
+		${when(selectedItems !== All, () =>
+			renderExportMenu(selectedItems as Item[]),
+		)}
 	</cosmoz-bottom-bar>`;
 };

--- a/src/lib/render-footer.ts
+++ b/src/lib/render-footer.ts
@@ -1,6 +1,6 @@
-import { isEmpty } from '@neovici/cosmoz-utils/template';
 import { t } from 'i18next';
 import { html } from 'lit-html';
+import { when } from 'lit-html/directives/when.js';
 import { saveAsCsvAction, type CsvColumn } from './save-as-csv-action';
 import { saveAsXlsxAction, type XlsxColumn } from './save-as-xlsx-action';
 import type { Column, Item } from './types';
@@ -41,6 +41,57 @@ export const renderFooter = ({
 	const selectedCount = isAllSelected
 		? (allItemsCount ?? 0)
 		: selectedItems.length;
+	const hasSelection = isAllSelected || selectedItems.length > 0;
+	const showSelectAllItems =
+		selectedItems !== All && enableSelectAll && allSelected;
+	const renderExportMenu = () => {
+		if (selectedItems === All) {
+			return;
+		}
+
+		return html`<cosmoz-dropdown-menu
+			part="extra"
+			slot="extra"
+			.placement=${topPlacement}
+		>
+			<svg
+				slot="button"
+				width="14"
+				height="18"
+				viewBox="0 0 14 18"
+				fill="none"
+				stroke="currentColor"
+				xmlns="http://www.w3.org/2000/svg"
+			>
+				<path
+					d="M1 8.5L7.00024 14.5L13 8.5"
+					stroke-width="2"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+				<path d="M13 17L1 17" stroke-width="2" stroke-linecap="round" />
+				<path d="M7 1V13" stroke-width="2" stroke-linecap="round" />
+			</svg>
+			<button
+				@click=${() =>
+					saveAsCsv(columns as CsvColumn[], selectedItems, csvFilename!)}
+			>
+				${t('Save selected items as CSV')}
+			</button>
+			<button
+				@click=${() =>
+					saveAsXlsx(
+						columns as XlsxColumn[],
+						selectedItems,
+						xlsxFilename!,
+						xlsxSheetname!,
+					)}
+			>
+				${t('Save selected items as XLSX')}
+			</button>
+			<slot name="download-menu"></slot>
+		</cosmoz-dropdown-menu>`;
+	};
 	let allLabel;
 
 	if (isAllSelected) {
@@ -54,62 +105,21 @@ export const renderFooter = ({
 
 	return html`<cosmoz-bottom-bar
 		id="bottomBar"
-		?active=${isAllSelected || !isEmpty(selectedCount)}
+		?active=${hasSelection}
 		part="bottomBar"
 		exportparts="bar: bottomBar-bar, info: bottomBar-info, buttons: bottomBar-buttons"
 	>
 		<span slot="info"> ${allLabel} </span>
-		${selectedItems !== All && enableSelectAll && allSelected
-			? html`<button @click=${() => setSelectedItems(All)}>
+		${when(
+			showSelectAllItems,
+			() =>
+				html`<button @click=${() => setSelectedItems(All)}>
 					${t('Select all items')}
-				</button>`
-			: ''}
+				</button>`,
+		)}
 		<slot name="actions" id="actions"></slot>
 		<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
 		<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>
-		${selectedItems !== All
-			? html`<cosmoz-dropdown-menu
-					part="extra"
-					slot="extra"
-					.placement=${topPlacement}
-				>
-					<svg
-						slot="button"
-						width="14"
-						height="18"
-						viewBox="0 0 14 18"
-						fill="none"
-						stroke="currentColor"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path
-							d="M1 8.5L7.00024 14.5L13 8.5"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						/>
-						<path d="M13 17L1 17" stroke-width="2" stroke-linecap="round" />
-						<path d="M7 1V13" stroke-width="2" stroke-linecap="round" />
-					</svg>
-					<button
-						@click=${() =>
-							saveAsCsv(columns as CsvColumn[], selectedItems, csvFilename!)}
-					>
-						${t('Save selected items as CSV')}
-					</button>
-					<button
-						@click=${() =>
-							saveAsXlsx(
-								columns as XlsxColumn[],
-								selectedItems,
-								xlsxFilename!,
-								xlsxSheetname!,
-							)}
-					>
-						${t('Save selected items as XLSX')}
-					</button>
-					<slot name="download-menu"></slot>
-				</cosmoz-dropdown-menu>`
-			: ''}
+		${when(selectedItems !== All, renderExportMenu)}
 	</cosmoz-bottom-bar>`;
 };

--- a/src/lib/render-footer.ts
+++ b/src/lib/render-footer.ts
@@ -9,8 +9,6 @@ import { All, type TAll } from './utils';
 interface RenderFooterParams {
 	columns: Column[];
 	selectedItems: Item[] | TAll;
-	saveAsCsv?: typeof saveAsCsvAction;
-	saveAsXlsx?: typeof saveAsXlsxAction;
 	setSelectedItems: (
 		items: Item[] | TAll | ((prev: Item[] | TAll) => Item[] | TAll),
 	) => void;
@@ -26,8 +24,6 @@ interface RenderFooterParams {
 export const renderFooter = ({
 	columns,
 	selectedItems,
-	saveAsCsv = saveAsCsvAction,
-	saveAsXlsx = saveAsXlsxAction,
 	setSelectedItems,
 	csvFilename,
 	xlsxFilename,
@@ -38,9 +34,6 @@ export const renderFooter = ({
 	allItemsCount,
 }: RenderFooterParams) => {
 	const isAllSelected = selectedItems === All;
-	const selectedCount = isAllSelected
-		? (allItemsCount ?? 0)
-		: selectedItems.length;
 	const hasSelection = isAllSelected || selectedItems.length > 0;
 	const showSelectAllItems =
 		selectedItems !== All && enableSelectAll && allSelected;
@@ -74,13 +67,13 @@ export const renderFooter = ({
 			</svg>
 			<button
 				@click=${() =>
-					saveAsCsv(columns as CsvColumn[], selectedItems, csvFilename!)}
+					saveAsCsvAction(columns as CsvColumn[], selectedItems, csvFilename!)}
 			>
 				${t('Save selected items as CSV')}
 			</button>
 			<button
 				@click=${() =>
-					saveAsXlsx(
+					saveAsXlsxAction(
 						columns as XlsxColumn[],
 						selectedItems,
 						xlsxFilename!,
@@ -92,16 +85,17 @@ export const renderFooter = ({
 			<slot name="download-menu"></slot>
 		</cosmoz-dropdown-menu>`;
 	};
-	let allLabel;
-
-	if (isAllSelected) {
-		allLabel =
+	const allLabel = when(
+		isAllSelected,
+		() =>
 			allItemsCount !== undefined
 				? t('All {count} items selected', { count: allItemsCount })
-				: t('All items selected');
-	} else {
-		allLabel = t('{count} selected item', { count: selectedCount });
-	}
+				: t('All items selected'),
+		() =>
+			t('{count} selected item', {
+				count: selectedItems === All ? 0 : selectedItems.length,
+			}),
+	);
 
 	return html`<cosmoz-bottom-bar
 		id="bottomBar"

--- a/src/lib/render-footer.ts
+++ b/src/lib/render-footer.ts
@@ -4,72 +4,112 @@ import { html } from 'lit-html';
 import { saveAsCsvAction, type CsvColumn } from './save-as-csv-action';
 import { saveAsXlsxAction, type XlsxColumn } from './save-as-xlsx-action';
 import type { Column, Item } from './types';
+import { All, type TAll } from './utils';
 
 interface RenderFooterParams {
 	columns: Column[];
-	selectedItems: Item[];
+	selectedItems: Item[] | TAll;
+	saveAsCsv?: typeof saveAsCsvAction;
+	saveAsXlsx?: typeof saveAsXlsxAction;
+	setSelectedItems: (
+		items: Item[] | TAll | ((prev: Item[] | TAll) => Item[] | TAll),
+	) => void;
 	csvFilename?: string;
 	xlsxFilename?: string;
 	xlsxSheetname?: string;
 	topPlacement?: string;
+	enableSelectAll?: boolean;
+	allSelected?: boolean;
+	allItemsCount?: number;
 }
 
 export const renderFooter = ({
 	columns,
 	selectedItems,
+	saveAsCsv = saveAsCsvAction,
+	saveAsXlsx = saveAsXlsxAction,
+	setSelectedItems,
 	csvFilename,
 	xlsxFilename,
 	xlsxSheetname,
 	topPlacement,
-}: RenderFooterParams) =>
-	html`<cosmoz-bottom-bar
+	enableSelectAll,
+	allSelected = false,
+	allItemsCount,
+}: RenderFooterParams) => {
+	const isAllSelected = selectedItems === All;
+	const selectedCount = isAllSelected
+		? (allItemsCount ?? 0)
+		: selectedItems.length;
+	let allLabel;
+
+	if (isAllSelected) {
+		allLabel =
+			allItemsCount !== undefined
+				? t('All {count} items selected', { count: allItemsCount })
+				: t('All items selected');
+	} else {
+		allLabel = t('{count} selected item', { count: selectedCount });
+	}
+
+	return html`<cosmoz-bottom-bar
 		id="bottomBar"
-		?active=${!isEmpty(selectedItems.length)}
+		?active=${isAllSelected || !isEmpty(selectedCount)}
 		part="bottomBar"
 		exportparts="bar: bottomBar-bar, info: bottomBar-info, buttons: bottomBar-buttons"
 	>
-		<slot name="info" slot="info">
-			${t('{count} selected item', { count: selectedItems.length })}
-		</slot>
+		<span slot="info"> ${allLabel} </span>
+		${selectedItems !== All && enableSelectAll && allSelected
+			? html`<button @click=${() => setSelectedItems(All)}>
+					${t('Select all items')}
+				</button>`
+			: ''}
 		<slot name="actions" id="actions"></slot>
 		<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
 		<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>
-		<cosmoz-dropdown-menu part="extra" slot="extra" .placement=${topPlacement}>
-			<svg
-				slot="button"
-				width="14"
-				height="18"
-				viewBox="0 0 14 18"
-				fill="none"
-				stroke="currentColor"
-				xmlns="http://www.w3.org/2000/svg"
-			>
-				<path
-					d="M1 8.5L7.00024 14.5L13 8.5"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				/>
-				<path d="M13 17L1 17" stroke-width="2" stroke-linecap="round" />
-				<path d="M7 1V13" stroke-width="2" stroke-linecap="round" />
-			</svg>
-			<button
-				@click=${() =>
-					saveAsCsvAction(columns as CsvColumn[], selectedItems, csvFilename!)}
-			>
-				${t('Save selected items as CSV')}
-			</button>
-			<button
-				@click=${() =>
-					saveAsXlsxAction(
-						columns as XlsxColumn[],
-						selectedItems,
-						xlsxFilename!,
-						xlsxSheetname!,
-					)}
-			>
-				${t('Save selected items as XLSX')}
-			</button>
-			<slot name="download-menu"></slot>
-		</cosmoz-dropdown-menu>
+		${selectedItems !== All
+			? html`<cosmoz-dropdown-menu
+					part="extra"
+					slot="extra"
+					.placement=${topPlacement}
+				>
+					<svg
+						slot="button"
+						width="14"
+						height="18"
+						viewBox="0 0 14 18"
+						fill="none"
+						stroke="currentColor"
+						xmlns="http://www.w3.org/2000/svg"
+					>
+						<path
+							d="M1 8.5L7.00024 14.5L13 8.5"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						/>
+						<path d="M13 17L1 17" stroke-width="2" stroke-linecap="round" />
+						<path d="M7 1V13" stroke-width="2" stroke-linecap="round" />
+					</svg>
+					<button
+						@click=${() =>
+							saveAsCsv(columns as CsvColumn[], selectedItems, csvFilename!)}
+					>
+						${t('Save selected items as CSV')}
+					</button>
+					<button
+						@click=${() =>
+							saveAsXlsx(
+								columns as XlsxColumn[],
+								selectedItems,
+								xlsxFilename!,
+								xlsxSheetname!,
+							)}
+					>
+						${t('Save selected items as XLSX')}
+					</button>
+					<slot name="download-menu"></slot>
+				</cosmoz-dropdown-menu>`
+			: ''}
 	</cosmoz-bottom-bar>`;
+};

--- a/src/lib/render-list.ts
+++ b/src/lib/render-list.ts
@@ -7,6 +7,7 @@ import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 import type { NormalizedSettings } from './settings/normalize';
 import type { Column, Item } from './types';
+import { type TAll } from './utils';
 
 interface HeaderParams {
 	settingsConfig: NormalizedSettings & {
@@ -26,8 +27,10 @@ interface ListParams {
 	loading: boolean;
 	displayEmptyGroups: boolean;
 	compareItemsFn?: (a: unknown, b: unknown) => boolean;
-	selectedItems: Item[];
-	setSelectedItems: (items: Item[] | ((prev: Item[]) => Item[])) => void;
+	selectedItems: Item[] | TAll;
+	setSelectedItems: (
+		items: Item[] | TAll | ((prev: Item[] | TAll) => Item[] | TAll),
+	) => void;
 	renderItem: (item: Item, index: number, params: unknown) => unknown;
 	renderGroup: (item: unknown, index: number, params: unknown) => unknown;
 	error?: { message: string } | null;

--- a/src/lib/render-list.ts
+++ b/src/lib/render-list.ts
@@ -7,7 +7,7 @@ import { html } from 'lit-html';
 import { when } from 'lit-html/directives/when.js';
 import type { NormalizedSettings } from './settings/normalize';
 import type { Column, Item } from './types';
-import { type TAll } from './utils';
+import { type TSelection } from './utils';
 
 interface HeaderParams {
 	settingsConfig: NormalizedSettings & {
@@ -27,9 +27,9 @@ interface ListParams {
 	loading: boolean;
 	displayEmptyGroups: boolean;
 	compareItemsFn?: (a: unknown, b: unknown) => boolean;
-	selectedItems: Item[] | TAll;
+	selectedItems: TSelection<Item>;
 	setSelectedItems: (
-		items: Item[] | TAll | ((prev: Item[] | TAll) => Item[] | TAll),
+		items: TSelection<Item> | ((prev: TSelection<Item>) => TSelection<Item>),
 	) => void;
 	renderItem: (item: Item, index: number, params: unknown) => unknown;
 	renderGroup: (item: unknown, index: number, params: unknown) => unknown;

--- a/src/lib/use-footer.ts
+++ b/src/lib/use-footer.ts
@@ -1,5 +1,5 @@
 import type { Item } from './types';
-import { type TAll } from './utils';
+import { type TSelection } from './utils';
 
 interface FooterHost extends HTMLElement {
 	csvFilename?: string;
@@ -11,10 +11,10 @@ interface FooterHost extends HTMLElement {
 
 interface UseFooterParams {
 	host: FooterHost;
-	selectedItems: Item[] | TAll;
+	selectedItems: TSelection<Item>;
 	allSelected: boolean;
 	setSelectedItems: (
-		items: Item[] | TAll | ((prev: Item[] | TAll) => Item[] | TAll),
+		items: TSelection<Item> | ((prev: TSelection<Item>) => TSelection<Item>),
 	) => void;
 	enableSelectAll: boolean;
 	allItemsCount?: number;

--- a/src/lib/use-footer.ts
+++ b/src/lib/use-footer.ts
@@ -1,12 +1,23 @@
+import type { Item } from './types';
+import { type TAll } from './utils';
+
 interface FooterHost extends HTMLElement {
 	csvFilename?: string;
 	xlsxFilename?: string;
 	xlsxSheetname?: string;
 	topPlacement?: string;
+	allItemsCount?: number;
 }
 
 interface UseFooterParams {
 	host: FooterHost;
+	selectedItems: Item[] | TAll;
+	allSelected: boolean;
+	setSelectedItems: (
+		items: Item[] | TAll | ((prev: Item[] | TAll) => Item[] | TAll),
+	) => void;
+	enableSelectAll: boolean;
+	allItemsCount?: number;
 	[key: string]: unknown;
 }
 

--- a/src/lib/use-header.js
+++ b/src/lib/use-header.js
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from '@pionjs/pion';
+import { All } from './utils';
 
 export const useHeader = ({
 	host,
@@ -14,7 +15,8 @@ export const useHeader = ({
 	...rest
 }) => {
 	const allSelected =
-			data && data.length > 0 && selectedItems.length === data.length,
+			selectedItems === All ||
+			(data && data.length > 0 && selectedItems.length === data.length),
 		onAllCheckboxChange = (event) => {
 			if (event.target.checked) {
 				host.shadowRoot.querySelector('#groupedList').selectAll();

--- a/src/lib/use-omnitable.js
+++ b/src/lib/use-omnitable.js
@@ -96,7 +96,7 @@ export const useOmnitable = (host) => {
 			allSelected: header.allSelected,
 			setSelectedItems,
 			columns,
-			enableSelectAll: host.enableSelectAll === true,
+			enableSelectAll: host.enableSelectAll,
 			allItemsCount: host.allItemsCount,
 		}),
 	};

--- a/src/lib/use-omnitable.js
+++ b/src/lib/use-omnitable.js
@@ -58,23 +58,25 @@ export const useOmnitable = (host) => {
 			...sortAndGroupOptions,
 		});
 
+	const header = useHeader({
+		host,
+		selectedItems,
+		sortAndGroupOptions,
+		dataIsValid,
+		data,
+		columns,
+		filters,
+		collapsedColumns,
+		settings,
+		filterFunctions,
+		settingS,
+		setFilterState,
+		hideSelectAll: host.hideSelectAll === true,
+		requestTween,
+	});
+
 	return {
-		header: useHeader({
-			host,
-			selectedItems,
-			sortAndGroupOptions,
-			dataIsValid,
-			data,
-			columns,
-			filters,
-			collapsedColumns,
-			settings,
-			filterFunctions,
-			settingS,
-			setFilterState,
-			hideSelectAll: host.hideSelectAll === true,
-			requestTween,
-		}),
+		header,
 		list: useList({
 			host,
 			error,
@@ -91,7 +93,11 @@ export const useOmnitable = (host) => {
 		footer: useFooter({
 			host,
 			selectedItems,
+			allSelected: header.allSelected,
+			setSelectedItems,
 			columns,
+			enableSelectAll: host.enableSelectAll === true,
+			allItemsCount: host.allItemsCount,
 		}),
 	};
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,14 @@ const indexSymbol = Symbol('index');
 
 export { indexSymbol };
 
+/**
+ * Sentinel symbol representing the bulk selection feature.
+ * Set as `selectedItems` when user clicks the footer "Select all items" button.
+ * The total count is provided via the `allItemsCount` property.
+ */
+export const All = Symbol('All');
+export type TAll = typeof All;
+
 export const findLastIndex = (
 	array: (number | undefined)[],
 	predicate: (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,6 +9,7 @@ export { indexSymbol };
  */
 export const All = Symbol('All');
 export type TAll = typeof All;
+export type TSelection<T = unknown> = T[] | TAll;
 
 export const findLastIndex = (
 	array: (number | undefined)[],

--- a/stories/cosmoz-omnitable-full-demo.stories.ts
+++ b/stories/cosmoz-omnitable-full-demo.stories.ts
@@ -22,6 +22,8 @@ const meta: Meta = {
 		settingsId: '',
 		selectedItems: [],
 		disabledFiltering: false,
+		enableSelectAll: false,
+		allItemsCount: 10000,
 	},
 	argTypes: {
 		loading: {
@@ -42,6 +44,10 @@ const meta: Meta = {
 		selectedItems: {
 			control: 'object',
 			description: 'Show selected items',
+		},
+		allItemsCount: {
+			control: 'number',
+			description: 'Total number of items',
 		},
 		data: {
 			control: 'object',
@@ -94,6 +100,7 @@ const meta: Meta = {
 				.loading=${args.loading}
 				.data=${args.data}
 				.selectedItems=${args.selectedItems}
+				.allItemsCount=${args.allItemsCount}
 				hash-param=${args.hashParam}
 				sort-on=${args.sortOn}
 				group-on=${args.groupOn}
@@ -101,6 +108,7 @@ const meta: Meta = {
 				.group-on-descending=${args.groupOnDescending}
 				settings-id=${args.settingsId}
 				?disabled-filtering=${args.disabledFiltering}
+				?enable-select-all=${args.enableSelectAll}
 			>
 				<cosmoz-omnitable-column
 					priority="-1"

--- a/stories/cosmoz-omnitable.stories.js
+++ b/stories/cosmoz-omnitable.stories.js
@@ -2,6 +2,15 @@ import { html } from 'lit-html';
 import '../src/cosmoz-omnitable.js';
 import demoData from './data.json';
 
+const generateLargeData = (count) =>
+	Array.from({ length: count }, (_, i) => ({
+		company: `Company ${Math.floor(i / 100) + 1}`,
+		age: 20 + (i % 50),
+		eyeColor: ['blue', 'green', 'brown', 'hazel'][i % 4],
+		balance: `$${(Math.random() * 10000).toFixed(2)}`,
+		registered: new Date(2020, 0, 1 + (i % 1000)).toISOString(),
+	}));
+
 export default {
 	title: 'Components/CosmozOmnitable',
 	component: 'cosmoz-omnitable',
@@ -18,9 +27,10 @@ const Template = (args) => {
 	return html`
 		<style>
 			.omnitable-container {
-				height: 300px;
+				height: calc(80vh - 60px);
 				display: flex;
 				flex-direction: column;
+				margin-bottom: 60px;
 			}
 			cosmoz-omnitable {
 				flex: 1;
@@ -34,6 +44,22 @@ const Template = (args) => {
 			cosmoz-omnitable-header-row {
 				border-bottom: 1px solid #e1e2e5;
 			}
+			[slot='actions'] button {
+				background-color: #1d2939;
+				color: #ffffff;
+				border: 1px solid #1d2939;
+				border-radius: 8px;
+				padding: 8px 14px;
+				font-size: 14px;
+				font-weight: 500;
+				cursor: pointer;
+				font-family: inherit;
+				line-height: 1.5;
+			}
+			[slot='actions'] button:hover {
+				background-color: #101828;
+				border-color: #101828;
+			}
 		</style>
 		<div class="omnitable-container">
 			<cosmoz-omnitable
@@ -44,6 +70,7 @@ const Template = (args) => {
 				?descending=${args.descending}
 				?group-on-descending=${args.groupOnDescending}
 				?hide-select-all=${args.hideSelectAll}
+				?enable-select-all=${args.enableSelectAll}
 				settings-id=${args.settingsId || ''}
 				?no-local=${args.noLocal}
 				?no-local-sort=${args.noLocalSort}
@@ -202,10 +229,7 @@ const InlineTemplate = (args) => {
 			>
 			</cosmoz-omnitable-column>
 
-			<div slot="actions">
-				<button>Export</button>
-				<button>Settings</button>
-			</div>
+			<button slot="bottom-bar-toolbar">Approve</button>
 		</cosmoz-omnitable>
 	`;
 };
@@ -232,4 +256,92 @@ InlineDisabledFiltering.parameters = {
 				'Inline mode with disabled filtering, suitable for search results where all rows are shown without internal scrolling.',
 		},
 	},
+};
+
+const LargeDataTemplate = (args) => html`
+	<style>
+		.omnitable-container {
+			height: calc(80vh - 60px);
+			margin-bottom: 60px;
+			display: flex;
+			flex-direction: column;
+		}
+		cosmoz-omnitable {
+			flex: 1;
+			min-height: 0;
+			display: flex;
+			flex-direction: column;
+		}
+		cosmoz-omnitable-item-row {
+			border-bottom: 1px solid #e1e2e5;
+		}
+		cosmoz-omnitable-header-row {
+			border-bottom: 1px solid #e1e2e5;
+		}
+	</style>
+	<div class="omnitable-container">
+		<cosmoz-omnitable
+			.data=${args.data}
+			.allItemsCount=${args.allItemsCount}
+			?enable-select-all=${args.enableSelectAll}
+		>
+			<cosmoz-omnitable-column
+				name="company"
+				title="Company"
+				value-path="company"
+				sort-on="company"
+				group-on="company"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="age"
+				title="Age"
+				value-path="age"
+				sort-on="age"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="eyeColor"
+				title="Eye Color"
+				value-path="eyeColor"
+				sort-on="eyeColor"
+				group-on="eyeColor"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="balance"
+				title="Balance"
+				value-path="balance"
+				sort-on="balance"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="registered"
+				title="Registered"
+				value-path="registered"
+				sort-on="registered"
+			>
+			</cosmoz-omnitable-column>
+
+			<button slot="bottom-bar-toolbar">Approve</button>
+		</cosmoz-omnitable>
+	</div>
+`;
+
+export const SelectAll = LargeDataTemplate.bind({});
+SelectAll.args = {
+	data: generateLargeData(100),
+	allItemsCount: 10000,
+	enableSelectAll: false,
+};
+
+export const BulkSelectAll = LargeDataTemplate.bind({});
+BulkSelectAll.args = {
+	data: generateLargeData(100),
+	allItemsCount: 10000,
+	enableSelectAll: true,
 };

--- a/test/footer-select-all.test.js
+++ b/test/footer-select-all.test.js
@@ -50,7 +50,7 @@ suite('footer select all', () => {
 		assert.isTrue(headerCheckbox.checked);
 		assert.include(omnitable.shadowRoot.textContent, 'Select all items');
 
-		omnitable.shadowRoot.querySelector('#bottomBar button').click();
+		omnitable.shadowRoot.querySelector('.selectAllItems').click();
 		await nextFrame();
 		await nextFrame();
 

--- a/test/footer-select-all.test.js
+++ b/test/footer-select-all.test.js
@@ -1,0 +1,65 @@
+import { assert, html, nextFrame } from '@open-wc/testing';
+
+import {
+	ensureDemoI18nInitialized,
+	setDemoLanguage,
+} from '../demo/helpers/i18n';
+import { generateTableDemoData } from '../demo/table-demo-helper';
+import {
+	ignoreResizeObserverLoopErrors,
+	setupOmnitableFixture,
+} from './helpers/utils';
+
+import '../src/cosmoz-omnitable-columns.ts';
+import '../src/cosmoz-omnitable.js';
+import { All } from '../src/lib/utils';
+
+suite('footer select all', () => {
+	ignoreResizeObserverLoopErrors(setup, teardown);
+	let omnitable;
+
+	setup(async () => {
+		await ensureDemoI18nInitialized();
+		await setDemoLanguage('en');
+		omnitable = await setupOmnitableFixture(
+			html`
+				<cosmoz-omnitable
+					id="omnitable"
+					selection-enabled
+					enable-select-all
+					.allItemsCount=${10000}
+				>
+					<cosmoz-omnitable-column
+						name="name"
+						value-path="name"
+					></cosmoz-omnitable-column>
+				</cosmoz-omnitable>
+			`,
+			generateTableDemoData(10, 11, 25),
+		);
+		await nextFrame();
+	});
+
+	test('shows select-all button after selecting displayed rows and switches to All', async () => {
+		const headerCheckbox = omnitable.shadowRoot.querySelector(
+			'input[type="checkbox"]',
+		);
+		headerCheckbox.click();
+		await nextFrame();
+
+		assert.isTrue(headerCheckbox.checked);
+		assert.include(omnitable.shadowRoot.textContent, 'Select all items');
+
+		omnitable.shadowRoot.querySelector('#bottomBar button').click();
+		await nextFrame();
+		await nextFrame();
+
+		const footerInfo = omnitable.shadowRoot.querySelector(
+			'#bottomBar [slot="info"]',
+		);
+
+		assert.strictEqual(omnitable.selectedItems, All);
+		assert.notInclude(footerInfo.textContent, 'Select all items');
+		assert.match(footerInfo.textContent, /All \d+ items selected/u);
+	});
+});

--- a/test/render-footer-export.test.js
+++ b/test/render-footer-export.test.js
@@ -16,9 +16,6 @@ suite('render-footer export', () => {
 			},
 		];
 
-		const csvCalls = [];
-		const xlsxCalls = [];
-
 		render(
 			renderFooter({
 				columns,
@@ -27,8 +24,6 @@ suite('render-footer export', () => {
 				csvFilename: 'test.csv',
 				xlsxFilename: 'test.xlsx',
 				xlsxSheetname: 'Sheet 1',
-				saveAsCsv: (...args) => csvCalls.push(args),
-				saveAsXlsx: (...args) => xlsxCalls.push(args),
 			}),
 			container,
 		);
@@ -37,13 +32,11 @@ suite('render-footer export', () => {
 		// so the export dropdown is hidden entirely.
 		const dropdown = container.querySelector('cosmoz-dropdown-menu');
 		assert.isNull(dropdown);
-		assert.lengthOf(csvCalls, 0);
-		assert.lengthOf(xlsxCalls, 0);
 
 		container.remove();
 	});
 
-	test('exports selectedItems when not All', () => {
+	test('shows export buttons when selectedItems is an array', () => {
 		const container = document.createElement('div');
 		document.body.append(container);
 
@@ -56,9 +49,6 @@ suite('render-footer export', () => {
 			},
 		];
 
-		const csvCalls = [];
-		const xlsxCalls = [];
-
 		render(
 			renderFooter({
 				columns,
@@ -67,21 +57,16 @@ suite('render-footer export', () => {
 				csvFilename: 'test.csv',
 				xlsxFilename: 'test.xlsx',
 				xlsxSheetname: 'Sheet 1',
-				saveAsCsv: (...args) => csvCalls.push(args),
-				saveAsXlsx: (...args) => xlsxCalls.push(args),
 			}),
 			container,
 		);
 
-		const buttons = container.querySelectorAll('cosmoz-dropdown-menu > button');
-		buttons[0].click();
-		buttons[1].click();
-
-		assert.lengthOf(csvCalls, 1);
-		assert.strictEqual(csvCalls[0][1], selectedItems);
-
-		assert.lengthOf(xlsxCalls, 1);
-		assert.strictEqual(xlsxCalls[0][1], selectedItems);
+		const dropdown = container.querySelector('cosmoz-dropdown-menu');
+		assert.isNotNull(dropdown);
+		assert.lengthOf(
+			container.querySelectorAll('cosmoz-dropdown-menu > button'),
+			2,
+		);
 
 		container.remove();
 	});

--- a/test/render-footer-export.test.js
+++ b/test/render-footer-export.test.js
@@ -1,0 +1,88 @@
+import { assert } from '@open-wc/testing';
+import { render } from 'lit-html';
+import { renderFooter } from '../src/lib/render-footer';
+import { All } from '../src/lib/utils';
+
+suite('render-footer export', () => {
+	test('hides CSV/XLSX export buttons when selectedItems is All', () => {
+		const container = document.createElement('div');
+		document.body.append(container);
+
+		const columns = [
+			{
+				title: 'ID',
+				getString: (_column, item) => String(item.id),
+				toXlsxValue: (_column, item) => String(item.id),
+			},
+		];
+
+		const csvCalls = [];
+		const xlsxCalls = [];
+
+		render(
+			renderFooter({
+				columns,
+				selectedItems: All,
+				setSelectedItems: () => undefined,
+				csvFilename: 'test.csv',
+				xlsxFilename: 'test.xlsx',
+				xlsxSheetname: 'Sheet 1',
+				saveAsCsv: (...args) => csvCalls.push(args),
+				saveAsXlsx: (...args) => xlsxCalls.push(args),
+			}),
+			container,
+		);
+
+		// When All items are selected, the full dataset is not available to export,
+		// so the export dropdown is hidden entirely.
+		const dropdown = container.querySelector('cosmoz-dropdown-menu');
+		assert.isNull(dropdown);
+		assert.lengthOf(csvCalls, 0);
+		assert.lengthOf(xlsxCalls, 0);
+
+		container.remove();
+	});
+
+	test('exports selectedItems when not All', () => {
+		const container = document.createElement('div');
+		document.body.append(container);
+
+		const selectedItems = [{ id: 1 }, { id: 2 }];
+		const columns = [
+			{
+				title: 'ID',
+				getString: (_column, item) => String(item.id),
+				toXlsxValue: (_column, item) => String(item.id),
+			},
+		];
+
+		const csvCalls = [];
+		const xlsxCalls = [];
+
+		render(
+			renderFooter({
+				columns,
+				selectedItems,
+				setSelectedItems: () => undefined,
+				csvFilename: 'test.csv',
+				xlsxFilename: 'test.xlsx',
+				xlsxSheetname: 'Sheet 1',
+				saveAsCsv: (...args) => csvCalls.push(args),
+				saveAsXlsx: (...args) => xlsxCalls.push(args),
+			}),
+			container,
+		);
+
+		const buttons = container.querySelectorAll('cosmoz-dropdown-menu > button');
+		buttons[0].click();
+		buttons[1].click();
+
+		assert.lengthOf(csvCalls, 1);
+		assert.strictEqual(csvCalls[0][1], selectedItems);
+
+		assert.lengthOf(xlsxCalls, 1);
+		assert.strictEqual(xlsxCalls[0][1], selectedItems);
+
+		container.remove();
+	});
+});


### PR DESCRIPTION
## Description

Adds a "Select all items" feature (Gmail-style) for paginated datasets, where only a subset of items may be loaded while a total count is known.

### Changes

- **`All` sentinel** — a `Symbol('All')` that represents "all items" (the full dataset, not just the loaded subset)
- **`enable-select-all` attribute** — boolean attribute on `<cosmoz-omnitable>` to enable the feature
- **`allItemsCount` property** — allows consumers to pass the total count (e.g., from API's `totalAvailable`) when only a subset is loaded
- **Footer UI** — shows "Select all items" button when some items are selected; shows "All {count} items selected" (or "All items selected" when no count is provided) after clicking
- **Header checkbox** — unchanged, selects only loaded items as array
- **Selection logic** — `isItemSelected` / select / deselect all handle the `All` sentinel correctly

### Storybook

Added `SelectAll` and `BulkSelectAll` stories with 100 items loaded and `allItemsCount: 10000` to demonstrate the paginated scenario.

Closes FE-66
