### PR TITLE
fix: rebase beta prerelease cycle onto 18.10.0 stable

### DIFF
--- a/.changeset/beta-features-minor.md
+++ b/.changeset/beta-features-minor.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-omnitable': minor
+---
+
+Add variant inline for disabled filter inputs, smooth transitions, skeleton padding fixes, and inline mode for auto-height omnitable

--- a/.changeset/beta-variant-inline.md
+++ b/.changeset/beta-variant-inline.md
@@ -1,5 +1,0 @@
----
-'@neovici/cosmoz-omnitable': minor
----
-
-Add variant inline for disabled filter inputs and smooth transitions for mini mode

--- a/.changeset/chubby-points-roll.md
+++ b/.changeset/chubby-points-roll.md
@@ -1,5 +1,0 @@
----
-'@neovici/cosmoz-omnitable': patch
----
-
-Adjust skeleton padding, header borders and mini row shadow

--- a/.changeset/hungry-pets-thank.md
+++ b/.changeset/hungry-pets-thank.md
@@ -1,5 +1,0 @@
----
-'@neovici/cosmoz-omnitable': minor
----
-
-Add `inline` attribute for auto-height mode — the omnitable expands to show all rows without internal scrolling, letting the page scroll instead.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,13 +2,7 @@
   "mode": "pre",
   "tag": "beta",
   "initialVersions": {
-    "@neovici/cosmoz-omnitable": "18.11.0"
+    "@neovici/cosmoz-omnitable": "18.10.0"
   },
-  "changesets": [
-    "beta-variant-inline",
-    "chubby-points-roll",
-    "hungry-pets-thank",
-    "ripe-lights-help",
-    "shaky-ants-fix"
-  ]
+  "changesets": []
 }

--- a/.changeset/ripe-lights-help.md
+++ b/.changeset/ripe-lights-help.md
@@ -1,5 +1,0 @@
----
-'@neovici/cosmoz-omnitable': patch
----
-
-Set white to table content background and mini mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 18.10.0-beta.3
-
-### Minor Changes
-
-- 6a4454a: Add `inline` attribute for auto-height mode — the omnitable expands to show all rows without internal scrolling, letting the page scroll instead.
-
 ## 18.10.0
 
 ### Minor Changes


### PR DESCRIPTION
## Why
Beta was at `18.10.0-beta.2` but `18.10.0` stable already exists. Per SemVer, `18.10.0-beta.2 < 18.10.0`, so npm wouldn't resolve the beta correctly. Root cause: `pre.json` had `initialVersions: 18.9.0`, capping all future bumps at `18.10.0-beta.X`.

A manual bump to `18.11.0-beta.0` was done in #1063, but `pre.json` still had stale changeset references and `initialVersions: 18.11.0`.

## What changed
- Exit/re-enter changeset prerelease mode → `initialVersions` reset to `18.10.0` (last stable)
- Removed 4 stale changeset files (already released or consumed)
- Added consolidated minor changeset for beta-only features
- Removed invalid `18.10.0-beta.3` changelog entry

## Result
CI will run `changeset version` → `18.12.0-beta.0` (minor + patch bumps from `18.11.0-beta.0`). Future beta bumps will work correctly.