### PR TITLE
feat: support inline mode for auto-height omnitable (no internal scrolling)

### DIFF
--- a/.changeset/hungry-pets-thank.md
+++ b/.changeset/hungry-pets-thank.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-omnitable': minor
+---
+
+Add `inline` attribute for auto-height mode — the omnitable expands to show all rows without internal scrolling, letting the page scroll instead.

--- a/src/cosmoz-omnitable-styles.ts
+++ b/src/cosmoz-omnitable-styles.ts
@@ -611,4 +611,16 @@ export default css`
 		border-color: rgba(0, 0, 0, 0.2);
 		border-top-color: #000;
 	}
+
+	:host([inline]) {
+		overflow: visible;
+	}
+	:host([inline]) .tableContent {
+		overflow-y: visible;
+		flex: none;
+	}
+	:host([inline]) .tableContent-scroller {
+		overflow: visible;
+		flex-basis: auto;
+	}
 `;

--- a/src/cosmoz-omnitable.js
+++ b/src/cosmoz-omnitable.js
@@ -61,6 +61,7 @@ customElements.define(
 			'disabled-filtering',
 			'loading',
 			'mini-breakpoint',
+			'inline',
 		],
 	}),
 );

--- a/src/grouped-list/cosmoz-grouped-list.ts
+++ b/src/grouped-list/cosmoz-grouped-list.ts
@@ -1,9 +1,9 @@
+import { component } from '@pionjs/pion';
 import {
 	renderCosmozGroupedList,
 	useCosmozGroupedList,
 	type UseCosmozGroupedListHost,
 } from './use-cosmoz-grouped-list';
-import { component } from '@pionjs/pion';
 
 const CosmozGroupedList = (host: UseCosmozGroupedListHost) =>
 	renderCosmozGroupedList(useCosmozGroupedList(host));

--- a/src/lib/use-list.js
+++ b/src/lib/use-list.js
@@ -1,6 +1,6 @@
+import { isEmpty } from '@neovici/cosmoz-utils/template';
 import { html, useCallback, useEffect, useMemo, useRef } from '@pionjs/pion';
 import { when } from 'lit-html/directives/when.js';
-import { isEmpty } from '@neovici/cosmoz-utils/template';
 import { indexSymbol } from './utils';
 import { onItemChange as _onItemChange } from './utils-data';
 

--- a/stories/cosmoz-omnitable.stories.js
+++ b/stories/cosmoz-omnitable.stories.js
@@ -132,3 +132,104 @@ export const DisabledFiltering = Template.bind({});
 DisabledFiltering.args = {
 	disabledFiltering: true,
 };
+
+const InlineTemplate = (args) => {
+	return html`
+		<style>
+			cosmoz-omnitable-item-row {
+				border-bottom: 1px solid #e1e2e5;
+			}
+			cosmoz-omnitable-header-row {
+				border-bottom: 1px solid #e1e2e5;
+			}
+		</style>
+		<cosmoz-omnitable
+			.data=${demoData}
+			?inline=${true}
+			hash-param=${args.hashParam || ''}
+			sort-on=${args.sortOn || ''}
+			group-on=${args.groupOn || ''}
+			?descending=${args.descending}
+			?group-on-descending=${args.groupOnDescending}
+			?hide-select-all=${args.hideSelectAll}
+			settings-id=${args.settingsId || ''}
+			?no-local=${args.noLocal}
+			?no-local-sort=${args.noLocalSort}
+			?no-local-filter=${args.noLocalFilter}
+			?disabled-filtering=${args.disabledFiltering}
+			?loading=${args.loading}
+			mini-breakpoint=${args.miniBreakpoint || '768px'}
+		>
+			<cosmoz-omnitable-column
+				name="company"
+				title="Company"
+				value-path="company"
+				sort-on="company"
+				group-on="company"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="age"
+				title="Age"
+				value-path="age"
+				sort-on="age"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="eyeColor"
+				title="Eye Color"
+				value-path="eyeColor"
+				sort-on="eyeColor"
+				group-on="eyeColor"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="balance"
+				title="Balance"
+				value-path="balance"
+				sort-on="balance"
+			>
+			</cosmoz-omnitable-column>
+
+			<cosmoz-omnitable-column
+				name="registered"
+				title="Registered"
+				value-path="registered"
+				sort-on="registered"
+			>
+			</cosmoz-omnitable-column>
+
+			<div slot="actions">
+				<button>Export</button>
+				<button>Settings</button>
+			</div>
+		</cosmoz-omnitable>
+	`;
+};
+
+export const Inline = InlineTemplate.bind({});
+Inline.args = {};
+Inline.parameters = {
+	docs: {
+		description: {
+			story:
+				'Inline mode: the omnitable expands to show all rows without internal scrolling. The page itself scrolls instead.',
+		},
+	},
+};
+
+export const InlineDisabledFiltering = InlineTemplate.bind({});
+InlineDisabledFiltering.args = {
+	disabledFiltering: true,
+};
+InlineDisabledFiltering.parameters = {
+	docs: {
+		description: {
+			story:
+				'Inline mode with disabled filtering, suitable for search results where all rows are shown without internal scrolling.',
+		},
+	},
+};


### PR DESCRIPTION
## Summary

Adds an `inline` attribute to `cosmoz-omnitable` that enables auto-height mode — the omnitable expands to show all rows without internal scrolling, letting the page scroll instead.

Closes FE-954

## How it works

When `<cosmoz-omnitable inline>` is active:

- `:host([inline])` → `overflow: visible` (remove fixed-height constraint)
- `:host([inline]) .tableContent` → `overflow-y: visible; flex: none` (no internal scrolling)
- `:host([inline]) .tableContent-scroller` → `overflow: visible; flex-basis: auto` (no internal scrolling)

With all parents having `overflow: visible`, lit-virtualizer's default (non-scroller) mode naturally detects no clipping ancestors and falls back to the browser viewport for visibility calculations. The virtualizer sets `minHeight` on `cosmoz-grouped-list` to the total content height, making it expand to show all rows while still virtualizing rendering.