### PR TITLE
fix: harden filter deserialization for malformed hash values

### DIFF
--- a/src/cosmoz-omnitable-column-amount.js
+++ b/src/cosmoz-omnitable-column-amount.js
@@ -81,7 +81,7 @@ class OmnitableColumnAmount extends columnMixin(PolymerElement) {
 	}
 
 	deserializeFilter(column, filter) {
-		if (filter == null || filter === '') {
+		if (typeof filter !== 'string' || filter === '') {
 			return null;
 		}
 		const matches = filter.match(/^([^~]+)?~([^~]+)?/iu);

--- a/src/cosmoz-omnitable-column-date.js
+++ b/src/cosmoz-omnitable-column-date.js
@@ -71,7 +71,7 @@ class OmnitableColumnDate extends columnMixin(PolymerElement) {
 	}
 
 	deserializeFilter(column, filter) {
-		if (filter == null || filter === '') {
+		if (typeof filter !== 'string' || filter === '') {
 			return null;
 		}
 		const matches = filter.match(/^([^~]+)?~([^~]+)?/iu);

--- a/src/cosmoz-omnitable-column-datetime.js
+++ b/src/cosmoz-omnitable-column-datetime.js
@@ -83,7 +83,7 @@ class OmnitableColumnDatetime extends columnMixin(PolymerElement) {
 	}
 
 	deserializeFilter(column, filter) {
-		if (filter == null || filter === '') {
+		if (typeof filter !== 'string' || filter === '') {
 			return null;
 		}
 		const matches = filter.match(/^([^~]+)?~([^~]+)?/iu);

--- a/src/cosmoz-omnitable-column-list-mixin.js
+++ b/src/cosmoz-omnitable-column-list-mixin.js
@@ -162,7 +162,16 @@ const unique = (values, valueProperty) => {
 			}
 
 			deserializeFilter(column, filter) {
-				return JSON.parse(decodeURIComponent(filter));
+				if (filter == null) {
+					return null;
+				}
+
+				try {
+					return JSON.parse(decodeURIComponent(filter));
+				} catch (error) {
+					console.warn('Failed to deserialize filter value:', error.message, filter);
+					return null;
+				}
 			}
 
 			computeSource(column, data) {

--- a/src/cosmoz-omnitable-column-list-mixin.js
+++ b/src/cosmoz-omnitable-column-list-mixin.js
@@ -169,7 +169,12 @@ const unique = (values, valueProperty) => {
 				try {
 					return JSON.parse(decodeURIComponent(filter));
 				} catch (error) {
-					console.warn('Failed to deserialize filter value:', error.message, filter);
+					// eslint-disable-next-line no-console
+					console.error('Failed to deserialize filter value:', {
+						error: error?.name,
+						message: error?.message,
+						filterLength: typeof filter === 'string' ? filter.length : null,
+					});
 					return null;
 				}
 			}

--- a/src/cosmoz-omnitable-column-mixin.js
+++ b/src/cosmoz-omnitable-column-mixin.js
@@ -139,7 +139,11 @@ export const getString = ({ valuePath }, item) => get(item, valuePath),
 				}
 
 				if (typeof filter === 'string') {
-					return window.decodeURIComponent(filter);
+					try {
+						return window.decodeURIComponent(filter);
+					} catch {
+						return null;
+					}
 				}
 				return filter;
 			}

--- a/src/cosmoz-omnitable-column-number.js
+++ b/src/cosmoz-omnitable-column-number.js
@@ -80,7 +80,7 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 	}
 
 	deserializeFilter(column, filter) {
-		if (filter == null || filter === '') {
+		if (typeof filter !== 'string' || filter === '') {
 			return null;
 		}
 		const matches = filter.match(/^([^~]+)?~([^~]+)?/iu);

--- a/src/cosmoz-omnitable-column-time.js
+++ b/src/cosmoz-omnitable-column-time.js
@@ -78,7 +78,7 @@ class OmnitableColumnTime extends columnMixin(PolymerElement) {
 	}
 
 	deserializeFilter(column, filter) {
-		if (filter == null || filter === '') {
+		if (typeof filter !== 'string' || filter === '') {
 			return null;
 		}
 		const matches = filter.match(/^([^~]+)?~([^~]+)?/iu);

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -141,6 +141,10 @@ suite('basic', () => {
 		assert.isNull(columnWithoutGroupOn.deserializeFilter({}, null));
 	});
 
+	test('deserializeFilter returns null for malformed percent-escape sequence', () => {
+		assert.isNull(columnWithoutGroupOn.deserializeFilter({}, '%E0%A4%A'));
+	});
+
 	// Column Behavior unit tests for more coverage
 	test('_hiddenChanged fires cosmoz-column-hidden-changed', () => {
 		const column = omnitable.columns[3][columnSymbol],

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -344,10 +344,14 @@ suite('deserializeFilter', () => {
 		assert.isNull(result);
 	});
 
+	test('returns null on malformed percent-escape sequence', () => {
+		const malformed = '[{"id":"supplier","label":"%E0%A4%A"}]';
+		const result = instance.deserializeFilter({}, malformed);
+		assert.isNull(result);
+	});
+
 	test('returns null on truncated JSON', () => {
-		const truncated = encodeURIComponent(
-			'[{ "id": "item1", "label": "Item ',
-		);
+		const truncated = encodeURIComponent('[{ "id": "item1", "label": "Item ');
 		const result = instance.deserializeFilter({}, truncated);
 		assert.isNull(result);
 	});

--- a/test/list.test.js
+++ b/test/list.test.js
@@ -308,3 +308,53 @@ suite('mixin class getComparableValue', () => {
 		);
 	});
 });
+
+suite('deserializeFilter', () => {
+	let instance;
+
+	setup(() => {
+		const MyClass = listColumnMixin(class {});
+		instance = new MyClass();
+	});
+
+	test('deserializes valid encoded JSON filter', () => {
+		const filter = encodeURIComponent(
+			JSON.stringify([{ id: 'item1', label: 'Item 1' }]),
+		);
+		assert.deepEqual(instance.deserializeFilter({}, filter), [
+			{ id: 'item1', label: 'Item 1' },
+		]);
+	});
+
+	test('handles null filter', () => {
+		assert.isNull(instance.deserializeFilter({}, null));
+	});
+
+	test('handles undefined filter', () => {
+		assert.isNull(instance.deserializeFilter({}, undefined));
+	});
+
+	test('returns null on truncated URL with non-ASCII characters', () => {
+		// Real scenario from FE-935: "Aktiebolaget Allt i Plåt" URL-encoded
+		// Full: [{"id":"supplier","label":"Aktiebolaget Allt i Plåt"}]
+		// Truncated mid-escape-sequence: ...Pl%C3%A
+		const full = '[{"id":"supplier","label":"Aktiebolaget Allt i Pl%C3%A5t"}]';
+		const truncated = full.slice(0, -2); // cuts off "t", leaving "Pl%C3%A"
+		const result = instance.deserializeFilter({}, truncated);
+		assert.isNull(result);
+	});
+
+	test('returns null on truncated JSON', () => {
+		const truncated = encodeURIComponent(
+			'[{ "id": "item1", "label": "Item ',
+		);
+		const result = instance.deserializeFilter({}, truncated);
+		assert.isNull(result);
+	});
+
+	test('returns null on invalid JSON', () => {
+		const invalid = encodeURIComponent('not valid json');
+		const result = instance.deserializeFilter({}, invalid);
+		assert.isNull(result);
+	});
+});

--- a/test/range-date.test.js
+++ b/test/range-date.test.js
@@ -114,6 +114,10 @@ suite('date', () => {
 		assert.equal(column.constructor.name, 'OmnitableColumnDate');
 	});
 
+	test('deserializeFilter returns null for non-string filters', () => {
+		assert.isNull(column.deserializeFilter({}, { min: '2015-03-18' }));
+	});
+
 	test('changing filter updates _filterInput', async () => {
 		const min = toDate('2015-03-18'),
 			max = toDate('2023-03-21');


### PR DESCRIPTION
## Summary
- fix FE-935 by making list filter deserialization resilient to malformed or truncated hash values
- sanitize deserialize error logging to avoid logging raw filter payloads, while preserving useful error metadata
- harden range-based column deserializers (amount/date/datetime/number/time) to safely return null for non-string filters
- harden base column deserialization to return null instead of throwing on malformed percent-escape sequences
- add regression tests for malformed percent-escape sequences and non-string filter deserialization

## Testing
- npm test -- --files test/list.test.js
- npm test -- --files test/range-date.test.js
- npm test -- --files test/basic.test.js

Note: targeted single-file runs can report global coverage-threshold failures even when all tests in the file pass.