### PR TITLE
fix: rename range-input horizontalAlign to align, clean up cellClass

### DIFF
--- a/.changeset/fix-range-input-alignment.md
+++ b/.changeset/fix-range-input-alignment.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-omnitable': patch
+---
+
+Rename the range-input's `horizontalAlign` property to `align` for consistency with the column API. Remove redundant `align-right` from number/amount `cellClass` defaults (alignment is now handled by the `align` property + `.cell[align]` CSS rules). Mark `.align-left`/`.align-right` CSS classes as `@deprecated` (kept for backward compat with consumers using `cellClass`).

--- a/src/cosmoz-omnitable-column-amount.js
+++ b/src/cosmoz-omnitable-column-amount.js
@@ -36,7 +36,7 @@ class OmnitableColumnAmount extends columnMixin(PolymerElement) {
 			autodetect: { type: Boolean, value: false, notify: true },
 			rates: { type: Object, notify: true },
 			width: { type: String, value: '70px' },
-			cellClass: { type: String, value: 'amount-cell align-right' },
+			cellClass: { type: String, value: 'amount-cell' },
 			headerCellClass: { type: String, value: 'amount-header-cell' },
 			align: { type: String, value: 'right' },
 		};
@@ -147,7 +147,7 @@ class OmnitableColumnAmount extends columnMixin(PolymerElement) {
 			.currency=${currency}
 			.autoupdate=${autoupdate}
 			.autodetect=${autodetect}
-			.horizontalAlign=${headerAlign ?? align}
+			.align=${headerAlign ?? align}
 			@filter-changed=${({ detail: { value } }) =>
 				setState((state) => ({ ...state, filter: value }))}
 			@header-focused-changed=${({ detail: { value } }) =>

--- a/src/cosmoz-omnitable-column-date.js
+++ b/src/cosmoz-omnitable-column-date.js
@@ -115,7 +115,7 @@ class OmnitableColumnDate extends columnMixin(PolymerElement) {
 			.max=${max}
 			.limits=${limits}
 			.locale=${locale}
-			.horizontalAlign=${headerAlign ?? align}
+			.align=${headerAlign ?? align}
 			@filter-changed=${({ detail: { value } }) =>
 				setState((state) => ({ ...state, filter: value }))}
 			@header-focused-changed=${({ detail: { value } }) =>

--- a/src/cosmoz-omnitable-column-datetime.js
+++ b/src/cosmoz-omnitable-column-datetime.js
@@ -136,7 +136,7 @@ class OmnitableColumnDatetime extends columnMixin(PolymerElement) {
 			.limits=${limits}
 			.locale=${locale}
 			.filterStep=${filterStep}
-			.horizontalAlign=${headerAlign ?? align}
+			.align=${headerAlign ?? align}
 			@filter-changed=${({ detail: { value } }) =>
 				setState((state) => ({ ...state, filter: value }))}
 			@header-focused-changed=${({ detail: { value } }) =>

--- a/src/cosmoz-omnitable-column-number.js
+++ b/src/cosmoz-omnitable-column-number.js
@@ -31,7 +31,7 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 			limits: { type: Function },
 			locale: { type: String, value: null, notify: true },
 			autoupdate: { type: Boolean, value: false, notify: true },
-			cellClass: { type: String, value: 'number-cell align-right' },
+			cellClass: { type: String, value: 'number-cell' },
 			width: { type: String, value: '30px' },
 			minWidth: { type: String, value: '30px' },
 			headerCellClass: { type: String, value: 'number-header-cell' },
@@ -143,7 +143,7 @@ class OmnitableColumnNumber extends columnMixin(PolymerElement) {
 			.maximumFractionDigits=${maximumFractionDigits}
 			.minimumFractionDigits=${minimumFractionDigits}
 			.autoupdate=${autoupdate}
-			.horizontalAlign=${headerAlign ?? align}
+			.align=${headerAlign ?? align}
 			@filter-changed=${({ detail: { value } }) =>
 				setState((state) => ({ ...state, filter: value }))}
 			@header-focused-changed=${({ detail: { value } }) =>

--- a/src/cosmoz-omnitable-column-time.js
+++ b/src/cosmoz-omnitable-column-time.js
@@ -128,7 +128,7 @@ class OmnitableColumnTime extends columnMixin(PolymerElement) {
 			.max=${max}
 			.locale=${locale}
 			.filterStep=${filterStep}
-			.horizontalAlign=${headerAlign ?? align}
+			.align=${headerAlign ?? align}
 			@filter-changed=${({ detail: { value } }) =>
 				setState((state) => ({ ...state, filter: value }))}
 			@header-focused-changed=${({ detail: { value } }) =>

--- a/src/cosmoz-omnitable-styles.ts
+++ b/src/cosmoz-omnitable-styles.ts
@@ -418,6 +418,8 @@ export default css`
 		direction: rtl;
 	}
 
+	/* @deprecated use the column align property + .cell[align] rules instead.
+	   Kept for backward compat with consumers using cellClass; remove in a future major version. */
 	.align-left {
 		text-align: left;
 	}

--- a/src/lib/cosmoz-omnitable-amount-range-input.js
+++ b/src/lib/cosmoz-omnitable-amount-range-input.js
@@ -74,7 +74,7 @@ class AmountRangeInput extends rangeInputMixin(
 				() => html`
 					<cosmoz-omnitable-dropdown-input
 						disabled
-						text-align=${this.horizontalAlign}
+						text-align=${this.align}
 						.label=${this.title}
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
@@ -88,7 +88,7 @@ class AmountRangeInput extends rangeInputMixin(
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
-						horizontalAlign: this.horizontalAlign,
+						align: this.align,
 						externalValues: this.externalValues,
 						onOpenedChanged,
 						content: html`

--- a/src/lib/cosmoz-omnitable-date-range-input.js
+++ b/src/lib/cosmoz-omnitable-date-range-input.js
@@ -43,7 +43,7 @@ class DateRangeInput extends dateInputMixin(
 				() => html`
 					<cosmoz-omnitable-dropdown-input
 						disabled
-						text-align=${this.horizontalAlign}
+						text-align=${this.align}
 						.label=${this.title}
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
@@ -57,7 +57,7 @@ class DateRangeInput extends dateInputMixin(
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
-						horizontalAlign: this.horizontalAlign,
+						align: this.align,
 						externalValues: this.externalValues,
 						onOpenedChanged,
 						content: html`

--- a/src/lib/cosmoz-omnitable-datetime-range-input.js
+++ b/src/lib/cosmoz-omnitable-datetime-range-input.js
@@ -42,7 +42,7 @@ class DatetimeRangeInput extends dateInputMixin(
 				() => html`
 					<cosmoz-omnitable-dropdown-input
 						disabled
-						text-align=${this.horizontalAlign}
+						text-align=${this.align}
 						.label=${this.title}
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
@@ -56,7 +56,7 @@ class DatetimeRangeInput extends dateInputMixin(
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
-						horizontalAlign: this.horizontalAlign,
+						align: this.align,
 						externalValues: this.externalValues,
 						onOpenedChanged,
 						content: html`

--- a/src/lib/cosmoz-omnitable-dropdown.ts
+++ b/src/lib/cosmoz-omnitable-dropdown.ts
@@ -9,7 +9,7 @@ interface DropdownProps {
 	filterText?: string;
 	onOpenedChanged?: (ev: Event) => void;
 	content: unknown;
-	horizontalAlign?: string;
+	align?: string;
 	externalValues?: boolean | null;
 }
 
@@ -19,7 +19,7 @@ export const renderDropdown = ({
 	filterText = '',
 	onOpenedChanged,
 	content,
-	horizontalAlign = 'left',
+	align = 'left',
 	externalValues = null,
 }: DropdownProps) => {
 	const classes: Record<string, boolean> = {
@@ -100,7 +100,7 @@ export const renderDropdown = ({
 				.label=${title}
 				.placeholder=${title}
 				.value=${filterText ?? ''}
-				text-align=${horizontalAlign}
+				text-align=${align}
 				?always-float-label=${filterText?.length > 0}
 			></cosmoz-omnitable-dropdown-input>
 			<div class="dropdown-content">${content}</div>

--- a/src/lib/cosmoz-omnitable-number-range-input.js
+++ b/src/lib/cosmoz-omnitable-number-range-input.js
@@ -63,7 +63,7 @@ class NumberRangeInput extends rangeInputMixin(
 				() => html`
 					<cosmoz-omnitable-dropdown-input
 						disabled
-						text-align=${this.horizontalAlign}
+						text-align=${this.align}
 						.label=${this.title}
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
@@ -77,7 +77,7 @@ class NumberRangeInput extends rangeInputMixin(
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
-						horizontalAlign: this.horizontalAlign,
+						align: this.align,
 						externalValues: this.externalValues,
 						onOpenedChanged,
 						content: html`

--- a/src/lib/cosmoz-omnitable-range-input-mixin.js
+++ b/src/lib/cosmoz-omnitable-range-input-mixin.js
@@ -50,7 +50,7 @@ export const rangeInputMixin = (base) =>
 
 				locale: { type: String, value: null },
 
-				horizontalAlign: { type: String, value: 'left' },
+				align: { type: String, value: 'left' },
 
 				_filterInput: {
 					type: Object,

--- a/src/lib/cosmoz-omnitable-time-range-input.js
+++ b/src/lib/cosmoz-omnitable-time-range-input.js
@@ -22,7 +22,7 @@ class TimeRangeInput extends dateInputMixin(
 				() => html`
 					<cosmoz-omnitable-dropdown-input
 						disabled
-						text-align=${this.horizontalAlign}
+						text-align=${this.align}
 						.label=${this.title}
 						.value=${this._filterText ?? ''}
 					></cosmoz-omnitable-dropdown-input>
@@ -36,7 +36,7 @@ class TimeRangeInput extends dateInputMixin(
 						title: this.title,
 						tooltip: this._tooltip,
 						filterText: this._filterText,
-						horizontalAlign: this.horizontalAlign,
+						align: this.align,
 						externalValues: this.externalValues,
 						onOpenedChanged,
 						content: html`

--- a/test/disabled-filtering.test.js
+++ b/test/disabled-filtering.test.js
@@ -5,14 +5,15 @@ import {
 	setupOmnitableFixture,
 } from './helpers/utils';
 
+import '../src/cosmoz-omnitable-column-amount.js';
 import '../src/cosmoz-omnitable-column-number.js';
 import '../src/cosmoz-omnitable-column.js';
 import '../src/cosmoz-omnitable.js';
 
 const data = [
-	{ id: 1, name: 'Alice', age: 30 },
-	{ id: 2, name: 'Bob', age: 25 },
-	{ id: 3, name: 'Charlie', age: 35 },
+	{ id: 1, name: 'Alice', age: 30, salary: 50000 },
+	{ id: 2, name: 'Bob', age: 25, salary: 45000 },
+	{ id: 3, name: 'Charlie', age: 35, salary: 60000 },
 ];
 
 suite('disabled-filtering (per-column)', () => {
@@ -43,6 +44,19 @@ suite('disabled-filtering (per-column)', () => {
 						name="age"
 						value-path="age"
 						disabled-filtering
+					>
+					</cosmoz-omnitable-column-number>
+					<cosmoz-omnitable-column-amount
+						title="Salary"
+						name="salary"
+						value-path="salary"
+						disabled-filtering
+					>
+					</cosmoz-omnitable-column-amount>
+					<cosmoz-omnitable-column-number
+						title="Score"
+						name="score"
+						value-path="age"
 					>
 					</cosmoz-omnitable-column-number>
 				</cosmoz-omnitable>
@@ -115,14 +129,58 @@ suite('disabled-filtering (per-column)', () => {
 		);
 		assert.isNotNull(dropdownInput, 'Dropdown input should exist');
 		assert.equal(
-			rangeInput.horizontalAlign,
+			rangeInput.align,
 			'right',
-			'Range input should have horizontalAlign="right"',
+			'Range input should have align="right"',
 		);
 		assert.equal(
 			dropdownInput.getAttribute('text-align'),
 			'right',
 			'Disabled number range input should have text-align="right"',
+		);
+	});
+
+	test('amount column disabled range input has right text-align', async () => {
+		const salaryHeaderCell = omnitable.shadowRoot.querySelector(
+			'.header-cell[name="salary"]',
+		);
+		const rangeInput = salaryHeaderCell.querySelector(
+			'cosmoz-omnitable-amount-range-input',
+		);
+		await nextFrame();
+		await nextFrame();
+		const dropdownInput = rangeInput.shadowRoot.querySelector(
+			'cosmoz-omnitable-dropdown-input',
+		);
+		assert.isNotNull(dropdownInput, 'Dropdown input should exist');
+		assert.equal(
+			rangeInput.align,
+			'right',
+			'Range input should have align="right"',
+		);
+		assert.equal(
+			dropdownInput.getAttribute('text-align'),
+			'right',
+			'Disabled amount range input should have text-align="right"',
+		);
+	});
+
+	test('number column range input has align right when not disabled', async () => {
+		const scoreHeaderCell = omnitable.shadowRoot.querySelector(
+			'.header-cell[name="score"]',
+		);
+		const rangeInput = scoreHeaderCell.querySelector(
+			'cosmoz-omnitable-number-range-input',
+		);
+		assert.isNotNull(rangeInput, 'Range input should exist');
+		assert.isFalse(
+			rangeInput.hasAttribute('disabled'),
+			'Range input should not be disabled',
+		);
+		assert.equal(
+			rangeInput.align,
+			'right',
+			'Non-disabled number range input should have align="right"',
 		);
 	});
 


### PR DESCRIPTION
## Summary

Follow-up to #1084. Polishing work that didn't make it into the merged PR: rename the range-input's `horizontalAlign` property to `align` for consistency with the column API, clean up redundant `cellClass` defaults, and mark the legacy `.align-*` CSS classes as deprecated.

## Changes

### Range input rename (`horizontalAlign` -> `align`)
- `range-input-mixin.js`: Rename `horizontalAlign` property to `align` (default `'left'`)
- `cosmoz-omnitable-dropdown.ts`: Rename `renderDropdown`'s `horizontalAlign` prop to `align` (interface + default + usage)
- 5 range inputs (number, amount, date, time, datetime): Use `this.align` in both disabled branch (`text-align` attribute) and non-disabled branch (`renderDropdown` param)
- 5 column `renderHeader` callers: `.horizontalAlign=${headerAlign ?? align}` -> `.align=${headerAlign ?? align}`

### cellClass cleanup
- `column-number.js`, `column-amount.js`: Remove redundant `align-right` from `cellClass` defaults (now `'number-cell'`/`'amount-cell'`; alignment handled by the `align` property + `.cell[align]` CSS rules introduced in #1084)

### CSS
- `styles.ts`: Mark `.align-left`/`.align-right` classes as `@deprecated` (kept for backward compat with consumers using `cellClass`; remove in a future major version)

### Tests
- `disabled-filtering.test.js`: Add amount column + non-disabled number column to fixture; add tests:
  - disabled amount range input has `align="right"` + `text-align="right"`
  - non-disabled number range input has `align="right"` (verifies `horizontalAlign`/`align` propagation on the non-disabled branch)
  - existing number disabled test updated to assert `align` instead of `horizontalAlign`

## Test plan

- [x] `npm test` — 325 passed, 0 failed
- [x] `npm run build` (tsc) — clean
- [x] `npm run lint` — 0 errors (2 pre-existing warnings)
- [ ] npm link into cosmoz-frontend, verify purchase contracts visual tests