### PR TITLE
chore: convert use-dom-columns to TypeScript

### DIFF
--- a/src/lib/save-as-csv-action.ts
+++ b/src/lib/save-as-csv-action.ts
@@ -1,12 +1,9 @@
 import { saveAs } from 'file-saver-es';
-import { Column, Item } from './types';
+import type { Column, Item } from './types';
 
 export interface CsvColumn extends Column {
 	title: string;
-	getString: (
-		column: CsvColumn,
-		item: Item,
-	) => string | number | null | undefined;
+	getString: (column: Column, item: Item) => string | number | null | undefined;
 }
 
 const makeCsvField = (str: string): string => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,12 +20,14 @@ export interface Column {
 	priority?: number;
 	flex?: string;
 	width?: string;
-	sortOn?: boolean;
-	groupOn?: boolean;
+	sortOn?: GetPath;
+	groupOn?: GetPath;
 	noSort?: boolean;
 	editable?: boolean;
 	mini?: number | null;
 	hidden?: boolean;
+	disabled?: boolean;
+	disabledFiltering?: boolean;
 	cellClass?: string;
 	headerCellClass?: string;
 	preferredDropdownHorizontalAlign?: string;
@@ -46,9 +48,38 @@ export interface Column {
 		setState: (s: unknown) => void,
 	) => unknown;
 	cellTitleFn?: (column: Column, item: Item) => string;
+	headerTitleFn?: (column: Column) => string | undefined;
 	toXlsxValue?: (column: Column, item: Item) => unknown;
+	getString?: (column: Column, item: Item) => unknown;
 	getComparableValue?: (column: Column, item: Item) => unknown;
 	serializeFilter?: (column: Column, filter: unknown) => unknown;
+	deserializeFilter?: (column: Column, filter: unknown) => unknown;
+	getFilterFn?: (
+		column: Column,
+		filter: unknown,
+	) => ((item: Item) => boolean) | undefined;
+	computeSource?: (column: Column, data: unknown) => unknown;
+	values?: unknown[];
+	noLocalFilter?: boolean;
+	loading?: boolean;
+	externalValues?: unknown;
+	trueLabel?: string;
+	falseLabel?: string;
+	valueProperty?: string;
+	textProperty?: string;
+	emptyLabel?: string;
+	emptyValue?: unknown;
+	emptyProperty?: string;
+	min?: number;
+	max?: number;
+	autoupdate?: boolean;
+	maximumFractionDigits?: number | null;
+	minimumFractionDigits?: number | null;
+	currency?: string;
+	rates?: Rates;
+	autodetect?: boolean;
+	ownerTree?: unknown;
+	keyProperty?: string;
 	[key: symbol]: unknown;
 }
 

--- a/src/lib/use-dom-columns.ts
+++ b/src/lib/use-dom-columns.ts
@@ -1,8 +1,30 @@
 import { memooize } from '@neovici/cosmoz-utils/memoize';
 import { useLayoutEffect, useState } from '@pionjs/pion';
+import type { Column, GetPath } from './types';
 
