### PR TITLE
chore(settings): migrate omnitable settings to ts

### DIFF
--- a/src/lib/settings/cosmoz-omnitable-settings.ts
+++ b/src/lib/settings/cosmoz-omnitable-settings.ts
@@ -6,13 +6,67 @@ import { component, html } from '@pionjs/pion';
 import { t } from 'i18next';
 import { when } from 'lit-html/directives/when.js';
 import { arrow, close, pull } from '../icons';
+import type { ColumnConfigInput } from '../layout';
 import { group, sort } from './cosmoz-omnitable-sort-group';
 import style, { dropdown as dropdownStyle } from './style.css';
 import useSettingsUi from './use-settings-ui';
 
+interface SettingsUiConfig {
+	settings: { columns: ColumnConfigInput[] };
+	setSettings: (
+		settings:
+			| { columns?: ColumnConfigInput[] }
+			| ((settings: { columns?: ColumnConfigInput[] }) => {
+					columns?: ColumnConfigInput[];
+			  }),
+	) => void;
+	collapsed?: { name?: string }[];
+	requestTween?: () => void;
+}
+
+interface SettingsUiConfigExtended extends SettingsUiConfig {
+	filters: Record<string, { filter?: unknown }>;
+	collapsed?: { name?: string }[];
+	badge?: boolean;
+	settingsId?: string;
+	onSave: () => void;
+	onReset: () => void;
+	hasChanges: boolean;
+	opened: Record<string, boolean>;
+	setOpened: (
+		opened:
+			| Record<string, boolean>
+			| ((prev: Record<string, boolean>) => Record<string, boolean>),
+	) => void;
+	requestTween?: () => void;
+}
+
+interface RenderItemParams {
+	onDragStart: (e: DragEvent) => void;
+	onDragEnter: (e: DragEvent) => void;
+	onDragOver: (e: DragEvent) => void;
+	onDragLeave: (e: DragEvent) => void;
+	onDrop: (e: DragEvent) => void;
+	onDown: (e: MouseEvent) => void;
+	onToggle: (e: Event) => void;
+	collapsed?: { name?: string }[];
+	filters: Record<string, { filter?: unknown }>;
+}
+
+interface SettingsProps {
+	config: SettingsUiConfigExtended;
+	newLayout?: boolean;
+}
+
 const middleware = [
 	size({
-		apply({ availableHeight, elements }) {
+		apply({
+			availableHeight,
+			elements,
+		}: {
+			availableHeight: number;
+			elements: { floating: HTMLElement };
+		}) {
 			Object.assign(elements.floating.style, {
 				maxHeight: `${Math.max(0, availableHeight)}px`,
 			});
@@ -32,8 +86,8 @@ const renderItem =
 		onToggle,
 		collapsed,
 		filters,
-	}) =>
-	(column, i) => {
+	}: RenderItemParams) =>
+	(column: ColumnConfigInput, i: number) => {
 		const indeterminate = !!collapsed?.find((c) => c.name === column.name),
 			checked = !column.disabled && !indeterminate;
 		return html` <div
@@ -61,7 +115,10 @@ const renderItem =
 		</div>`;
 	};
 
-const SettingsUI = (host) => {
+const SettingsUI = (
+	host: HTMLElement & { config: SettingsUiConfigExtended },
+) => {
+	const settingsUi = { ...useSettingsUi(host), ...host.config };
 	const {
 		settings,
 		settingsId,
@@ -71,13 +128,14 @@ const SettingsUI = (host) => {
 		opened,
 		setOpened,
 		...thru
-	} = useSettingsUi(host);
+	} = settingsUi;
 	return html` <div class="headline">
 			${t('Sort and filter')}
 			<button
 				class="close"
-				@click=${(e) => {
-					const tg = e.currentTarget;
+				@click=${(e: Event) => {
+					const tg =
+						e.currentTarget instanceof HTMLElement ? e.currentTarget : null;
 					tg?.focus();
 					tg?.blur();
 				}}
@@ -90,7 +148,11 @@ const SettingsUI = (host) => {
 			<div
 				class="heading"
 				?data-opened=${opened.columns}
-				@click=${() => setOpened((c) => ({ ...c, columns: !c.columns }))}
+				@click=${() =>
+					setOpened((c: Record<string, boolean>) => ({
+						...c,
+						columns: !c.columns,
+					}))}
 				part="columns columns-heading"
 			>
 				${t('Columns')} ${arrow}
@@ -105,7 +167,8 @@ const SettingsUI = (host) => {
 			<div
 				class="heading"
 				?data-opened=${opened.sort}
-				@click=${() => setOpened((c) => ({ ...c, sort: !c.sort }))}
+				@click=${() =>
+					setOpened((c: Record<string, boolean>) => ({ ...c, sort: !c.sort }))}
 			>
 				${t('Sort on')} ${arrow}
 			</div>
@@ -114,7 +177,11 @@ const SettingsUI = (host) => {
 			<div
 				class="heading"
 				?data-opened=${opened.group}
-				@click=${() => setOpened((c) => ({ ...c, group: !c.group }))}
+				@click=${() =>
+					setOpened((c: Record<string, boolean>) => ({
+						...c,
+						group: !c.group,
+					}))}
 				part="groups groups-heading"
 			>
 				${t('Group on')} ${arrow}
@@ -147,7 +214,7 @@ customElements.define(
 	component(SettingsUI, { styleSheets: [sheet(style)] }),
 );
 
-const Settings = ({ config, newLayout }) => html`
+const Settings = ({ config, newLayout }: SettingsProps) => html`
 	<cosmoz-dropdown
 		.placement="${newLayout ? 'bottom-start' : 'bottom-end'}"
 		.middleware="${middleware}"

--- a/src/lib/settings/cosmoz-omnitable-settings.ts
+++ b/src/lib/settings/cosmoz-omnitable-settings.ts
@@ -9,24 +9,10 @@ import { arrow, close, pull } from '../icons';
 import type { ColumnConfigInput } from '../layout';
 import { group, sort } from './cosmoz-omnitable-sort-group';
 import style, { dropdown as dropdownStyle } from './style.css';
-import useSettingsUi from './use-settings-ui';
-
-interface SettingsUiConfig {
-	settings: { columns: ColumnConfigInput[] };
-	setSettings: (
-		settings:
-			| { columns?: ColumnConfigInput[] }
-			| ((settings: { columns?: ColumnConfigInput[] }) => {
-					columns?: ColumnConfigInput[];
-			  }),
-	) => void;
-	collapsed?: { name?: string }[];
-	requestTween?: () => void;
-}
+import useSettingsUi, { type SettingsUiConfig } from './use-settings-ui';
 
 interface SettingsUiConfigExtended extends SettingsUiConfig {
 	filters: Record<string, { filter?: unknown }>;
-	collapsed?: { name?: string }[];
 	badge?: boolean;
 	settingsId?: string;
 	onSave: () => void;
@@ -38,7 +24,6 @@ interface SettingsUiConfigExtended extends SettingsUiConfig {
 			| Record<string, boolean>
 			| ((prev: Record<string, boolean>) => Record<string, boolean>),
 	) => void;
-	requestTween?: () => void;
 }
 
 interface RenderItemParams {
@@ -118,7 +103,6 @@ const renderItem =
 const SettingsUI = (
 	host: HTMLElement & { config: SettingsUiConfigExtended },
 ) => {
-	const settingsUi = { ...useSettingsUi(host), ...host.config };
 	const {
 		settings,
 		settingsId,
@@ -128,7 +112,7 @@ const SettingsUI = (
 		opened,
 		setOpened,
 		...thru
-	} = settingsUi;
+	} = useSettingsUi(host);
 	return html` <div class="headline">
 			${t('Sort and filter')}
 			<button

--- a/src/lib/settings/use-settings-ui.ts
+++ b/src/lib/settings/use-settings-ui.ts
@@ -2,7 +2,7 @@ import { useMeta } from '@neovici/cosmoz-utils/hooks/use-meta';
 import { useCallback } from '@pionjs/pion';
 import type { ColumnConfigInput } from '../layout';
 
-interface SettingsUiConfig {
+export interface SettingsUiConfig {
 	settings: { columns: ColumnConfigInput[] };
 	setSettings: (
 		settings:
@@ -23,16 +23,22 @@ interface SettingsUiMeta {
 	handle?: HTMLElement | null;
 }
 
-interface UseSettingsUiHost {
-	config: SettingsUiConfig;
-}
-
 const parseIndex = (str?: string | null) => {
 	const idx = parseInt(str ?? '', 10);
 	return isFinite(idx) ? idx : undefined;
 };
 
-export default (host: UseSettingsUiHost) => {
+export default <C extends SettingsUiConfig>(host: {
+	config: C;
+}): C & {
+	onDown: (e: MouseEvent) => void;
+	onDragStart: (e: DragEvent) => void;
+	onDragEnter: (e: DragEvent) => void;
+	onDragOver: (e: DragEvent) => void;
+	onDragLeave: (e: DragEvent) => void;
+	onDrop: (e: DragEvent) => void;
+	onToggle: (e: Event) => void;
+} => {
 	const { config } = host,
 		{ settings, setSettings, collapsed, requestTween } = config,
 		meta = useMeta<SettingsUiMeta>({


### PR DESCRIPTION
Refs FE-1008

Summary
- migrate src/lib/settings/cosmoz-omnitable-settings.js to TypeScript
- keep the settings component behavior unchanged

Verification
- npx tsc --noEmit
