### PR TITLE
fix: use data-align attribute instead of HTML align on cells

### DIFF
--- a/.changeset/fix-data-align-attribute.md
+++ b/.changeset/fix-data-align-attribute.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-omnitable': patch
+---
+
+Fix: use `data-align` attribute instead of HTML `align` attribute on cell divs. The HTML `align` attribute is a presentational attribute that triggers user-agent stylesheet `text-align` inheritance, causing unintended text alignment changes in sibling elements like the bottom bar. Using `data-align` avoids this behavior while maintaining the same CSS specificity.

--- a/src/cosmoz-omnitable-header-row.js
+++ b/src/cosmoz-omnitable-header-row.js
@@ -24,7 +24,7 @@ const renderHeaderRow = ({
 		(column) => [
 			html`<div
 				class="cell ${column.headerCellClass} header-cell"
-				align="${column.headerAlign ?? column.align ?? 'left'}"
+				data-align="${column.headerAlign ?? column.align ?? 'left'}"
 				part="cell header-cell cell-${column.name} header-cell-${column.name}"
 				?hidden="${column === groupOnColumn}"
 				title="${column.headerTitleFn(column)}"

--- a/src/cosmoz-omnitable-item-row.ts
+++ b/src/cosmoz-omnitable-item-row.ts
@@ -36,7 +36,7 @@ const ItemRow = ({
 		(column) => {
 			return html`<div
 				class="cell itemRow-cell ${column.cellClass ?? ''}"
-				align="${column.align ?? 'left'}"
+				data-align="${column.align ?? 'left'}"
 				part="cell itemRow-cell cell-${column.name} itemRow-cell-${column.name}"
 				?hidden="${column === groupOnColumn}"
 				?editable="${column.editable}"

--- a/src/cosmoz-omnitable-styles.ts
+++ b/src/cosmoz-omnitable-styles.ts
@@ -418,7 +418,7 @@ export default css`
 		direction: rtl;
 	}
 
-	/* @deprecated use the column align property + .cell[align] rules instead.
+	/* @deprecated use the column align property + .cell[data-align] rules instead.
 	   Kept for backward compat with consumers using cellClass; remove in a future major version. */
 	.align-left {
 		text-align: left;
@@ -428,15 +428,15 @@ export default css`
 		text-align: right;
 	}
 
-	.cell[align='right'] {
+	.cell[data-align='right'] {
 		text-align: right;
 	}
 
-	.cell[align='left'] {
+	.cell[data-align='left'] {
 		text-align: left;
 	}
 
-	.cell[align='center'] {
+	.cell[data-align='center'] {
 		text-align: center;
 	}
 


### PR DESCRIPTION
## Problem

The HTML `align` attribute is a presentational attribute. Browsers apply `text-align` via the user-agent stylesheet to elements with `align="right"`. Since `cosmoz-omnitable-item-row` uses `useShadowDOM: false`, the cell divs with `align="right"` are in the omnitable's shadow DOM. The user-agent stylesheet's `text-align` was being inherited by the `cosmoz-bottom-bar` (also in the omnitable's shadow DOM), causing the "Selected:" text to shift position by a few subpixels — producing visual regression test failures (647px diffs).

## Fix

Switch from HTML `align` attribute to `data-align` custom attribute. CSS rules updated from `.cell[align='right']` to `.cell[data-align='right']`. This avoids the presentational attribute behavior while maintaining the same CSS specificity.

## Test plan

- [x] `npm test` — 325 passed, 0 failed
- [x] `npm run build` (tsc) — clean
- [x] `npm run lint` — clean
- [ ] Visual tests in cosmoz-frontend pass with this fix