-const columnSymbol = Symbol('column');
-const verifyColumnSetup = (columns) => {
+export const columnSymbol: unique symbol = Symbol('column');
+
+export interface DomColumn
+	extends HTMLElement, Omit<Column, 'title' | 'hidden'> {
+	isOmnitableColumn: boolean;
+	hidden: boolean;
+	disabled?: boolean;
+	disabledFiltering?: boolean;
+	computeSource: (column: Column, data: unknown) => unknown;
+	getConfig?: (column: DomColumn) => Record<string, unknown>;
+}
+
+export interface NormalizedColumn extends Column {
+	name: string;
+	valuePath: GetPath;
+	groupOn: GetPath;
+	sortOn: GetPath;
+	disabledFiltering?: boolean;
+	source: (column: Column, data: unknown) => unknown;
+	[columnSymbol]: DomColumn;
+}
+
+const verifyColumnSetup = (columns: DomColumn[]): boolean => {
 	let ok = true;
 	const columnNames = columns.map((c) => c.name);
 	// Check if column names are set
@@ -34,11 +56,14 @@ const verifyColumnSetup = (columns) => {
 	return ok;
 };
 
-const normalizeColumn = (column, disabledFiltering) => {
-	const valuePath = column.valuePath ?? column.name;
+const normalizeColumn = (
+	column: DomColumn,
+	disabledFiltering?: boolean,
+): NormalizedColumn => {
+	const valuePath: GetPath = column.valuePath ?? column.name!;
 
 	return {
-		name: column.name,
+		name: column.name!,
 		title: column.title,
 
 		valuePath,
@@ -119,38 +144,52 @@ const normalizeColumn = (column, disabledFiltering) => {
 	};
 };
 
-const isVisibleColumn = (child) => child.isOmnitableColumn && !child.hidden;
+const isVisibleColumn = (child: Node): child is DomColumn =>
+	(child as DomColumn).isOmnitableColumn && !(child as DomColumn).hidden;
 
-const collectDomColumns = (assignedElements) => {
+const collectDomColumns = (assignedElements: Node[]): DomColumn[] => {
 	const domColumns = assignedElements.filter(isVisibleColumn);
 
 	if (!verifyColumnSetup(domColumns)) return [];
 	return domColumns;
 };
 
-const normalizeColumns = (domColumns, enabledColumns, disabledFiltering) => {
+const normalizeColumns = (
+	domColumns: DomColumn[],
+	enabledColumns: string[] | undefined,
+	disabledFiltering?: boolean,
+): NormalizedColumn[] => {
 	const columns = Array.isArray(enabledColumns)
-		? domColumns.filter((column) => enabledColumns.includes(column.name))
+		? domColumns.filter((column) => enabledColumns.includes(column.name!))
 		: domColumns.filter((column) => !column.disabled);
 
 	return columns.map((col) => normalizeColumn(col, disabledFiltering));
 };
 
-export const useDOMColumns = (host, { enabledColumns, disabledFiltering }) => {
-	const [columns, setColumns] = useState([]);
+interface UseDOMColumnsParams {
+	enabledColumns?: string[];
+	disabledFiltering?: boolean;
+}
+
+export const useDOMColumns = (
+	host: HTMLElement,
+	{ enabledColumns, disabledFiltering }: UseDOMColumnsParams,
+): NormalizedColumn[] => {
+	const [columns, setColumns] = useState<NormalizedColumn[]>([]);
 
 	useLayoutEffect(() => {
-		let sched;
-		let previous = [];
-		const slot = host.shadowRoot.querySelector('#columnsSlot');
-		const update = (force) => () => {
+		let sched: number | undefined;
+		let previous: Node[] = [];
+		const slot =
+			host.shadowRoot!.querySelector<HTMLSlotElement>('#columnsSlot')!;
+		const update = (force?: boolean) => () => {
 			const current = slot.assignedNodes({ flatten: true });
 
 			if (!force) {
 				const added = current.filter((n) => !previous.includes(n));
 				const removed = previous.filter((n) => !current.includes(n));
 				const columnsChanged = [...added, ...removed].some(
-					(element) => element.isOmnitableColumn,
+					(element) => (element as Partial<DomColumn>).isOmnitableColumn,
 				);
 
 				previous = current;
@@ -169,8 +208,8 @@ export const useDOMColumns = (host, { enabledColumns, disabledFiltering }) => {
 			);
 		};
 
-		const scheduleUpdate = (ev) => {
-			cancelAnimationFrame(sched);
+		const scheduleUpdate = (ev?: Event) => {
+			cancelAnimationFrame(sched!);
 			sched = requestAnimationFrame(
 				update(ev?.type === 'cosmoz-column-prop-changed'),
 			);
@@ -184,11 +223,9 @@ export const useDOMColumns = (host, { enabledColumns, disabledFiltering }) => {
 		return () => {
 			slot.removeEventListener('slotchange', scheduleUpdate);
 			host.removeEventListener('cosmoz-column-prop-changed', scheduleUpdate);
-			cancelAnimationFrame(sched);
+			cancelAnimationFrame(sched!);
 		};
 	}, [enabledColumns, disabledFiltering]);
 
 	return columns;
 };
-
-export { columnSymbol };


### PR DESCRIPTION
## Summary
- Convert `src/lib/use-dom-columns.js` → `.ts` with full type annotations
- Zero runtime changes — type-only conversion

## Changes

### `src/lib/use-dom-columns.ts`
- `columnSymbol` typed as `unique symbol`
- Exported `DomColumn` interface (extends `HTMLElement & Omit<Column, 'title' | 'hidden'>`)
- Exported `NormalizedColumn` interface (extends `Column` with required `name`/`valuePath`/`groupOn`/`sortOn`/`source` + `[columnSymbol]: DomColumn`)
- All functions typed: `verifyColumnSetup`, `normalizeColumn`, `isVisibleColumn` (type predicate), `collectDomColumns`, `normalizeColumns`, `useDOMColumns`
- Non-null assertions (`!`) for `column.name` (guaranteed by `verifyColumnSetup`), `shadowRoot`, `slot`, `sched`

### `src/lib/types.ts`
- Fixed `sortOn`/`groupOn` from `boolean` to `GetPath` (pre-existing type bug — `columnMixin` defines them as `type: String`, used as paths downstream)
- Expanded `Column` interface with missing fields: `disabled`, `disabledFiltering`, `headerTitleFn`, `getString`, `deserializeFilter`, `getFilterFn`, `computeSource`, `values`, `noLocalFilter`, `loading`, `externalValues`, `trueLabel`, `falseLabel`, `valueProperty`, `textProperty`, `emptyLabel`, `emptyValue`, `emptyProperty`, `min`, `max`, `autoupdate`, `maximumFractionDigits`, `minimumFractionDigits`, `currency`, `rates`, `autodetect`, `ownerTree`, `keyProperty`
- `maximumFractionDigits`/`minimumFractionDigits` typed as `number | null` (compatible with `NumberColumn`)

### `src/lib/save-as-csv-action.ts`
- `CsvColumn.getString` param changed from `CsvColumn` to `Column` (fixes contravariance with `Column.getString`)
- `import` → `import type` for type-only imports

## Verification
- `tsc --noEmit` — 0 errors ✅
- `npm test` — 317 tests pass, 87.6% coverage ✅
- `npm run lint` — 0 errors ✅

Part of the strategic TypeScript migration (Tier 1b). Previous: #1062 (Tier 1a, merged).