### PR TITLE
chore: convert item-expand and item-row to TypeScript

### DIFF
--- a/src/cosmoz-omnitable-item-expand.ts
+++ b/src/cosmoz-omnitable-item-expand.ts
@@ -2,8 +2,23 @@ import { component } from '@pionjs/pion';
 import { html } from 'lit-html';
 import { map } from 'lit-html/directives/map.js';
 import './cosmoz-omnitable-item-expand-line';
+import type { Column, Item } from './lib/types';
 
-const ItemExpand = ({ columns, item, selected, expanded, groupOnColumn }) => {
+type ItemExpandProps = {
+	columns: Column[];
+	item: Item;
+	selected: boolean;
+	expanded: boolean;
+	groupOnColumn?: Column;
+};
+
+const ItemExpand = ({
+	columns,
+	item,
+	selected,
+	expanded,
+	groupOnColumn,
+}: ItemExpandProps) => {
 	return map(
 		columns,
 		(column) =>
@@ -11,7 +26,7 @@ const ItemExpand = ({ columns, item, selected, expanded, groupOnColumn }) => {
 				.column=${column}
 				?hidden=${column === groupOnColumn}
 				exportparts="item-expand-label, item-expand-value"
-				>${column.renderCell(column, {
+				>${column.renderCell!(column, {
 					item,
 					selected,
 					expanded,

--- a/src/cosmoz-omnitable-item-row.ts
+++ b/src/cosmoz-omnitable-item-row.ts
@@ -1,10 +1,25 @@
 import { component, html } from '@pionjs/pion';
 import { repeat } from 'lit-html/directives/repeat.js';
+import type { Column, Item, ItemRenderData } from './lib/types';
 
-const renderCell = (column, data, onItemChange) =>
+type ItemRowProps = {
+	columns: Column[];
+	groupOnColumn?: Column;
+	item: Item;
+	index: number;
+	selected: boolean;
+	expanded: boolean;
+	onItemChange: (column: Column, item: Item) => (value: unknown) => void;
+};
+
+const renderCell = (
+	column: Column,
+	data: ItemRenderData,
+	onItemChange: (column: Column, item: Item) => (value: unknown) => void,
+) =>
 	column.editable
-		? column.renderEditCell(column, data, onItemChange(column, data.item))
-		: column.renderCell(column, data);
+		? column.renderEditCell!(column, data, onItemChange(column, data.item))
+		: column.renderCell!(column, data);
 
 const ItemRow = ({
 	columns,
@@ -14,7 +29,7 @@ const ItemRow = ({
 	selected,
 	expanded,
 	onItemChange,
-}) =>
+}: ItemRowProps) =>
 	repeat(
 		columns,
 		(column) => column.name,
@@ -24,7 +39,7 @@ const ItemRow = ({
 				part="cell itemRow-cell cell-${column.name} itemRow-cell-${column.name}"
 				?hidden="${column === groupOnColumn}"
 				?editable="${column.editable}"
-				title="${column.cellTitleFn(column, item)}"
+				title="${column.cellTitleFn!(column, item)}"
 				name="${column.name}"
 			>
 				${renderCell(column, { item, index, selected, expanded }, onItemChange)}


### PR DESCRIPTION
## Summary
- Convert `cosmoz-omnitable-item-expand.js` → `.ts` (28 lines)
- Convert `cosmoz-omnitable-item-row.js` → `.ts` (38 lines)
- Zero runtime changes — type-only conversion

## Changes

### `src/cosmoz-omnitable-item-expand.ts`
- `import type { Column, Item }` from `./lib/types`
- `ItemExpandProps` type with `columns: Column[]`, `item: Item`, `selected: boolean`, `expanded: boolean`, `groupOnColumn?: Column`
- `!` assertion on `column.renderCell` (optional on `Column`, always defined at runtime via `columnMixin`)

### `src/cosmoz-omnitable-item-row.ts`
- `import type { Column, Item, ItemRenderData }` from `./lib/types`
- `ItemRowProps` type with `columns: Column[]`, `groupOnColumn?: Column`, `item: Item`, `index: number`, `selected: boolean`, `expanded: boolean`, `onItemChange: (column: Column, item: Item) => (value: unknown) => void`
- `renderCell` helper typed with `Column`, `ItemRenderData`, curried `onItemChange`
- `!` assertions on `column.renderEditCell`, `column.renderCell`, `column.cellTitleFn` (optional on `Column`, always defined at runtime)

## Verification
- `tsc --noEmit` — 0 errors ✅
- `npm test` — 317 tests pass ✅
- `npm run lint` — 0 errors ✅
- esbuild compile diff — byte-identical (zero runtime changes) ✅

Part of the strategic TypeScript migration (Tier 1c). Previous: #1067 (use-dom-columns, merged).