### PR TITLE
fix: restore info slot redistribution in render-footer

### DIFF
--- a/.changeset/fix-info-slot-redistribution.md
+++ b/.changeset/fix-info-slot-redistribution.md
@@ -1,0 +1,5 @@
+---
+'@neovici/cosmoz-omnitable': patch
+---
+
+Fix regression in render-footer where the `info` slot redistribution (`<slot name="info" slot="info">`) was accidentally replaced with a plain `<span slot="info">` in #1037, breaking consumer content slotted as `name="info"`.

--- a/src/lib/render-footer.ts
+++ b/src/lib/render-footer.ts
@@ -99,7 +99,7 @@ export const renderFooter = ({
 		part="bottomBar"
 		exportparts="bar: bottomBar-bar, info: bottomBar-info, buttons: bottomBar-buttons"
 	>
-		<span slot="info">
+		<slot name="info" slot="info">
 			${allLabel}
 			${when(
 				showSelectAllItems,
@@ -115,7 +115,7 @@ export const renderFooter = ({
 							${t('Select all items')}
 						</span>`,
 			)}
-		</span>
+		</slot>
 		<slot name="actions" id="actions"></slot>
 		<slot name="bottom-bar-toolbar" slot="bottom-bar-toolbar"></slot>
 		<slot name="bottom-bar-menu" slot="bottom-bar-menu"></slot>

--- a/test/render-footer-export.test.js
+++ b/test/render-footer-export.test.js
@@ -36,6 +36,30 @@ suite('render-footer export', () => {
 		container.remove();
 	});
 
+	test('redistributes consumer info-slot content via a slot (regression for #1037)', () => {
+		const container = document.createElement('div');
+		document.body.append(container);
+
+		render(
+			renderFooter({
+				columns: [],
+				selectedItems: [{ id: 1 }],
+				setSelectedItems: () => undefined,
+			}),
+			container,
+		);
+
+		// PR #899 introduced `<slot name="info" slot="info">` to both catch
+		// consumer content slotted as name="info" and redistribute it into
+		// cosmoz-bottom-bar's info slot. PR #1037 accidentally replaced this
+		// with a plain <span slot="info">, breaking slot redistribution.
+		const infoSlot = container.querySelector('slot[name="info"]');
+		assert.isNotNull(infoSlot);
+		assert.equal(infoSlot.getAttribute('slot'), 'info');
+
+		container.remove();
+	});
+
 	test('shows export buttons when selectedItems is an array', () => {
 		const container = document.createElement('div');
 		document.body.append(container);


### PR DESCRIPTION
## Problem

A regression was introduced in #1037 ("feat: add select all items feature", released in 18.10.2). The `<slot name="info" slot="info">` redistribution slot in `src/lib/render-footer.ts` was accidentally replaced with a plain `<span slot="info">`, breaking slot redistribution for consumers.

PR #899 ("feat: support cosmoz-bottom-bar v11 and re-add slot redistributions") intentionally added the dual-purpose `<slot name="info" slot="info">` pattern:
- `name="info"` catches consumer content supplied as `<x slot="info">`
- `slot="info"` redistributes that content into `cosmoz-bottom-bar`'s `info` slot (defined at `node_modules/@neovici/cosmoz-bottom-bar/dist/cosmoz-bottom-bar.js:261`)

#1037 dropped this pattern while adding the Select all items feature, so any consumer content slotted as `name="info"` silently stopped appearing in the bottom bar.

## Fix

Restores the `<slot name="info" slot="info">` wrapper around the existing internal content (`allLabel` + Select all items span), preserving #1037's feature while restoring #899's redistribution behavior.

## Regression test

Adds a test in `test/render-footer-export.test.js` asserting the `<slot name="info" slot="info">` element exists (guards against the slot being replaced by a non-slot element like the `<span>` from #1037).

## Verification

- `npm run lint` — 0 errors (2 pre-existing warnings)
- `npm run build` — passes
- `npm test` (render-footer-export + footer-select-all) — 4/4 passed

## Changeset

Patch bump to 18.10.3 via `.changeset/fix-info-slot-redistribution.md`.