### PR TITLE
chore: bump beta version to 18.11.0-beta.0

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,7 +2,7 @@
   "mode": "pre",
   "tag": "beta",
   "initialVersions": {
-    "@neovici/cosmoz-omnitable": "18.9.0"
+    "@neovici/cosmoz-omnitable": "18.11.0"
   },
   "changesets": [
     "beta-variant-inline",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neovici/cosmoz-omnitable",
-	"version": "18.10.0-beta.3",
+	"version": "18.11.0-beta.0",
 	"description": "[![Build Status](https://travis-ci.org/Neovici/cosmoz-omnitable.svg?branch=master)](https://travis-ci.org/Neovici/cosmoz-omnitable)",
 	"keywords": [
 		"web-components"


### PR DESCRIPTION
The previous version (18.10.0-beta.3) had lower semver precedence than the stable 18.10.0 release, causing npm to resolve `^18.10.0-beta.3` to 18.10.0 instead of the intended beta.

This manual version bump ensures the beta release has higher precedence than the latest stable.

Changes:
- Bump package version from 18.10.0-beta.3 to 18.11.0-beta.0
- Update pre.json initialVersions from 18.9.0 to 18.11.0 so future changesets compute versions correctly

Note: Adding a changeset would result in 18.10.0-beta.4 (still below 18.10.0) because `semver.inc('18.10.0-beta.3', 'minor')` returns '18.10.0' (strips prerelease). Manual version bump is the only way to get above 18.10.0 stable.